### PR TITLE
Fix clean_k8s


### DIFF
--- a/playbooks/generic-clean_k8s.yml
+++ b/playbooks/generic-clean_k8s.yml
@@ -1,0 +1,22 @@
+---
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+- hosts: osh-deployer
+  gather_facts: no
+  tasks:
+    - name: Running cleanup script
+      script: "{{ playbook_dir }}/../script_library/cleanup-k8s.sh"

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -53,7 +53,7 @@ function clean_k8s(){
     echo "DANGER ZONE. Set the env var 'DELETE_ANYWAY' to 'YES' to delete everything in your userspace."
     if [[ ${DELETE_ANYWAY:-"NO"} == "YES" ]]; then
         echo "DELETE_ANYWAY is set, cleaning up k8s"
-        ansible -m script -a "script_library/cleanup-k8s.sh" osh-deployer -i inventory-osh.ini
+        run_ansible ${socok8s_absolute_dir}/playbooks/generic-clean_k8s.yml
     fi
 }
 function clean_openstack(){


### PR DESCRIPTION


The clean_k8s function referred to an old inventory location.
This uses the same way of running ansible scripts as other plays,
and therefore simplifies understanding at the same time.

