### PR TITLE
Fix DNS resolution issue in rally testing


### DIFF
--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -79,6 +79,7 @@
       {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} cinder cinder.openstack.svc.cluster.local
       {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} nova nova.openstack.svc.cluster.local
       {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} neutron neutron.openstack.svc.cluster.local
+      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} neutron-server neutron-server.openstack.svc.cluster.local
       {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} horizon horizon.openstack.svc.cluster.local
       {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} heat heat.openstack.svc.cluster.local
 


### PR DESCRIPTION


Rally by default makes use of a url containing neutron-server [1], which is not
resolving by default.

This adds the neutron-server into the known hosts.

ConnectFailure: Unable to establish connection to http://neutron-server.openstack.svc.cluster.
local:9696/v2.0/agents: HTTPConnectionPool(host='neutron-server.openstack.svc.cluster.local

