### PR TITLE
Remove rbd application enable in Stage 2

### DIFF
--- a/ses-ansible/roles/ses/tasks/openstack_config.yml
+++ b/ses-ansible/roles/ses/tasks/openstack_config.yml
@@ -5,11 +5,6 @@
   changed_when: false
   failed_when: false
 
-- name: Associate openstack pool(s) to application rbd
-  command: "ceph osd pool application enable {{ item.name }} rbd"
-  with_items: "{{ ses_openstack_pools | unique }}"
-  changed_when: false
-
 - name: Create openstack key(s)
   shell: "ceph-authtool -C /etc/ceph/ceph.{{ item.name }}.keyring --name {{ item.name }} --add-key {{ item.key }} --cap mon \"{{ item.mon_cap|default('') }}\" --cap osd \"{{ item.osd_cap|default('') }}\" --cap mds \"{{ item.mds_cap|default('') }}\""
   args:


### PR DESCRIPTION
Enabling the rbd application on the pools here causes the
helm service bringup to fail since an application with a different
name has already been enabled for that pool. Remove this for now to
get it working; look more in-depth at pool creation, etc later but
leave it as is for now since it's not a blocker.