### PR TITLE
Freeze OSH repos

### DIFF
--- a/7_deploy_osh/roles/suse-osh-deploy/defaults/main.yml
+++ b/7_deploy_osh/roles/suse-osh-deploy/defaults/main.yml
@@ -25,14 +25,14 @@ suse_osh_deploy_packages:
 # Keep this until helm is packaged as rpm
 helm_download_url: "https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get"
 
-# OpenStack-Helm repos
+# OpenStack-Helm repos, frozen on 26th september 2018
 osh_repos:
   openstack-helm-infra:
     src: https://git.openstack.org/openstack/openstack-helm-infra.git
-    version: master
+    version: ff116a26fde308c05a8947c62fdf4f94a9650099
   openstack-helm:
     src: https://git.openstack.org/openstack/openstack-helm.git
-    version: master
+    version: c2459fe4e2aa8f051ab088ed2ed7696fb491ddf4
 
 suse_osh_deploy_require_ha: True
 


### PR DESCRIPTION
Currently the OSH are tracking master, which is a fast moving
target.

This is a problem, as master has introduced regressions in the
past.

This fixes it by setting a SHA for each of the consumed repos,
so that we have a more stable interface.