### PR TITLE
Do no skip the include step


### DIFF
--- a/7_deploy_osh/roles/dev-patcher/tasks/main.yml
+++ b/7_deploy_osh/roles/dev-patcher/tasks/main.yml
@@ -1,9 +1,11 @@
 ---
-- name: Include global vars
-  include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
-
-- name: Include repo vars
-  include_vars: "{{ playbook_dir }}/../vars/manifest.yml"
+- name: Include variables
+  include_vars: "{{ item }}"
+  loop:
+    - "{{ playbook_dir }}/../vars/common-vars.yml"
+    - "{{ playbook_dir }}/../vars/manifest.yml"
+  tags:
+    - always
 
 - name: Install the necessary packages on the deployer node
   package:
@@ -17,7 +19,7 @@
     update: yes
     force: yes
     version: "{{ item.value.version }}"
-  loop: "{{ upstream_repos | dict2items }}"
+  loop: "{{ (upstream_repos | default({})) | dict2items }}"
   register: _gitclone
   until: _gitclone is succeeded
 


### PR DESCRIPTION


If the include step is skipped, the dev patcher will fail, as
the variable on which to apply the dict2items filter is undefined.
(Even if the task is skipped, the filter would throw a Jinja exception
causing the play to fail).

This fixes it by ensuring the include always run (even if tag
filtering on the play is applied), and by ensuring the dict is
empty by default.

