### PR TITLE
Modifying cleanup logic and fixing cli usage of --all

### DIFF
--- a/script_library/cleanup-k8s.sh
+++ b/script_library/cleanup-k8s.sh
@@ -6,7 +6,17 @@ for line in $(helm ls -a | awk 'NR > 1 {print $1 }'); do
     helm delete $line --purge;
 done
 
-for NS in openstack ceph nfs libvirt; do
+reserved_namespaces=" kube-system kube-public default "
+deploy_namespaces=()
+for namespace_used in $(kubectl get namespaces | awk ' NR > 1 { print $1 ; }'); do
+    if [[ ! $reserved_namespaces =~ $namespace_used ]]; then
+        deploy_namespaces+=($namespace_used)
+    fi
+done
+
+echo "deploy namespaces are: ${deploy_namespaces[@]}"
+
+for NS in "${deploy_namespaces[@]}"; do
    helm ls --namespace $NS --short | xargs -r -L1 -P2 helm delete --purge
 done
 
@@ -16,17 +26,35 @@ rm -rf /var/lib/nova/*
 rm -rf /etc/libvirt/qemu/*
 findmnt --raw | awk '/^\/var\/lib\/kubelet\/pods/ { print $1 }' | xargs -r -L1 -P16 sudo umount -f -l
 
-for pvc in $(kubectl get pvc -n openstack | awk ' NR > 1 { print $1 ; }'); do
-    kubectl delete pvc $pvc -n openstack --all;
+deleted_items=()
+echo "deleting persistent volume claims in namespaces: ${deploy_namespaces[@]}"
+for NS in "${deploy_namespaces[@]}"; do
+    for pvc in $(kubectl get pvc -n $NS | awk ' NR > 1 { print $1 ; }'); do
+        kubectl delete pvc $pvc -n $NS;
+        deleted_items+=("$NS:$pvc")
+    done
 done
+echo "deleted persistent volume claims : ${deleted_items[@]}"
 
-for pv in $(kubectl get pv -n openstack | awk ' NR > 1 { print $1 ; }'); do
-    kubectl delete pv $pv -n openstack --all || true;
+deleted_items=()
+echo "deleting persistent volumes in namespaces: ${deploy_namespaces[@]}"
+for NS in "${deploy_namespaces[@]}"; do
+    for pv in $(kubectl get pv -n $NS | awk ' NR > 1 { print $1 ; }'); do
+        kubectl delete pv $pv -n $NS || true;
+        deleted_items+=("$NS:$pv")
+    done
 done
+echo "deleted persistent volumes : ${deleted_items[@]}"
 
-for configmap in $(kubectl get configmap -n openstack | awk ' NR > 1 { print $1 ; }'); do
-    kubectl delete configmap $configmap -n openstack --all;
+deleted_items=()
+echo "deleting configmaps in namespaces: ${deploy_namespaces[@]}"
+for NS in "${deploy_namespaces[@]}"; do
+    for configmap in $(kubectl get configmap -n $NS | awk ' NR > 1 { print $1 ; }'); do
+        kubectl delete configmap $configmap -n $NS;
+        deleted_items+=("$NS:$configmap")
+    done
 done
+echo "deleted configmaps : ${deleted_items[@]}"
 
 echo "Removing suse socok8s files in /tmp"
 


### PR DESCRIPTION
delete commands with component name and --all complains silently and
did not delete the requested resource. As we are providing component
name and related namespace so prioviding --all option is erroneous