### PR TITLE
Improve deletion script


### DIFF
--- a/script_library/cleanup-k8s.sh
+++ b/script_library/cleanup-k8s.sh
@@ -20,6 +20,10 @@ for NS in openstack ceph nfs; do
     kubectl get job -n ${NS} -o name | xargs kubectl delete -n ${NS}  --ignore-not-found=true
 done
 
+# Remove extra data
+kubectl delete clusterrolebinding PrivilegedRoleBinding
+kubectl delete clusterrolebinding NonResourceUrlRoleBinding
+kubectl delete clusterrolebinding ingress-kube-system-ingress
 
 rm -rf /var/lib/openstack-helm/*
 rm -rf /var/lib/nova/*

--- a/script_library/cleanup-k8s.sh
+++ b/script_library/cleanup-k8s.sh
@@ -20,6 +20,10 @@ for NS in openstack ceph nfs; do
     kubectl get job -n ${NS} -o name | xargs kubectl delete -n ${NS}  --ignore-not-found=true
 done
 
+# DO NOT USE clusterrolebinding, else you will delete all rolebindings, even the suse: and system: ones,
+# even when scoped in the namespace.
+kubectl get -n openstack rolebinding.rbac.authorization.k8s.io -o name | xargs kubectl -n openstack delete
+
 # Remove extra data
 kubectl delete clusterrolebinding PrivilegedRoleBinding
 kubectl delete clusterrolebinding NonResourceUrlRoleBinding


### PR DESCRIPTION


The deletion script let a few kubernetes components hanging.
This should be remove all the objects we didn't remove.

When all the SUSE generated files will be moved to /tmp/socok8s-* this
will also simplify the cleanup script, by deleting them in one go.

