### PR TITLE
WIP: Stack output and floating IPs for the workers

### DIFF
--- a/3_caasp_nodes_on_openstack_heat/caasp-stack.yaml
+++ b/3_caasp_nodes_on_openstack_heat/caasp-stack.yaml
@@ -210,3 +210,24 @@ resources:
           admin_node_ip: { get_attr: [admin, first_address] }
           num_volumes: { get_param: worker_num_volumes }
           volume_size: { get_param: worker_volume_size }
+
+  worker_floating_ips:
+    type: OS::Heat::ResourceGroup
+    properties:
+      count: { get_param: worker_count }
+      resource_def:
+        type: caasp-worker-floatingip.yaml
+        properties:
+          workers: { get_attr: [ workers, worker_name ] }
+          worker_ids: { get_attr: [ workers, worker_id ] }
+          ports: { get_attr: [ workers, worker_port_id ] }
+          public_network: { get_param: external_net }
+          index: '%index%'
+
+outputs:
+  master_server_ids:
+    value: {get_attr: [masters, master_server_id]}
+  master_floating_ips:
+    value: {get_attr: [masters, master_floating_ip]}
+  worker_floating_ips:
+    value: {get_attr: [worker_floating_ips, ip_assignment]}

--- a/3_caasp_nodes_on_openstack_heat/caasp-worker-floatingip.yaml
+++ b/3_caasp_nodes_on_openstack_heat/caasp-worker-floatingip.yaml
@@ -1,0 +1,46 @@
+heat_template_version: 2015-04-30
+
+parameters:
+  index:
+    type: number
+
+  ports:
+    type: comma_delimited_list
+    label: Server ports
+
+  public_network:
+    type: string
+    label: Public network name or ID
+    description: Public network with floating IP addresses.
+    default: public
+
+  workers:
+    type: comma_delimited_list
+    label: worker names
+  
+  worker_ids:
+    type: comma_delimited_list
+    label: worker ids
+
+
+resources:
+  floating_ip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: { get_param: public_network }
+
+  floating_ip_assoc:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      floatingip_id: { get_resource: floating_ip }
+      port_id: { get_param: [ ports, { get_param: index } ] }
+
+outputs:
+  ip_assignment:
+    description: 'Assigned floating IP in the format "server-name | server-id | port-id | floatingip"'
+    value: {list_join: [' | ', [
+        {get_param: [ workers, { get_param: index } ] },
+        {get_param: [ worker_ids, { get_param: index } ] },
+        {get_param: [ ports, { get_param: index } ] },
+        {get_attr: [ floating_ip, floating_ip_address ] }
+       ]]}


### PR DESCRIPTION
This changes assigns floating IPs for the worker nodes and adds some
stack outputs to the CaaSP stack for making the floating IPs easily
consumable.