### PR TITLE
Remove files in /tmp when cleaning up

### DIFF
--- a/script_library/cleanup-k8s.sh
+++ b/script_library/cleanup-k8s.sh
@@ -25,3 +25,9 @@ done
 for configmap in $(kubectl get configmap -n openstack | awk ' NR > 1 { print $1 ; }'); do
     kubectl delete configmap $configmap -n openstack --all;
 done
+
+echo "Removing suse socok8s files in /tmp"
+
+for filename in suse-mariadb.yaml suse-rabbitmq.yaml suse-memcached.yaml suse-glance.yaml suse-cinder.yaml suse-ovs.yaml suse-libvirt.yaml suse-nova.yaml; do
+    rm -f /tmp/$filename;
+done


### PR DESCRIPTION
Cleaning up k8s doesn't remove all files present on the
deployment node: the /tmp files used for value override stay.

This fixes it.