### PR TITLE
Add ingress support

### DIFF
--- a/7_deploy_osh/roles/suse-osh-deploy/defaults/main.yml
+++ b/7_deploy_osh/roles/suse-osh-deploy/defaults/main.yml
@@ -60,6 +60,8 @@ suse_osh_deploy_privileged_cluster_role: suse:caasp:psp:privileged
 # Default overrides
 suse_osh_deploy_cinder_yaml_overrides: {}
 suse_osh_deploy_glance_yaml_overrides: {}
+suse_osh_deploy_ingress_kube_system_yaml_overrides: {}
+suse_osh_deploy_ingress_namespace_yaml_overrides: {}
 suse_osh_deploy_keystone_yaml_overrides: {}
 suse_osh_deploy_libvirt_yaml_overrides: {}
 suse_osh_deploy_mariadb_yaml_overrides: {}

--- a/7_deploy_osh/roles/suse-osh-deploy/files/020-ingress.sh
+++ b/7_deploy_osh/roles/suse-osh-deploy/files/020-ingress.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Copyright 2017 The Openstack-Helm Authors.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+set -xe
+
+#NOTE: Deploy global ingress
+: ${OSH_INFRA_PATH:="../openstack-helm-infra"}
+tee /tmp/ingress-kube-system.yaml << EOF
+pod:
+  replicas:
+    error_page: 2
+deployment:
+  mode: cluster
+  type: DaemonSet
+network:
+  host_namespace: true
+EOF
+helm upgrade --install ingress-kube-system ${OSH_INFRA_PATH}/ingress \
+  --namespace=kube-system \
+  --values=/tmp/ingress-kube-system.yaml \
+  ${OSH_EXTRA_HELM_ARGS} \
+  ${OSH_EXTRA_HELM_ARGS_INGRESS_KUBE_SYSTEM}
+
+#NOTE: Wait for deploy
+./tools/deployment/common/wait-for-pods.sh kube-system
+
+#NOTE: Display info
+helm status ingress-kube-system
+
+#NOTE: Deploy namespaced ingress controllers
+for NAMESPACE in openstack ceph; do
+  # Allow $OSH_EXTRA_HELM_ARGS_INGRESS_ceph and $OSH_EXTRA_HELM_ARGS_INGRESS_openstack overrides
+  OSH_EXTRA_HELM_ARGS_INGRESS_NAMESPACE="OSH_EXTRA_HELM_ARGS_INGRESS_${NAMESPACE}"
+  #NOTE: Deploy namespace ingress
+  tee /tmp/ingress-${NAMESPACE}.yaml << EOF
+pod:
+  replicas:
+    ingress: 2
+    error_page: 2
+EOF
+  helm upgrade --install ingress-${NAMESPACE} ${OSH_INFRA_PATH}/ingress \
+    --namespace=${NAMESPACE} \
+    --values=/tmp/ingress-${NAMESPACE}.yaml \
+  ${OSH_EXTRA_HELM_ARGS} \
+  ${!OSH_EXTRA_HELM_ARGS_INGRESS_NAMESPACE}
+
+  #NOTE: Wait for deploy
+  ./tools/deployment/common/wait-for-pods.sh ${NAMESPACE}
+
+  #NOTE: Display info
+  helm status ingress-${NAMESPACE}
+done

--- a/7_deploy_osh/roles/suse-osh-deploy/tasks/component-install.yml
+++ b/7_deploy_osh/roles/suse-osh-deploy/tasks/component-install.yml
@@ -12,4 +12,3 @@
   args:
     executable: /bin/bash
     chdir: "{{ _cmpnt_chdir | default('/opt/openstack-helm') }}"
-  failed_when: false #terrible idea, but no ingress yet

--- a/7_deploy_osh/roles/suse-osh-deploy/tasks/main.yml
+++ b/7_deploy_osh/roles/suse-osh-deploy/tasks/main.yml
@@ -7,6 +7,7 @@
       - ceph_admin_keyring_b64key is defined
       - ceph_user_keyring_b64key is defined
       - ceph_monitors_ips is defined
+      - suse_osh_deploy_vip_with_cidr is defined
 
 - name: Set monitors data
   set_fact:
@@ -47,6 +48,17 @@
   tags:
     - run
 
+- name: Ensure VIP is present in /etc/hosts for the services to deploy
+  blockinfile:
+    path: /etc/hosts
+    block: |
+      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} keystone keystone.openstack.svc.cluster.local
+      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} glance glance.openstack.svc.cluster.local
+      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} cinder cinder.openstack.svc.cluster.local
+      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} nova nova.openstack.svc.cluster.local
+      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} neutron neutron.openstack.svc.cluster.local
+      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} horizon horizon.openstack.svc.cluster.local
+
 - name: Fetch OSH code
   include: code-install.yml
   tags:
@@ -62,6 +74,11 @@
   tags:
     - install
 
+- name: Create privileged ClusterRoleBinding for ServiceAccounts
+  include: privileged-cluster-role-binding.yml
+  tags:
+    - run
+
 # TODO(evrardjp): Use mechanism like glance to re-use component-install.yml code and allow any override.
 - name: Setup openstack CLIs
   shell: ./tools/deployment/multinode/010-setup-client.sh
@@ -71,23 +88,40 @@
   tags:
     - run
 
-# TODO(evrardjp): Use mechanism like glance to re-use component-install.yml code and allow any override.
-- name: Setup Basic ingress and namespace
-  shell: ./tools/deployment/multinode/020-ingress.sh
-  args:
-    executable: /bin/bash
-    chdir: /opt/openstack-helm
+# TODO(evrardjp): Follow on https://review.openstack.org/#/c/605005/
+- name: Use a different ingress script as long as upstream does not support overrides
+  copy:
+    src: 020-ingress.sh
+    dest: /opt/ccp/020-ingress.sh
+    mode: '0755'
   tags:
+    - ingress
+    - run
+
+- name: Template file for the namespaces ingress
+  config_template:
+    src: suse-ingress-namespace.yaml.j2
+    dest: /tmp/suse-ingress-namespace.yaml
+    config_overrides: "{{ suse_osh_deploy_ingress_namespace_yaml_overrides }}"
+    config_type: yaml
+
+- name: Setup Basic ingress and namespace
+  import_tasks: component-install.yml
+  vars:
+    _cmpnt_template: suse-ingress-kube-system.yaml
+    _cmpnt_overrides: "{{ suse_osh_deploy_ingress_kube_system_yaml_overrides }}"
+    _cmpnt_runcommand: /opt/ccp/020-ingress.sh
+  environment:
+    OSH_EXTRA_HELM_ARGS_INGRESS_KUBE_SYSTEM: "{{ lookup('env', 'OSH_EXTRA_HELM_ARGS_INGRESS_KUBE_SYSTEM') | default('', True) }} -f /tmp/suse-ingress-kube-system.yaml"
+    OSH_EXTRA_HELM_ARGS_INGRESS_OPENSTACK: "{{ lookup('env', 'OSH_EXTRA_HELM_ARGS_INGRESS_OPENSTACK') | default('', True) }} -f /tmp/suse-ingress-namespace.yaml"
+    OSH_EXTRA_HELM_ARGS_INGRESS_CEPH: "{{ lookup('env', 'OSH_EXTRA_HELM_ARGS_INGRESS_CEPH') | default('', True) }} -f /tmp/suse-ingress-namespace.yaml"
+  tags:
+    - ingress
     - run
 
 # TODO(evrardjp): Improve idempotency
 - name: Add ceph secrets to k8s
   include: ceph-secrets.yml
-  tags:
-    - run
-
-- name: Create privileged ClusterRoleBinding for ServiceAccounts
-  include: privileged-cluster-role-binding.yml
   tags:
     - run
 

--- a/7_deploy_osh/roles/suse-osh-deploy/templates/privileged-cluster-role-binding.yml.j2
+++ b/7_deploy_osh/roles/suse-osh-deploy/templates/privileged-cluster-role-binding.yml.j2
@@ -38,6 +38,9 @@ subjects:
 - kind: ServiceAccount
   name: openvswitch-db
   namespace: openstack
+- kind: ServiceAccount
+  name: ingress-kube-system-ingress
+  namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/7_deploy_osh/roles/suse-osh-deploy/templates/suse-ingress-kube-system.yaml.j2
+++ b/7_deploy_osh/roles/suse-osh-deploy/templates/suse-ingress-kube-system.yaml.j2
@@ -1,0 +1,17 @@
+---
+pod:
+  replicas:
+    error_page: 2
+deployment:
+  mode: cluster
+  type: DaemonSet
+network:
+  host_namespace: true
+  vip:
+    manage: true
+    # what type of vip manage machanism will be used
+    # possible options: routed, keepalived
+    mode: routed
+    interface: ingress-vip
+    addr: {{ suse_osh_deploy_vip_with_cidr }}
+    external_policy_local: true

--- a/7_deploy_osh/roles/suse-osh-deploy/templates/suse-ingress-namespace.yaml.j2
+++ b/7_deploy_osh/roles/suse-osh-deploy/templates/suse-ingress-namespace.yaml.j2
@@ -1,0 +1,3 @@
+---
+network:
+  host_namespace: false

--- a/script_library/cleanup-k8s.sh
+++ b/script_library/cleanup-k8s.sh
@@ -28,6 +28,6 @@ done
 
 echo "Removing suse socok8s files in /tmp"
 
-for filename in suse-mariadb.yaml suse-rabbitmq.yaml suse-memcached.yaml suse-glance.yaml suse-cinder.yaml suse-ovs.yaml suse-libvirt.yaml suse-nova.yaml; do
+for filename in suse-mariadb.yaml suse-rabbitmq.yaml suse-memcached.yaml suse-glance.yaml suse-cinder.yaml suse-ovs.yaml suse-libvirt.yaml suse-nova.yaml suse-ingress-kube-system.yaml suse-ingress-namespace.yaml; do
     rm -f /tmp/$filename;
 done


### PR DESCRIPTION
The VIP cannot be guessed, and therefore has to be user-provided.
The mechanism of overrides for ingress in upstream is incomplete,
and therefore we need to carry the 020-ingress.sh shell script
until upstream is patched [1].

[1]: https://review.openstack.org/#/c/605005/