### PR TITLE
Added option to delete CaaSP only

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Here are the actions available:
 * setup_everything: From A to Z.
 * teardown: Destroys all the nodes in an openstack environment.
   Set the env var 'DELETE_ANYWAY' to 'YES' to delete everything in your userspace.
+* delete_caasp: Removes existing CaaSP deployment
 * clean_k8s: Removes all k8s definitions that were introduced during deployment
   (Experimental!)
 

--- a/run.sh
+++ b/run.sh
@@ -73,6 +73,9 @@ case "$deployment_action" in
     "teardown")
         teardown
         ;;
+    "delete_caasp")
+        delete_caasp
+        ;;
     "clean_k8s")
         clean_k8s
         ;;

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -55,6 +55,7 @@ function deploy_osh(){
 }
 function teardown(){
     clean_openstack
+    delete_caasp
     clean_userfiles
 }
 function clean_k8s(){
@@ -64,12 +65,14 @@ function clean_k8s(){
         ansible -m script -a "script_library/cleanup-k8s.sh" osh-deployer -i inventory-osh.ini
     fi
 }
-function clean_openstack(){
-    echo "Deleting on OpenStack"
-    ${socok8s_absolute_dir}/4_osh_node_on_openstack/delete.sh
+function delete_caasp(){
     echo "Delete Caasp nodes"
     ${socok8s_absolute_dir}/3_caasp_nodes_on_openstack_heat/delete.sh || true
     ${socok8s_absolute_dir}/3_caasp_nodes_on_openstack_manually/delete.sh || true
+}
+function clean_openstack(){
+    echo "Deleting on OpenStack"
+    ${socok8s_absolute_dir}/4_osh_node_on_openstack/delete.sh
     echo "Delete SES node"
     ${socok8s_absolute_dir}/1_ses_node_on_openstack/delete.sh
 }


### PR DESCRIPTION
If CaaSP deployment goes wrong, user might need to redeploy it.
Instead of tearing down complete socok8s setup, it should be enough
to delete CaaSP before.

(This will need rebase after the merge of https://github.com/SUSE-Cloud/socok8s/pull/76)