### PR TITLE
Bump upstream OpenStack-Helm SHAs

### DIFF
--- a/7_deploy_osh/roles/suse-osh-deploy/defaults/main.yml
+++ b/7_deploy_osh/roles/suse-osh-deploy/defaults/main.yml
@@ -25,14 +25,14 @@ suse_osh_deploy_packages:
 # Keep this until helm is packaged as rpm
 helm_download_url: "https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get"
 
-# OpenStack-Helm repos, frozen on 26th september 2018
+# OpenStack-Helm repos, frozen on 9th November 2018
 osh_repos:
   openstack-helm-infra:
     src: https://git.openstack.org/openstack/openstack-helm-infra.git
-    version: ff116a26fde308c05a8947c62fdf4f94a9650099
+    version: b55e9b10a72ce5531ae22f15f953b2eb71e6f623
   openstack-helm:
     src: https://git.openstack.org/openstack/openstack-helm.git
-    version: c2459fe4e2aa8f051ab088ed2ed7696fb491ddf4
+    version: 4f94593e870ac879b2d01300cb02485ace58b3ac
 
 suse_osh_deploy_require_ha: True
 

--- a/7_deploy_osh/roles/suse-osh-deploy/templates/privileged-cluster-role-binding.yml.j2
+++ b/7_deploy_osh/roles/suse-osh-deploy/templates/privileged-cluster-role-binding.yml.j2
@@ -38,3 +38,26 @@ subjects:
 - kind: ServiceAccount
   name: openvswitch-db
   namespace: openstack
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: non-resource-url-get
+rules:
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - get
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: NonResourceUrlRoleBinding
+roleRef:
+  kind: ClusterRole
+  name: non-resource-url-get
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: mariadb-mariadb
+  namespace: openstack


### PR DESCRIPTION
This updates the SHAs to the latest OSH and OSH-infra versions.

This requires extra privileges to be added, else the mariadb
deployment crashes, with in the logs:

kubernetes.client.rest.ApiException: (403)
Reason: Forbidden
HTTP response (...) message: forbidden: User
system:serviceaccount:openstack:mariadb-mariadb" cannot get path
"/version/"

This is due to a refactor upstream of mariadb [1]

[1]: https://github.com/openstack/openstack-helm-infra/commit/f6e84fe15f84d5ba1fa0f0cffbac448b0cc5aa06