### PR TITLE
Adapt to new ses_config structure


### DIFF
--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: Create a list of monitors (ip and port) if no override exists for it.
   set_fact:
-    suse_osh_deploy_ceph_mons:  "[{% for ip in ses_cluster_configuration.ceph_conf.mon_host.split(',') %}'{{ ip }}:{{ ceph_mon_port | default(6789) }}'{% if not loop.last %},{% endif %}{% endfor %}]"
+    suse_osh_deploy_ceph_mons: "[{{ ses_cluster_configuration['conf_options']['ses_mon_host'] }}:{{ ceph_mon_port | default(6789) }}]"
   when: suse_osh_deploy_ceph_mons is not defined
   tags:
     - always


### PR DESCRIPTION


The ses_config was changed in this tooling to match the latest
ardana changes. Therefore the set_fact would fail to get the proper mon
hosts.

This should fix the set_fact (when the user is not overriding its
value with extravars), for the new structure.

