### PR TITLE
Only use dev-patcher and build-images when developer mode


### DIFF
--- a/7_deploy_osh/play.yml
+++ b/7_deploy_osh/play.yml
@@ -3,15 +3,23 @@
 - hosts: osh-deployer
   gather_facts: yes
   any_errors_fatal: true
+  pre_tasks:
+    #http://jinja.pocoo.org/docs/2.10/templates/#default
+    - name: Check if developer mode should be enabled
+      set_fact:
+        developer_mode: "{{ (lookup('env','OSH_DEVELOPER_MODE') | default('False', true) ) | bool }}"
   roles:
-    - suse-dev-patcher
+    - role: suse-dev-patcher
+      when: developer_mode
 
 - hosts: osh-deployer
   gather_facts: yes
   any_errors_fatal: true
   roles:
     - role: suse-build-images
-      when: build_osh_images | default('False') | bool
+      when:
+        - developer_mode
+        - build_osh_images | default('False') | bool
 
 - hosts: osh-deploy-cp
   gather_facts: yes


### PR DESCRIPTION


Only developers have a need to temporarily patch and build images
for the environment.

The deployment can now toggles theses features by reading
the OSH_DEVELOPER_MODE environment variable.
Should that variable be a truthy boolean-like (yes, true, True),
then developer mode will be enabled, and patching/image building
will be done.

