### PR TITLE
Be more explicit about source


### DIFF
--- a/playbooks/roles/suse-build-images/tasks/main.yml
+++ b/playbooks/roles/suse-build-images/tasks/main.yml
@@ -26,7 +26,7 @@
   tags:
     - install
 
-- name: Build and push the non-LOCI components
+- name: Build and push the non-LOCI components from OSH-images
   include_tasks: build-with-docker.yml
   loop: "{{ docker_images }}"
   loop_control:
@@ -34,7 +34,7 @@
 
 # TODO(evrardjp): Ensure idempotency here
 # In the meantime, skip_ansible_lint
-- name: Build and push Openstack Services images via loci
+- name: Build and push Openstack Services images from OSH-images LOCI process
   include_tasks: build-with-loci.yml
   when:
     - loci_build_projects | length > 0


### PR DESCRIPTION


This adds, in the task name, the location of the repo used for
building image.
This makes it more explicit, and is easier to know what's going on.

This should be applied on top of #93.

