### PR TITLE
Rework ssh wait loop and knownhosts update

### DIFF
--- a/playbooks/openstack-deploy_caasp.yml
+++ b/playbooks/openstack-deploy_caasp.yml
@@ -183,18 +183,31 @@
 
         - meta: refresh_inventory
 
-        # Waiting for port is not enough, as the port might be up (systemd)
-        # while ssh is not ready. Wait for connection is not good either
-        # because the key is unknown.
-        - name: Wait for a while for SSH to be properly booted up
+        - name: Wait for a SSH to be properly started
           wait_for:
-            timeout: 120
+            host: "{{ hostvars[item]['ansible_host'] }}"
+            port: 22
+            search_regex: OpenSSH
+            state: started
+            delay: 10
+            timeout: 180
+          loop: "{{ groups['caasp-admin'] + groups['caasp-masters'] + groups['caasp-workers'] }}"
 
         - name: Get pubkey, and add it to known hosts
-          shell: ssh-keyscan -H {{ hostvars[item]['ansible_host'] | quote }} >> ${HOME}/.ssh/known_hosts
+          command: "ssh-keyscan -H {{ hostvars[item]['ansible_host'] | quote }}"
+          register: _caaspsshkeys
+          retries: 10
+          delay: 10
+          until: _caaspsshkeys.stdout and _caaspsshkeys.stdout.strip()
           loop: "{{ groups['caasp-admin'] + groups['caasp-masters'] + groups['caasp-workers'] }}"
-          args:
-            executable: /bin/bash
+
+
+        - name: Insert known host
+          known_hosts:
+            state: present
+            name: "{{ hostvars[item.item]['ansible_host'] }}"
+            key: "{{ item.stdout }}"
+          loop: "{{ _caaspsshkeys.results }}"
 
     - name: Handle deletion
       when:

--- a/playbooks/openstack-osh_instance.yml
+++ b/playbooks/openstack-osh_instance.yml
@@ -59,16 +59,22 @@
 
         - meta: refresh_inventory
 
-        # Waiting for port is not enough, as the port might be up (systemd)
-        # while ssh is not ready. Wait for connection is not good either
-        # because the key is unknown.
-        - name: Wait for a while for SSH to be properly booted up
+        - name: Wait for a SSH to be properly started
           wait_for:
-            timeout: 120
+            host: "{{ osh_floating_ip }}"
+            port: 22
+            search_regex: OpenSSH
+            state: started
+            delay: 10
+            timeout: 180
 
         - name: Get pubkey, and add it to known hosts
           command: "ssh-keyscan -H {{ osh_floating_ip | quote }}"
           register: _oshfloatingkey
+          retries: 10
+          delay: 10
+          until: _oshfloatingkey.stdout and _oshfloatingkey.stdout.strip()
+
 
         - name: Insert known host
           known_hosts:

--- a/playbooks/openstack-ses_aio_instance.yml
+++ b/playbooks/openstack-ses_aio_instance.yml
@@ -59,16 +59,21 @@
 
         - meta: refresh_inventory
 
-        # Waiting for port is not enough, as the port might be up (systemd)
-        # while ssh is not ready. Wait for connection is not good either
-        # because the key is unknown.
-        - name: Wait for a while for SSH to be properly booted up
+        - name: Wait for a SSH to be properly started
           wait_for:
-            timeout: 120
+            host: "{{ ses_floating_ip }}"
+            port: 22
+            search_regex: OpenSSH
+            state: started
+            delay: 10
+            timeout: 180
 
         - name: Get pubkey, and add it to known hosts
           command: "ssh-keyscan -H {{ ses_floating_ip | quote }}"
           register: _sesfloatingkey
+          retries: 10
+          delay: 10
+          until: _sesfloatingkey.stdout and _sesfloatingkey.stdout.strip()
 
         - name: Insert known host
           known_hosts:


### PR DESCRIPTION
The addition of the host keys to the knownhosts file frequently failed
for the SES and CaaSP nodes because ssh-keyscan didn't return any valid
keys for the nodes yet.

This commit changes the wait condition to wait until sshd is answering
on port 22 and additionally adds a retry to the "ssh-keyscan" call for
running the command until it actually returns something. (Unfortunately
"ssh-keyscan" always returns a 0 exit code it seems)