### PR TITLE
Fix Stage 2 output of user vars

### DIFF
--- a/2_deploy_ses_aio/set-user-variables.yml
+++ b/2_deploy_ses_aio/set-user-variables.yml
@@ -21,4 +21,4 @@
         block: |
           ceph_admin_keyring_b64key: {{ _clientadminkey.stdout_lines[0] }}
           ceph_user_keyring_b64key: {{ _clientadminkey.stdout_lines[0]  }}
-          suse_osh_deploy_ceph_mons: "[{% for ip in ansible_all_ipv4_addresses %}'{{ ip }}:6789'{% if not loop.last %},{% endif %}{% endfor %}]" #list containing all ips of the host (which should be an AIO containing the mons).
+          suse_osh_deploy_ceph_mons: [{% for ip in ansible_all_ipv4_addresses %}'{{ ip }}:6789'{% if not loop.last %},{% endif %}{% endfor %}] #list containing all ips of the host (which should be an AIO containing the mons).


### PR DESCRIPTION
/tmp/ceph-storage-classes.yaml should now be correctly generated in
Stage 7 with this change to generation of user-variables.yml in
Stage 2.