### PR TITLE
Update node labels with compute, node-class, and openvswitch 

### DIFF
--- a/7_deploy_osh/roles/suse-osh-deploy/tasks/enroll-caasp-nodes-for-osh.yml
+++ b/7_deploy_osh/roles/suse-osh-deploy/tasks/enroll-caasp-nodes-for-osh.yml
@@ -12,15 +12,42 @@
     - _all_casp_nodenames.stdout_lines | length < 3
 
 # TODO(evrardjp): Make this conditional if a previous enrollment was already done
-- name: Enroll node for OSH
+- name: Enroll node for OSH control plane
   shell: "kubectl label nodes {{ item }} openstack-control-plane=enabled"
   register: _enrollforopenstack
   changed_when:
     - _enrollforopenstack.rc == 0
   failed_when:
     - _enrollforopenstack.rc != 0
-    - _enrollforopenstack.stderr.find("'openstack-control-plane' already has a value (enabled)") == -1
-  with_items: "{{ _all_casp_nodenames.stdout_lines }}"
+    - _enrollforopenstack.stderr.find("already has a value (enabled)") == -1
+  with_items:
+    - "{{ _all_casp_nodenames.stdout_lines }}"
+  tags:
+    - skip_ansible_lint
+
+- name: Enroll node for OSH compute node
+  shell: "kubectl label nodes {{ item }} openstack-compute-node=enabled"
+  register: _enrollforopenstack
+  changed_when:
+    - _enrollforopenstack.rc == 0
+  failed_when:
+    - _enrollforopenstack.rc != 0
+    - _enrollforopenstack.stderr.find("already has a value (enabled)") == -1
+  with_items:
+    - "{{ _all_casp_nodenames.stdout_lines }}"
+  tags:
+    - skip_ansible_lint
+
+- name: Enroll node for OSH as ovs node
+  shell: "kubectl label nodes {{ item }} openvswitch=enabled"
+  register: _enrollforopenstack
+  changed_when:
+    - _enrollforopenstack.rc == 0
+  failed_when:
+    - _enrollforopenstack.rc != 0
+    - _enrollforopenstack.stderr.find("already has a value (enabled)") == -1
+  with_items:
+    - "{{ _all_casp_nodenames.stdout_lines }}"
   tags:
     - skip_ansible_lint
 
@@ -29,22 +56,32 @@
   changed_when: false
   register: _nodes
 
-# TODO(evrardjp): Be more selective in taint node selection
-- name: Find tainted master master if ha is asked and only 3 nodes
+- name: Find master node
   set_fact:
     master_node: "{{ _nodes.stdout_lines | join('') | from_json | json_query(query)}}"
   vars:
     query: 'items[].spec.{node: externalID, taints: taints} | [?taints].node'
-  when:
-    - suse_osh_deploy_require_ha | bool
-    - (_all_casp_nodenames.stdout_lines | length) == 3
 
-- debug:
-    var: master_node
- 
+# Select the first non-master node for single-node labels
+- name: Apply labels to a single non-master node
+  vars:
+    primary_node: "{{ _all_casp_nodenames.stdout_lines | difference(master_node) | first }}"
+  shell: "kubectl label nodes {{ primary_node }} {{ item }} --overwrite=true"
+  register: _enrollforopenstack
+  changed_when:
+    - _enrollforopenstack.rc == 0
+  failed_when:
+    - _enrollforopenstack.rc != 0
+  with_items:
+    - 'openstack-helm-node-class=primary'
+    - 'ceph-mon=enabled'
+  when:
+    - "(master_node | default('')) | length > 0"
+
 - name: Remove taints when only 3 nodes and ha is required
   shell: "kubectl taint nodes {{ item }} node-role.kubernetes.io/master:NoSchedule-"
   with_items: "{{ master_node }}"
   when:
-    - master_node is defined
-    - master_node | length > 0
+    - "(master_node | default('')) | length > 0"
+    - suse_osh_deploy_require_ha | bool
+    - (_all_casp_nodenames.stdout_lines | length) == 3

--- a/7_deploy_osh/roles/suse-osh-deploy/tasks/enroll-caasp-nodes-for-osh.yml
+++ b/7_deploy_osh/roles/suse-osh-deploy/tasks/enroll-caasp-nodes-for-osh.yml
@@ -13,14 +13,16 @@
 
 # TODO(evrardjp): Make this conditional if a previous enrollment was already done
 - name: Enroll node for OSH
-  shell: "kubectl label nodes {{ item }} openstack-control-plane=enabled"
+  shell: "kubectl label nodes {{ item[0] }} {{ item[1] }} --overwrite=true"
   register: _enrollforopenstack
   changed_when:
     - _enrollforopenstack.rc == 0
   failed_when:
     - _enrollforopenstack.rc != 0
-    - _enrollforopenstack.stderr.find("'openstack-control-plane' already has a value (enabled)") == -1
-  with_items: "{{ _all_casp_nodenames.stdout_lines }}"
+#    - _enrollforopenstack.stderr.find("already has a value (enabled)") == -1
+  with_nested:
+    - "{{ _all_casp_nodenames.stdout_lines }}"
+    - ['openstack-control-plane=enabled', 'openstack-compute-node=enabled', 'openvswitch=enabled']
   tags:
     - skip_ansible_lint
 
@@ -34,17 +36,31 @@
   set_fact:
     master_node: "{{ _nodes.stdout_lines | join('') | from_json | json_query(query)}}"
   vars:
-    query: 'items[].spec.{node: externalID, taints: taints} | [?taints].node'
-  when:
-    - suse_osh_deploy_require_ha | bool
-    - (_all_casp_nodenames.stdout_lines | length) == 3
+    query: 'items[].spec.{node: externalID, taints: taints} | [?taints].node'    
 
 - debug:
     var: master_node
  
+ # Select the first non-master node for single-node labels
+- name: Apply labels to a single non-master node
+  vars:
+    primary_node: "{{ _all_casp_nodenames.stdout_lines | difference(master_node) | first }}"
+  shell: "kubectl label nodes {{ primary_node }} {{ item }} --overwrite=true"
+  register: _enrollforopenstack
+  changed_when:
+    - _enrollforopenstack.rc == 0
+  failed_when:
+    - _enrollforopenstack.rc != 0
+  with_items: ['openstack-helm-node-class=primary', 'ceph-mon=enabled']
+  when:
+    - master_node is defined
+    - master_node | length > 0
+
 - name: Remove taints when only 3 nodes and ha is required
   shell: "kubectl taint nodes {{ item }} node-role.kubernetes.io/master:NoSchedule-"
   with_items: "{{ master_node }}"
   when:
     - master_node is defined
     - master_node | length > 0
+    - suse_osh_deploy_require_ha | bool
+    - (_all_casp_nodenames.stdout_lines | length) == 3

--- a/7_deploy_osh/roles/suse-osh-deploy/tasks/enroll-caasp-nodes-for-osh.yml
+++ b/7_deploy_osh/roles/suse-osh-deploy/tasks/enroll-caasp-nodes-for-osh.yml
@@ -13,16 +13,14 @@
 
 # TODO(evrardjp): Make this conditional if a previous enrollment was already done
 - name: Enroll node for OSH
-  shell: "kubectl label nodes {{ item[0] }} {{ item[1] }} --overwrite=true"
+  shell: "kubectl label nodes {{ item }} openstack-control-plane=enabled"
   register: _enrollforopenstack
   changed_when:
     - _enrollforopenstack.rc == 0
   failed_when:
     - _enrollforopenstack.rc != 0
-#    - _enrollforopenstack.stderr.find("already has a value (enabled)") == -1
-  with_nested:
-    - "{{ _all_casp_nodenames.stdout_lines }}"
-    - ['openstack-control-plane=enabled', 'openstack-compute-node=enabled', 'openvswitch=enabled']
+    - _enrollforopenstack.stderr.find("'openstack-control-plane' already has a value (enabled)") == -1
+  with_items: "{{ _all_casp_nodenames.stdout_lines }}"
   tags:
     - skip_ansible_lint
 
@@ -36,31 +34,17 @@
   set_fact:
     master_node: "{{ _nodes.stdout_lines | join('') | from_json | json_query(query)}}"
   vars:
-    query: 'items[].spec.{node: externalID, taints: taints} | [?taints].node'    
+    query: 'items[].spec.{node: externalID, taints: taints} | [?taints].node'
+  when:
+    - suse_osh_deploy_require_ha | bool
+    - (_all_casp_nodenames.stdout_lines | length) == 3
 
 - debug:
     var: master_node
  
- # Select the first non-master node for single-node labels
-- name: Apply labels to a single non-master node
-  vars:
-    primary_node: "{{ _all_casp_nodenames.stdout_lines | difference(master_node) | first }}"
-  shell: "kubectl label nodes {{ primary_node }} {{ item }} --overwrite=true"
-  register: _enrollforopenstack
-  changed_when:
-    - _enrollforopenstack.rc == 0
-  failed_when:
-    - _enrollforopenstack.rc != 0
-  with_items: ['openstack-helm-node-class=primary', 'ceph-mon=enabled']
-  when:
-    - master_node is defined
-    - master_node | length > 0
-
 - name: Remove taints when only 3 nodes and ha is required
   shell: "kubectl taint nodes {{ item }} node-role.kubernetes.io/master:NoSchedule-"
   with_items: "{{ master_node }}"
   when:
     - master_node is defined
     - master_node | length > 0
-    - suse_osh_deploy_require_ha | bool
-    - (_all_casp_nodenames.stdout_lines | length) == 3

--- a/7_deploy_osh/roles/suse-osh-deploy/templates/privileged-cluster-role-binding.yml.j2
+++ b/7_deploy_osh/roles/suse-osh-deploy/templates/privileged-cluster-role-binding.yml.j2
@@ -38,6 +38,3 @@ subjects:
 - kind: ServiceAccount
   name: openvswitch-db
   namespace: openstack
-- kind: ServiceAccount
-  name: ingress-kube-system-ingress
-  namespace: kube-system

--- a/7_deploy_osh/roles/suse-osh-deploy/templates/privileged-cluster-role-binding.yml.j2
+++ b/7_deploy_osh/roles/suse-osh-deploy/templates/privileged-cluster-role-binding.yml.j2
@@ -38,3 +38,6 @@ subjects:
 - kind: ServiceAccount
   name: openvswitch-db
   namespace: openstack
+- kind: ServiceAccount
+  name: ingress-kube-system-ingress
+  namespace: kube-system


### PR DESCRIPTION
There may be a better way to handle the single-node labels, but the idea was to pick the first non-master node to ensure the node-class label gets applied to a node where pods can be scheduled even if the master node taints are left in place (in a cluster with at least 3 worker nodes).