### PR TITLE
Building suse images locally via openstack-helm-images patches

### DIFF
--- a/7_deploy_osh/play.yml
+++ b/7_deploy_osh/play.yml
@@ -1,4 +1,18 @@
 ---
+
+- hosts: osh-deployer
+  gather_facts: yes
+  any_errors_fatal: true
+  roles:
+    - suse-dev-patcher
+
+- hosts: osh-deployer
+  gather_facts: yes
+  any_errors_fatal: true
+  roles:
+    - role: suse-build-images
+      when: build_osh_images | default('False') | bool
+
 - hosts: osh-deploy-cp
   gather_facts: yes
   any_errors_fatal: true

--- a/7_deploy_osh/roles/suse-build-images/defaults/main.yml
+++ b/7_deploy_osh/roles/suse-build-images/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# defaults file for suse-build-images
+
+devenv_root: /opt
+
+local_registry_name: local-registry
+local_registry_port: 5000
+openstack_svcs_build_image_version: stable/queens
+
+suse_build_images_packages:
+  - docker

--- a/7_deploy_osh/roles/suse-build-images/tasks/main.yml
+++ b/7_deploy_osh/roles/suse-build-images/tasks/main.yml
@@ -37,9 +37,10 @@
       {{ ansible_default_ipv4.address | ipaddr('address') }} {{ local_registry_name }}
 
 - name: Make sure docker daemon file is present on host
-  file:
-    path: "/etc/docker/daemon.json"
-    state: touch
+  copy:
+    dest: "/etc/docker/daemon.json"
+    content: "{}"
+    force: no
     mode: 0644
 
 - name: Read existing docker daemon conf file

--- a/7_deploy_osh/roles/suse-build-images/tasks/main.yml
+++ b/7_deploy_osh/roles/suse-build-images/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+
+- name: Install system packages for build images
+  package:
+    name: "{{ suse_build_images_packages }}"
+    state: present
+  register: install_packages
+  until: install_packages is success
+  retries: 5
+  delay: 2
+  tags:
+    - install
+
+- name: Ensure docker is running on host
+  service:
+    name: docker
+    state: started
+
+- name: Check if local docker registry server is running
+  shell: |
+    docker ps | grep {{ local_registry_name }}
+  register: registry_running_cmd_status
+  failed_when: false
+  tags:
+    - run
+
+- name: Start local docker registry if not running
+  shell: |
+    docker run -d -p {{ local_registry_port }}:{{ local_registry_port }} --name {{ local_registry_name }} --restart always registry:2
+  when:
+    - registry_running_cmd_status.rc != 0
+
+- name: Ensure local-registry DNS resolution is set in /etc/hosts
+  blockinfile:
+    path: /etc/hosts
+    block: |
+      {{ ansible_default_ipv4.address | ipaddr('address') }} {{ local_registry_name }}
+
+- name: Make sure docker daemon file is present on host
+  file:
+    path: "/etc/docker/daemon.json"
+    state: touch
+    mode: 0644
+
+- name: Read existing docker daemon conf file
+  set_fact:
+    _docker_daemon_conf: "{{ lookup('file', '/etc/docker/daemon.json') | default({}) | from_json }}"
+
+- name: Set registry entry in docker daemon conf if not defined
+  set_fact:
+    _upd_docker_daemon_conf: "{{ _docker_daemon_conf | combine({ item.key: item.value }) }}"
+  with_items:
+    - { key: "insecure-registries", value: "[\"{{local_registry_name}}:{{local_registry_port}}\"]" }
+  when:
+    - _docker_daemon_conf | json_query('"insecure-registries"') | default("", true) == ""
+
+- name: Write back updated docker daemon file
+  copy:
+    content: "{{ _upd_docker_daemon_conf | to_nice_json }}"
+    dest: "/etc/docker/daemon.json"
+  when:
+    - _upd_docker_daemon_conf is defined
+
+- name: Restart docker if needed
+  service:
+    name: docker
+    state: restarted
+  when: _upd_docker_daemon_conf is defined
+
+- name: Build Openstack Services images via loci
+  shell: |
+    export LOCI_SRC_DIR={{ devenv_root }}/loci
+    export REGISTRY_URI={{ local_registry_name }}:{{ local_registry_port }}/openstackhelm/
+    export BASE_IMAGE=leap15
+    export OPENSTACK_VERSION="{{ openstack_svcs_build_image_version }}"
+    export PUSH_TO_REGISTRY=yes
+    ./openstack/loci/build.sh
+  args:
+    chdir: "{{ devenv_root }}/openstack-helm-images"

--- a/7_deploy_osh/roles/suse-dev-patcher/defaults/main.yml
+++ b/7_deploy_osh/roles/suse-dev-patcher/defaults/main.yml
@@ -1,0 +1,46 @@
+---
+# defaults file for suse-dev-patcher
+
+devenv_root: /opt
+
+suse_dev_patcher_packages:
+  - autoconf
+  - git
+  - jq
+  - curl
+
+osh_repos:
+  openstack-helm-infra:
+    src: https://git.openstack.org/openstack/openstack-helm-infra
+    version: 5da44ee3095906d97808fe73b8d0f6617cd623c7  # commit ref 4th December 2018
+  openstack-helm:
+    src: https://git.openstack.org/openstack/openstack-helm
+    version: 030868aee3e14122eac1d39a1bb2d154ef9c86c9  # frozen ref 4th December 2018
+  openstack-helm-images:
+    src: https://github.com/openstack/openstack-helm-images
+    version: master
+  loci:
+    src: https://github.com/openstack/loci
+    version: master
+
+# Following configuration is defined per gerrit review site.
+# Review site need to support unauthenticated access via its REST API.
+# Right now, only review.openstack.org is used and REST APIs are used to
+# identify latest patchset of a review.
+
+# On a per-repo basis, you may specify a list of patchsets to apply by
+# the review number in the URL. There is no need to specify the revision
+# as the latest revision of the patchset will always be chosen.
+osh_patchsets:
+  - review_api_base_URL: "https://review.openstack.org/changes"
+    repo_refs:
+      - repo_ref: loci
+        review_numbers:
+          - 621051
+      - repo_ref: openstack-helm-images
+        review_numbers:
+          - 621206
+          - 621254
+          - 621143
+          - 621145
+

--- a/7_deploy_osh/roles/suse-dev-patcher/tasks/clone-repos.yml
+++ b/7_deploy_osh/roles/suse-dev-patcher/tasks/clone-repos.yml
@@ -1,0 +1,11 @@
+---
+- name: Clone OpenStack-Helm related code repositories
+  git:
+    repo: "{{ item.value.src }}"
+    dest: "/opt/{{ item.key }}"
+    update: yes
+    force: yes
+    version: "{{ item.value.version }}"
+  with_dict: "{{ osh_repos }}"
+  register: _gitclone
+  until: _gitclone is succeeded

--- a/7_deploy_osh/roles/suse-dev-patcher/tasks/main.yml
+++ b/7_deploy_osh/roles/suse-dev-patcher/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Install system packages for dev patcher
+  package:
+    name: "{{ suse_dev_patcher_packages }}"
+    state: present
+  register: install_packages
+  until: install_packages is success
+  retries: 5
+  delay: 2
+  tags:
+    - install
+
+- name: Clone OSH related repos
+  import_tasks: clone-repos.yml
+  tags:
+    - run
+
+- name: Apply upstream reviews in flight to OSH related repos
+  include: patch-review-repos.yml
+  with_items: "{{ osh_patchsets | default({}) }}"
+  loop_control:
+    loop_var: review_site
+  tags:
+    - run

--- a/7_deploy_osh/roles/suse-dev-patcher/tasks/main.yml
+++ b/7_deploy_osh/roles/suse-dev-patcher/tasks/main.yml
@@ -10,13 +10,20 @@
   tags:
     - install
 
+# TODO(arunkant): Remove this pip package install in SCRD-6151 when a venv for bootstrap is provided
+- name: Install pip packages needed for ansible filters usage later
+  pip:
+    name:
+      - netaddr
+      - jmespath
+
 - name: Clone OSH related repos
   import_tasks: clone-repos.yml
   tags:
     - run
 
 - name: Apply upstream reviews in flight to OSH related repos
-  include: patch-review-repos.yml
+  include_tasks: patch-review-repos.yml
   with_items: "{{ osh_patchsets | default({}) }}"
   loop_control:
     loop_var: review_site

--- a/7_deploy_osh/roles/suse-dev-patcher/tasks/patch-review-repos.yml
+++ b/7_deploy_osh/roles/suse-dev-patcher/tasks/patch-review-repos.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Apply changesets in flight for review site {{ review_site }}
+  shell: |
+    set -e
+    status=$(curl -sb -H "Accept: application/json" "{{ review_site.review_api_base_URL }}/?q={{ item.1 }}&o=CURRENT_REVISION" | awk 'NR>1' | jq -r ".[0].status")
+    if [[ $status != "MERGED" ]]; then
+      ref=$(curl -sb -H "Accept: application/json" "{{ review_site.review_api_base_URL }}/?q={{ item.1 }}&o=CURRENT_REVISION" | awk 'NR>1' | jq -r ".[0].revisions[.[0].current_revision].ref")
+      git fetch {{ osh_repos[item.0.repo_ref].src }} $ref
+      git cherry-pick FETCH_HEAD
+    fi
+  args:
+      chdir: "{{ devenv_root }}/{{ item.0.repo_ref }}"
+  with_subelements:
+    - "{{ review_site.repo_refs | default({}) }}"
+    - review_numbers

--- a/7_deploy_osh/roles/suse-osh-deploy/tasks/main.yml
+++ b/7_deploy_osh/roles/suse-osh-deploy/tasks/main.yml
@@ -68,11 +68,6 @@
       {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} neutron neutron.openstack.svc.cluster.local
       {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} horizon horizon.openstack.svc.cluster.local
 
-- name: Fetch OSH code
-  include: code-install.yml
-  tags:
-    - install
-
 # NOTE: This task should stay close to code-install, so that no race condition
 # happens between the git-cloning, an eventual failure, and the building of the charts.
 - name: Build infra charts

--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ The `<subcommand>` can be one of the following:
 * `deploy_osh`: This subcommand runs the 'step 7' plays, deploying
   OpenStack-Helm.
 
+* `build_deploy_osh`: This subcommand runs the 'step 7' plays, which includes
+  building Openstack-Helm images locally and deploying OpenStack-Helm.
+
 * `teardown`: This subcommand deletes all evidences of the deployment
   on the `$deploy_mechanism`, and then removes all user files from
   localhost. Destructive operation.

--- a/run.sh
+++ b/run.sh
@@ -21,6 +21,13 @@ function deploy_osh(){
     echo "SUSE OSH deployed"
 }
 
+function build_osh_images_and_deploy(){
+    source script_library/detect-ansible.sh
+    export ANSIBLE_STDOUT_CALLBACK=debug
+    $ansible_playbook ./7_deploy_osh/play.yml -i inventory-osh.ini -e "build_osh_images=yes"
+    echo "SUSE OSH images built locally and SUSE OSH deployed"
+}
+
 function pre_deploy_on_openstack(){
     source script_library/pre-flight-checks.sh openstack_early_tests
     echo "Deploying on OpenStack"
@@ -82,6 +89,9 @@ case "$action" in
     "deploy_osh")
         deploy_osh
         ;;
+    "build_deploy_osh")
+        build_osh_images_and_deploy
+        ;;
     "teardown")
         delete_on_$deploy_mechanism
         delete_user_files
@@ -92,6 +102,8 @@ case "$action" in
     *)
         echo "Usage: ${0} full_deploy|deploy_osh|teardown|clean_k8s"
         echo "full_deploy ensures the requirements are setup and then does the deploy_osh step"
+        echo "osh_deploy deploys OSH infra and services helm charts on caasp cluster"
+        echo "build_deploy_osh first builds OSH images locally and then runs osh_deploy steps mentioned above"
         echo "teardown removes all nodes used for deployment"
         echo "clean_k8s cleans up the kubernetes cluster of all evidence of an OSH deployment"
         ;;


### PR DESCRIPTION
This change is using openstack-helm-images and loci upstream patches
to build openstack services images. So added support for pulling-in
those patches. If a given patch is merged in master, then that change
is not checked out as its already available via clone of that repo with
master branch.

Currently its building stable/queens images.