### PR TITLE
disable debug for ansible on developer mode

### DIFF
--- a/doc/source/user/ansible_tips.rst
+++ b/doc/source/user/ansible_tips.rst
@@ -1,0 +1,32 @@
+==============================
+Ansible tips
+==============================
+
+
+There is several variables that you can use to get extra debugging from the ansible playbooks as shown in https://docs.ansible.com/ansible/latest/reference_appendices/config.html
+
+Some examples:
+
+.. code-block:: console
+
+    export ANSIBLE_VERBOSITY=3
+    export ANSIBLE_STDOUT_CALLBACK=debug
+
+Both of this environment variables will enable a lot of verbosity and debug for all the playbooks being run
+
+
+You can also enable the debugger for failed tasks as shown in https://docs.ansible.com/ansible/latest/user_guide/playbooks_debugger.html
+
+.. code-block:: console
+
+    export ANSIBLE_ENABLE_TASK_DEBUGGER=True
+
+
+This will drop you into the debugger when a task fails so you can examine the task, vars, retry it and so on. Make sure to check the ansible docs linked for all available options
+
+
+Other notable helpers are the debug task which will allow you to print to stdout while the playbooks are executed: https://docs.ansible.com/ansible/latest/modules/debug_module.html
+
+
+.. note ::
+    All this settings can be also set in your ~/.ansible.cfg file

--- a/script_library/run-ansible.sh
+++ b/script_library/run-ansible.sh
@@ -20,14 +20,6 @@ function run_ansible(){
         cp ${socok8s_absolute_dir}/examples/workdir/inventory/hosts.yml ${inventorydir}
     fi
 
-    #Add extra debugging info if necessary
-    if [[ ${OSH_DEVELOPER_MODE:-"False"} == "True" ]]; then
-        # This is set in the current shell env vars, instead of
-        # ${ANSIBLE_RUNNER_DIR}/env/envvars, to be non persistent between runs
-        export ANSIBLE_STDOUT_CALLBACK=debug
-        export ANSIBLE_VERBOSITY=3
-    fi
-
     if [[ -f ${extravarsfile} ]]; then
         echo "Extra variables file exists: $(realpath ${extravarsfile}). Loading its vars in ansible-playbook call."
         extra_vars="-e @${extravarsfile}"


### PR DESCRIPTION
Currently the developer mode is linked into an increase in ansible
verbose AND a change to the stdout callback

Instead of that, have a different var for it as developer mode is
needed for some roles (build_images) but you dont necessarily want
extra verbosity or you stdout_callback to be overwritten