### PR TITLE
Do not skip installation of component if code was changed

### DIFF
--- a/7_deploy_osh/roles/suse-osh-deploy/defaults/main.yml
+++ b/7_deploy_osh/roles/suse-osh-deploy/defaults/main.yml
@@ -57,9 +57,6 @@ suse_osh_deploy_storage:
 # ClusterRole to allow privileged containers
 suse_osh_deploy_privileged_cluster_role: suse:caasp:psp:privileged
 
-# Set this to false if you want to speed up your builds or do partial upgrades
-suse_osh_deploy_always_redeploy: True
-
 # Default overrides
 suse_osh_deploy_cinder_yaml_overrides: {}
 suse_osh_deploy_glance_yaml_overrides: {}

--- a/7_deploy_osh/roles/suse-osh-deploy/tasks/component-install.yml
+++ b/7_deploy_osh/roles/suse-osh-deploy/tasks/component-install.yml
@@ -12,6 +12,4 @@
   args:
     executable: /bin/bash
     chdir: "{{ _cmpnt_chdir | default('/opt/openstack-helm') }}"
-  when:
-    - _usertemplatedata is changed or (suse_osh_deploy_always_redeploy | bool)
   failed_when: false #terrible idea, but no ingress yet

--- a/7_deploy_osh/roles/suse-osh-deploy/tasks/main.yml
+++ b/7_deploy_osh/roles/suse-osh-deploy/tasks/main.yml
@@ -52,12 +52,13 @@
   tags:
     - install
 
-# TODO(evrardjp): Ensure this task doesn't run if the expected files are already there!
+# NOTE: This task should stay close to code-install, so that no race condition
+# happens between the git-cloning, an eventual failure, and the building of the charts.
 - name: Build infra charts
   make:
     chdir: /opt/openstack-helm-infra
     target: all
-  when: _gitclone is changed or (suse_osh_deploy_always_redeploy | bool)
+  when: _gitclone is changed
   tags:
     - install
 


### PR DESCRIPTION
Without this patch, the installation of a component could be
skipped if the code has changed, but the user overrides stay the
same.

This is a problem, as code should always trigger a
redeployment.

This fixes it by removing all the conditionals, therefore ensuring
the deployments always happen (therefore removing all races
conditions of failures).

The conditional used to override does not need to exist anymore
and has been removed.