### PR TITLE
Bring back code for importing SES configuration

### DIFF
--- a/2_deploy_ses_aio/play.yml
+++ b/2_deploy_ses_aio/play.yml
@@ -23,52 +23,9 @@
   vars:
     ses_openstack_config: True
 
-- hosts: ses_nodes[0]
-  vars:
-    ses_config_file_path: "~/suse-osh-deploy/ses_config.yml"
-  tasks:
-    - name: Ensure the OSH config folder exists
-      file:
-        state: directory
-        name: "{{ ses_config_file_path | dirname }}"
-      delegate_to: localhost
-
-    # The AIO ses creates /tmp/ses_config/ on localhost,
-    # but that can disappear anytime. So we'll store
-    # The ses config in our userspace.
-    - name: Copy SES config in userspace
-      copy:
-        src: "/tmp/ses_config/ses_config.yml"
-        dest: "{{ ses_config_file_path | dirname }}"
-        remote_src: yes
-      delegate_to: localhost
-
-    # TODO(evrardjp): Add return code to latest call to make sure idempotency is known.
-    # This step is needed until we decide to use ses_config created pools (and have properly tested them)
-    - name: Create pools
-      shell: "ceph -k /etc/ceph/ceph.client.admin.keyring osd pool ls | grep {{ item }} || ceph -k /etc/ceph/ceph.client.admin.keyring osd pool create {{ item }} 128 128"
-      with_items:
-        - rbd
-        - volumes
-        - cinder_backup
-        - images
-        - vms
-- hosts: ses_nodes[0]
-  gather_facts: yes
-  vars:
-    suse_osh_deploy_user_variables: "~/suse-osh-deploy/env/extravars"
-  tasks:
-    - name: Find the admin keyring b64 value
-      shell: ceph auth get-key client.admin | base64
-      changed_when: false
-      register: _clientadminkey
-
-    - name: Create user_variables
-      delegate_to: localhost
-      blockinfile:
-        path: "{{ suse_osh_deploy_user_variables }}"
-        create: yes
-        block: |
-          ceph_admin_keyring_b64key: {{ _clientadminkey.stdout_lines[0] }}
-          ceph_user_keyring_b64key: {{ _clientadminkey.stdout_lines[0]  }}
-          suse_osh_deploy_ceph_mons: [{% for ip in ansible_all_ipv4_addresses %}'{{ ip }}:6789'{% if not loop.last %},{% endif %}{% endfor %}] #list containing all ips of the host (which should be an AIO containing the mons).
+- name: Import SES configs
+  hosts: ses_nodes[0]
+  remote_user: root
+  gather_facts: false
+  roles:
+    - ses-osh

--- a/2_deploy_ses_aio/roles/ses-osh/defaults/main.yml
+++ b/2_deploy_ses_aio/roles/ses-osh/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+ses_config_path: "~/suse-osh-deploy/"
+suse_osh_deploy_user_variables: "{{ ses_config_path }}/env/extravars"
+radosgw_keystone: False

--- a/2_deploy_ses_aio/roles/ses-osh/tasks/main.yml
+++ b/2_deploy_ses_aio/roles/ses-osh/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+- name: Ensure ses config directory exist
+  delegate_to: localhost
+  file:
+    path: "{{ ses_config_path }}"
+    state: directory
+
+- name: Drop ceph conf and keys
+  delegate_to: localhost
+  copy:
+    dest: "{{ ses_config_path }}/{{ item.item }}"
+    content: "{{ item.content | b64decode }}"
+    mode: 0644
+  with_items:
+    - "{{ hostvars[groups['ses_nodes'][0]].ceph_files.results }}"
+
+- name: Generate ses-config.yml
+  delegate_to: localhost
+  template:
+    src: ses-config.yml.j2
+    dest: "{{ ses_config_path }}/ses_config.yml"
+
+- name: Create pools
+  shell: "ceph -k /etc/ceph/ceph.client.admin.keyring osd pool ls | grep {{ item }} || ceph -k /etc/ceph/ceph.client.admin.keyring osd pool create {{ item }} 128 128"
+  with_items:
+    - rbd
+    - volumes
+    - cinder_backup
+    - images
+    - vms
+
+- name: Find the admin keyring b64 value
+  shell: ceph auth get-key client.admin | base64
+  changed_when: false
+  register: _clientadminkey
+
+- name: Create user_variables
+  delegate_to: localhost
+  blockinfile:
+    path: "{{ suse_osh_deploy_user_variables }}"
+    create: yes
+    block: |
+      ceph_admin_keyring_b64key: {{ _clientadminkey.stdout_lines[0] }}
+      ceph_user_keyring_b64key: {{ _clientadminkey.stdout_lines[0]  }}
+      suse_osh_deploy_ceph_mons: [{% for ip in ansible_all_ipv4_addresses %}'{{ ip }}:6789'{% if not loop.last %},{% endif %}{% endfor %}] #list containing all ips of the host (which should be an AIO containing the mons).

--- a/2_deploy_ses_aio/roles/ses-osh/templates/ses-config.yml.j2
+++ b/2_deploy_ses_aio/roles/ses-osh/templates/ses-config.yml.j2
@@ -1,0 +1,28 @@
+ses_cluster_configuration:
+  ses_cluster_name: ceph
+{% if radosgw_keystone %}
+  ses_radosgw_url: "http://{{ hostvars[groups['ses_nodes'][0]].ansible_default_ipv4.address }}:8080/swift/v1"
+{% endif %}
+
+  conf_options:
+      ses_fsid: {{ hostvars[groups['ses_nodes'][0]].conf_options.stdout_lines.0 }}
+      ses_mon_initial_members: {{ hostvars[groups['ses_nodes'][0]].conf_options.stdout_lines.1 }}
+      ses_mon_host: {{ hostvars[groups['ses_nodes'][0]].conf_options.stdout_lines.2 }}
+      ses_public_network: {{ hostvars[groups['ses_nodes'][0]].conf_options.stdout_lines.3 }}
+      ses_cluster_network: {{ hostvars[groups['ses_nodes'][0]].conf_options.stdout_lines.4 }}
+  cinder:
+      rbd_store_pool: cinder
+      rbd_store_pool_user: cinder
+      keyring_file_name: ceph.client.cinder.keyring
+  cinder-backup:
+      rbd_store_pool: backups
+      rbd_store_pool_user: cinder_backup
+      keyring_file_name: ceph.client.cinder_backup.keyring
+ # Nova uses the cinder user to access the nova pool, cinder pool
+ # So all we need here is the nova pool name.
+  nova:
+      rbd_store_pool: nova
+  glance:
+      rbd_store_pool: glance
+      rbd_store_pool_user: glance
+      keyring_file_name: ceph.client.glance.keyring


### PR DESCRIPTION
This is a partial revert and rework of commit 2afb55084. It brings back
the code to create the SES configuration (ses-config.yml). This file is
later consumed by get-ses-data.yml. Without it new deployments from
scratch are failing.