### PR TITLE
Draft documentation for semi-automated install

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,84 @@ sections of the script in order.
 # Deployment using KVM
 
 This is not currently supported, but is a planned future addition.
+
+# Deployment using manually-installed SES and CAASP
+
+While a fully automated baremetal or VM based installation is not
+currently supported, selected parts of the automated install process
+can be used to configure existing SES and CAASP nodes. Here is an
+overview of how to do this. Note that these instructions are a work in
+progress and do not currently provide a comprehensive overview of
+installing SES and CAASP themselves.
+
+## Manually installing nodes
+
+Install SLES12SP3 with the SES5 extension from the SLES12SP3
+ISO. Please ensure that your SES system has a second disk device
+available.
+
+Install a CAASP admin, master, and two worker nodes manually from the
+CAASP ISO, setting the hostname on each node at install time. Visit
+the admin web interface and configure it, being sure to install
+Tiller.
+
+You will also want a system that acts as a deployer, which should have
+SSH access via keys to the CAASP and SES nodes. Note that the
+playbooks currently expect to use the root user on the remote systems
+and you may have better luck running the playbooks as the root user on
+your deployer as well.
+
+## Manually running Stage 2 to configure SES
+
+On your deployer, check out this repository. Be sure to import the git
+submodules as above. In the top level of the repository, create a file
+named .ses_ip containing the IP address of your SES node. Also create
+a file named inventory-ses.ini with the following contents:
+
+ses ansible_ssh_host=<SES IP> ansible_user=root ansible_ssh_user=root
+
+On the SES node, you will need to either configure SuSEfirewall2 to
+allow access to the SSH port, or disable SuSEfirewall2 entirely. Next,
+add a /root/.ssh/authorized_keys file containing the id_rsa.pub from
+your deployer. Finally, note that the SES node must have a FQDN in
+/etc/hosts, such as mycaasp.local for all steps to succeed.
+
+Now you are ready to run the Stage 2 playbooks. From the top level of
+this repository, run ./2_deploy_ses_aio/run.sh.
+
+## Manually running Stage 7 to run OpenStack Helm
+
+Prior to running Stage 7, you will need to perform additional
+configuration on the deployer.
+
+On the deployer:
+
+- Create an inventory-osh.ini file in the top level of this
+  repository. To do this, copy the file from
+  examples/config/inventory-osh.ini and edit it to reflect your
+  environment.
+
+- Enable and start sshd on your deployer and the location you are
+  running the playbooks. [NOTE: this step can be removed or adapted
+  subject to merge of PR #29]
+
+- Add suse_osh_deploy_vip_with_cidr to
+  ~/suse-osh-deploy/user_variables.yml. This should be an IP available
+  on the network you're using which can be used as a VIP.
+
+- Download the kubeconfig from Velum on the CAASP admin node and copy
+  it to ~/suse-osh-deploy/kubeconfig and ~/.kube/config
+
+- pip install --upgrade pip to avoid segfaults when installing
+  openstack clients.
+
+- pip install jmespath netaddr
+
+On each CAASP node:
+
+- add id_rsa.pub to root's authorized_keys file.
+
+Now you are ready to run Stage 7, as follows:
+
+ansible-playbook -vvv -e @~/suse-osh-deploy/user_variables.yml
+./7_deploy_osh/play.yml -i inventory-osh.ini


### PR DESCRIPTION
Here's a draft of how to use Stages 2 & 7 on a manually installed
SES and CAASP. This is a little incomplete in the "how to install
CAASP/SES" area right now - I'm of the opinion that we can either
build on it or obsolete it via KVM with kubic-automation.

Note that this install process is not currently guaranteed to produce
a full working environment due to disagreements re the inventory-ses.ini
format between Stage 2 and Stage 7 the last time I worked with it
(which presumably also break run.sh deployment on engcloud :() But it
should give everyone an idea of what needs to be done and can be refined
as we go.