### PR TITLE
Do not assume deployer is localhost

### DIFF
--- a/1_ses_node_on_openstack/create.sh
+++ b/1_ses_node_on_openstack/create.sh
@@ -27,7 +27,7 @@ openstack server add floating ip ${SERVER_NAME} $IP_CREATE
 
 pushd ${MAIN_FOLDER}
     echo ${IP_CREATE} > .ses_ip
-    grep ${IP_CREATE} inventory-ses.ini 2>&1 > /dev/null || (echo "${SERVER_NAME} ansible_ssh_host=${IP_CREATE} ansible_host=${IP_CREATE} ansible_user=root ansible_ssh_user=root" >> inventory-ses.ini)
+    grep ${IP_CREATE} inventory-ses.ini 2>&1 > /dev/null || (echo "[ses_nodes]" > inventory-ses.ini && echo "${SERVER_NAME} ansible_ssh_host=${IP_CREATE} ansible_host=${IP_CREATE} ansible_user=root ansible_ssh_user=root" >> inventory-ses.ini)
     echo "Waiting for the node to come up before scanning ssh key" && sleep 120 # 60 seconds are not enough
     ssh-keyscan -H ${IP_CREATE} >> ~/.ssh/known_hosts
 popd

--- a/1_ses_node_on_openstack/playbooks/play.yml
+++ b/1_ses_node_on_openstack/playbooks/play.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all:!localhost
+- hosts: ses_nodes
   gather_facts: no
   vars:
     ses_packages:

--- a/2_deploy_ses_aio/get-ses-data.yml
+++ b/2_deploy_ses_aio/get-ses-data.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all:!localhost
+- hosts: ses_nodes[0]
   vars:
     ses_config_file_path: "~/suse-osh-deploy/ses_config.yml"
   tasks:

--- a/2_deploy_ses_aio/prepare-ses-ansible.yml
+++ b/2_deploy_ses_aio/prepare-ses-ansible.yml
@@ -6,6 +6,8 @@
     ses_ansible_folder: "{{ playbook_dir }}/../ses-ansible/"
     ses_ip: "{{ lookup('file', playbook_dir + '/../.ses_ip') }}"
   tasks:
+    # The role and play expect the hostname to be 'ses' in the
+    # 'all' group.
     - name: Prepare inventory
       copy:
         content: |

--- a/2_deploy_ses_aio/set-user-variables.yml
+++ b/2_deploy_ses_aio/set-user-variables.yml
@@ -3,7 +3,7 @@
 # This can probably be removed in the future, should we decide to ALWAYS use ses_config.yml, and
 # load ses_config.yml in the OSH play
 
-- hosts: all:!localhost
+- hosts: ses_nodes[0]
   gather_facts: yes
   vars:
     suse_osh_deploy_user_variables: "~/suse-osh-deploy/user_variables.yml"

--- a/4_osh_node_on_openstack/create.sh
+++ b/4_osh_node_on_openstack/create.sh
@@ -28,7 +28,7 @@ openstack server add floating ip ${SERVER_NAME} $IP_CREATE
 pushd ${MAIN_FOLDER}
     echo ${IP_CREATE} > .osh_ip
     if [ ! -f inventory-osh.ini ]; then
-        echo '[osh-deploy]' > inventory-osh.ini
+        echo '[osh-deployer]' > inventory-osh.ini
     fi
     echo "${SERVER_NAME} ansible_ssh_host=${IP_CREATE} ansible_host=${IP_CREATE} ansible_user=root ansible_ssh_user=root" >> inventory-osh.ini
 

--- a/5_automate_caasp_enroll/play.yml
+++ b/5_automate_caasp_enroll/play.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all:!localhost
+- hosts: osh-deployer
   gather_facts: no
   vars:
     velum_automation_src: https://github.com/kubic-project/automation.git

--- a/README.md
+++ b/README.md
@@ -71,6 +71,61 @@ To begin a deployment from scratch, go to the root of your socok8s
 clone and run "./run.sh". This will run each of the seven top-level
 sections of the script in order.
 
+## Reference archiecture and inventories
+
+By default, it is expected these playbooks and scripts would run
+on a CI/developer machine.
+
+In order to not pollute the developer/CI machine (called further
+'localhost'), all the data relevant for a deployment (like any
+eventual override) will be stored in user-space, unpriviledged
+access. Any hardware and software distribution can be used,
+as long as 'localhost' is able to run git, and ansible
+(see requirements). This also helps the story of running behind
+a corporate firewall: the 'developer' can be (connecting to)
+a bastion host, while the real actions happen behind the firewall.
+
+This SoCok8s deployment mechanism requires therefore another
+entity, another machine, to orchestrate kubernetes commands.
+This machine is named the `deployer` node.
+The `deployer` node will be in charge of running the OSH code,
+and manage the kubernetes configuration.
+
+The `deployer` node is expected to run SLE.
+
+The deployer node can be the same as the `localhost`
+(developer/CI machine), but it is not a requirement.
+
+The deployer node (currently) needs access to the SES machines
+through SSH to fetch the keys. In the future, this SSH connection
+might be skipped if the `localhost` have knowledge of these keys.
+
+### Example inventories and conventions
+
+In order for a deployer to bring its own inventory, we have
+defined a set of convention about inventory groupnames.
+
+* All nodes belonging to the SES deployment should be listed
+  under the `ses_nodes` group. First node in this group must
+  be a monitor node with the appropriate ceph keyrings in
+  `/etc/ceph/`.
+
+* The inventory for SES nodes is stored in `inventory-ses.ini`
+  by default.
+
+* The CI/developer machine is always named `localhost`.
+
+* The `deployer` node is listed in a group `osh-deployer`.
+  In order to not extend the length of the deployment,
+  the `osh-deployer` group should contain only one node.
+  We might support multiple `osh-deployer` nodes for
+  muliple k8s deployments later.
+
+* The inventory for the `deployer` node is stored in
+  `inventory-osh.ini` by default.
+
+* Example inventories and user variables can be found
+  in the `examples/` directory.
 
 # Deployment using KVM
 

--- a/examples/config/inventory-osh.ini
+++ b/examples/config/inventory-osh.ini
@@ -2,16 +2,16 @@
 localhost  ansible_connection=local
 
 [osh-deploy-admin]
-caasp-admin ansible_host=192.168.86.199
+caasp-admin ansible_host=192.168.86.199 ansible_user=root
 
 [osh-deploy-masters]
-caasp-master ansible_host=192.168.86.200
+caasp-master ansible_host=192.168.86.200 ansible_user=root
 
 [osh-deploy-cp-workers]
-cassp-worker1 ansible_host=192.168.86.201
-caasp-worker2 ansible_host=192.168.86.202
-cassp-worker3 ansible_host=192.168.86.203
-cassp-worker4 ansible_host=192.168.86.204
+cassp-worker1 ansible_host=192.168.86.201 ansible_user=root
+caasp-worker2 ansible_host=192.168.86.202 ansible_user=root
+cassp-worker3 ansible_host=192.168.86.203 ansible_user=root
+cassp-worker4 ansible_host=192.168.86.204 ansible_user=root
 
 [osh-deploy-compute-workers]
 
@@ -30,6 +30,3 @@ osh-deploy-admin
 osh-deploy-masters
 osh-deploy-workers
 osh-deployer
-
-[osh-deploy-all-nodes:vars]
-ansible_user=root

--- a/run.sh
+++ b/run.sh
@@ -66,7 +66,7 @@ function delete_on_kvm(){
 function clean_k8s(){
     echo "DANGER ZONE"
     read -p "Press Enter or Ctrl-C. Enter will remove all the deployed components on your kubernetes cluster"
-    ansible -m script -a "script_library/cleanup-k8s.sh" localhost
+    ansible -m script -a "script_library/cleanup-k8s.sh" osh-deployer -i inventory-osh.ini
 }
 function delete_user_files(){
     echo "DANGER ZONE"


### PR DESCRIPTION
Without this patch, deployment would fail on a non SLE (for
example a macbook) localhost.

This is a problem, as we confused two roles in this tooling, the
developer/ci node, and the OSH deployer, focused on that purpose.
They can be the same node, or be different.

This fixes it, and clarifies the usage in the documentation.