### PR TITLE
Revise Stage 2 ses-config.yml to match SES version

### DIFF
--- a/ses-ansible/roles/setup_ses_configs/tasks/main.yml
+++ b/ses-ansible/roles/setup_ses_configs/tasks/main.yml
@@ -16,6 +16,13 @@
   when:
     - ses_openstack_config
 
+- name: Get key values for ses-config.yml
+  set_fact:
+    "ceph_{{ item.name | regex_replace('[\\.\\-]', '_') }}_key":
+       "{{lookup('ini', 'key section={{ item.name }} file={{ ses_config_path }}/ceph.{{ item.name }}.keyring') }}"
+  with_items:
+    - "{{ ses_openstack_keys }}"
+
 - name: Generate ses-config.yml
   template:
     src: ses-config.yml.j2

--- a/ses-ansible/roles/setup_ses_configs/templates/ses-config.yml.j2
+++ b/ses-ansible/roles/setup_ses_configs/templates/ses-config.yml.j2
@@ -1,28 +1,25 @@
-ses_cluster_configuration:
-  ses_cluster_name: ceph
-{% if radosgw_keystone %}
-  ses_radosgw_url: "http://{{ hostvars['ses'].ansible_default_ipv4.address }}:8080/swift/v1"
-{% endif %}
+---
+# TODO - align hardcoded values with defaults in SES
+# TODO - break out hardcoded values into default vars or something
+ceph_conf:
+  cluster_network: {{ hostvars['ses'].conf_options.stdout_lines.4 }}
+  fsid: {{ hostvars['ses'].conf_options.stdout_lines.0 }}
+  mon_host: {{ hostvars['ses'].conf_options.stdout_lines.2 }}
+  mon_initial_members: {{ hostvars['ses'].conf_options.stdout_lines.1 }}
+  public_network: {{ hostvars['ses'].conf_options.stdout_lines.3 }}
+cinder:
+  key: {{ ceph_client_cinder_key }}
+  rbd_store_pool: cinder
+  rbd_store_user: cinder
+cinder-backup:
+  key: {{ ceph_client_cinder_backup_key }}
+  rbd_store_pool: backups
+  rbd_store_user: cinder_backup
+nova:
+  rbd_store_pool: nova
+glance:
+  key: {{ ceph_client_glance_key }}
+  rbd_store_pool: glance
+  rbd_store_user: glance
+radosgw_urls: []
 
-  conf_options:
-      ses_fsid: {{ hostvars['ses'].conf_options.stdout_lines.0 }}
-      ses_mon_initial_members: {{ hostvars['ses'].conf_options.stdout_lines.1 }}
-      ses_mon_host: {{ hostvars['ses'].conf_options.stdout_lines.2 }}
-      ses_public_network: {{ hostvars['ses'].conf_options.stdout_lines.3 }}
-      ses_cluster_network: {{ hostvars['ses'].conf_options.stdout_lines.4 }}
-  cinder:
-      rbd_store_pool: cinder
-      rbd_store_pool_user: cinder
-      keyring_file_name: ceph.client.cinder.keyring
-  cinder-backup:
-      rbd_store_pool: backups
-      rbd_store_pool_user: cinder_backup
-      keyring_file_name: ceph.client.cinder_backup.keyring
- # Nova uses the cinder user to access the nova pool, cinder pool
- # So all we need here is the nova pool name.
-  nova:
-      rbd_store_pool: nova
-  glance:
-      rbd_store_pool: glance
-      rbd_store_pool_user: glance
-      keyring_file_name: ceph.client.glance.keyring


### PR DESCRIPTION
Stage 7 will be using a ses-config.yml that matches the output of
https://github.com/SUSE/DeepSea/blob/master/srv/modules/runners/openstack.py
Modify the Stage 2 ses-config.yml to reflect this change so end-to-end
runs on engcloud and the manual installation + Stage 2 + Stage 7 will
work.