### PR TITLE
Allow externally provided ceph mons

### DIFF
--- a/2_deploy_ses_aio/set-user-variables.yml
+++ b/2_deploy_ses_aio/set-user-variables.yml
@@ -21,4 +21,4 @@
         block: |
           ceph_admin_keyring_b64key: {{ _clientadminkey.stdout_lines[0] }}
           ceph_user_keyring_b64key: {{ _clientadminkey.stdout_lines[0]  }}
-          ceph_monitors_ips: {{ ansible_all_ipv4_addresses }} #list containing all ips of the host (which should be an AIO containing the mons).
+          suse_osh_deploy_ceph_mons: "[{% for ip in ansible_all_ipv4_addresses %}'{{ ip }}:6789'{% if not loop.last %},{% endif %}{% endfor %}]" #list containing all ips of the host (which should be an AIO containing the mons).

--- a/7_deploy_osh/roles/suse-osh-deploy/tasks/main.yml
+++ b/7_deploy_osh/roles/suse-osh-deploy/tasks/main.yml
@@ -16,9 +16,10 @@
       - ceph_user_keyring_b64key is defined
       - suse_osh_deploy_vip_with_cidr is defined
 
-- name: Set monitors data
+- name: Create a list of monitors (ip and port) if no override exists for it.
   set_fact:
-    suse_osh_deploy_ceph_mons:  "{% for ip in ses_cluster_configuration.ceph_conf.mon_host.split(',') %}{{ ip }}:6789{% if not loop.last %},{% endif %}{% endfor %}"
+    suse_osh_deploy_ceph_mons:  "[{% for ip in ses_cluster_configuration.ceph_conf.mon_host.split(',') %}'{{ ip }}:{{ ceph_mon_port | default(6789) }}'{% if not loop.last %},{% endif %}{% endfor %}]"
+  when: suse_osh_deploy_ceph_mons is not defined
   tags:
     - always
     - run

--- a/7_deploy_osh/roles/suse-osh-deploy/templates/046-ceph-deploy-with-existing-ceph.sh.j2
+++ b/7_deploy_osh/roles/suse-osh-deploy/templates/046-ceph-deploy-with-existing-ceph.sh.j2
@@ -33,7 +33,7 @@ storageclass:
 conf:
   ceph:
     global:
-      mon_host: {{ suse_osh_deploy_ceph_mons }}
+      mon_host: {{ ','.join(suse_osh_deploy_ceph_mons) }}
 manifests:
   configmap_bin: false
   configmap_bin_common: false

--- a/7_deploy_osh/roles/suse-osh-deploy/templates/suse-define-ses-storageclasses-in-k8s.yml.j2
+++ b/7_deploy_osh/roles/suse-osh-deploy/templates/suse-define-ses-storageclasses-in-k8s.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: general
 provisioner: kubernetes.io/rbd
 parameters:
-  monitors: {{ suse_osh_deploy_ceph_mons }}
+  monitors: {{ ','.join(suse_osh_deploy_ceph_mons) }}
   adminId: {{ suse_osh_deploy_storage.adminId }}
   adminSecretName: {{ suse_osh_deploy_storage.adminSecretName }}
   adminSecretNamespace: {{ suse_osh_deploy_storage.adminSecretNamespace }}

--- a/7_deploy_osh/roles/suse-osh-deploy/templates/suse-glance.yaml.j2
+++ b/7_deploy_osh/roles/suse-osh-deploy/templates/suse-glance.yaml.j2
@@ -2,7 +2,7 @@ storage: rbd
 conf:
   ceph:
     enabled: true
-    monitors: {{ suse_osh_deploy_ceph_mons }}
+    monitors: {{ ','.join(suse_osh_deploy_ceph_mons) }}
     admin_keyring: {{ ceph_admin_keyring_b64key | b64decode }}
   glance:
     glance_store:

--- a/examples/config/ses_config.yml
+++ b/examples/config/ses_config.yml
@@ -23,8 +23,3 @@ ses_cluster_configuration:
       rbd_store_pool: glance
       rbd_store_pool_user: glance
       keyring_file_name: ceph.client.glance.keyring
-# BEGIN ANSIBLE MANAGED BLOCK
-ceph_admin_keyring_b64key: QVFCMzNlUmJBQUFBQUJBQVdqZGFHN2VxUXdhRlBzQ1NuanQvc3c9PQ==
-ceph_user_keyring_b64key: QVFCMzNlUmJBQUFBQUJBQVdqZGFHN2VxUXdhRlBzQ1NuanQvc3c9PQ==
-ceph_monitors_ips: ['192.168.86.205'] #list containing all ips of the host (which should be an AIO containing the mons).
-# END ANSIBLE MANAGED BLOCK

--- a/examples/config/user_variables.yml
+++ b/examples/config/user_variables.yml
@@ -1,7 +1,6 @@
 # BEGIN ANSIBLE MANAGED BLOCK
 ceph_admin_keyring_b64key: QVFCMzNlUmJBQUFBQUJBQVdqZGFHN2VxUXdhRlBzQ1NuanQvc3c9PQ==
 ceph_user_keyring_b64key: QVFCMzNlUmJBQUFBQUJBQVdqZGFHN2VxUXdhRlBzQ1NuanQvc3c9PQ==
-ceph_monitors_ips: ['192.168.86.205'] #list containing all ips of the host (which should be an AIO containing the mons).
 # END ANSIBLE MANAGED BLOCK
 
 caasp_cluster_master_nodes: [192.168.86.200]


### PR DESCRIPTION
Under certain cases, like running on a cloud with floating ips,
the generated ses-config only contains the private IP, not the
IP it should be used to reach the final node (if different
networks or port security for example).

If we are only using the ceph mons from the ses-config, the
cloud deployment would then fail, because the ceph mons are
unreachable.

This is a problem but very situational.

This patches fixes it by allowing a deployer to override the
default provided ceph mons, by providing its own list of
ceph mons, each element would be composed of ip:port.