### PR TITLE
Revise osh templates and example ses_config.yml file

### DIFF
--- a/examples/workdir/ses_config.yml
+++ b/examples/workdir/ses_config.yml
@@ -1,25 +1,27 @@
-ses_cluster_configuration:
-  ses_cluster_name: ceph
-
-  conf_options:
-      ses_fsid: ad762bdd-d2c1-3028-a5ec-5c1b6768adac
-      ses_mon_initial_members: jevrard-ses
-      ses_mon_host: 192.168.50.10
-      ses_public_network: 192.168.50.0/24
-      ses_cluster_network: 192.168.50.0/24
-  cinder:
-      rbd_store_pool: cinder
-      rbd_store_pool_user: cinder
-      keyring_file_name: ceph.client.cinder.keyring
-  cinder-backup:
-      rbd_store_pool: backups
-      rbd_store_pool_user: cinder_backup
-      keyring_file_name: ceph.client.cinder_backup.keyring
- # Nova uses the cinder user to access the nova pool, cinder pool
- # So all we need here is the nova pool name.
-  nova:
-      rbd_store_pool: nova
-  glance:
-      rbd_store_pool: glance
-      rbd_store_pool_user: glance
-      keyring_file_name: ceph.client.glance.keyring
+---
+# Example ses_config.yml file
+ceph_conf:
+  cluster_network: 192.168.111.0/24
+  fsid: f85b97cb-ce8c-375a-80cc-d7ce32ba797f
+  mon_host: 192.168.111.124
+  mon_initial_members: linux-qx79
+  public_network: 192.168.111.0/24
+cinder:
+  key: AQCDH9tbV49jDxAAk+d2wdxsXRcSFzjf0DHWyw==
+  rbd_store_pool: cinder
+  rbd_store_user: cinder
+cinder-backup:
+  key: AQCSH9tbx9YzNBAA65C+mwyNdmqaRwokMcHAlQ==
+  rbd_store_pool: cinder_backup
+  rbd_store_user: cinder-backup
+glance:
+  key: AQCuH9tbCNUuLBAAImRsG9tgH2ArPPlu4pt0EQ==
+  rbd_store_pool: glance
+  rbd_store_user: glance
+libvirt:
+  key: AQCDH9tbV49jDxAAk+d2wdxsXRcSFzjf0DHWyw==
+  rbd_store_pool: vms
+  rbd_store_user: cinder
+nova:
+  rbd_store_pool: nova
+radosgw_urls: []

--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -9,7 +9,8 @@
     - always
 
 - name: Get ses_cluster_configuration
-  include_vars: "{{ socok8s_ses_pools_details }}"
+  set_fact:
+    ses_cluster_configuration: "{{ lookup('file', socok8s_ses_pools_details) | from_yaml }}"
   tags:
     - always
 

--- a/playbooks/roles/deploy-osh/templates/cinder.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/cinder.yaml.j2
@@ -6,14 +6,14 @@ conf:
     DEFAULT:
       debug: true
       backup_driver: cinder.backup.drivers.ceph
-      backup_ceph_user: {{ ses_cluster_configuration['cinder-backup']['rbd_store_pool_user'] }}
+      backup_ceph_user: {{ ses_cluster_configuration['cinder-backup']['rbd_store_user'] }}
       backup_ceph_pool: {{ ses_cluster_configuration['cinder-backup']['rbd_store_pool'] }}
   backends:
     rbd1:
       volume_driver: cinder.volume.drivers.rbd.RBDDriver
       volume_backend_name: rbd1
       rbd_ceph_conf: "/etc/ceph/ceph.conf"
-      rbd_user: {{ ses_cluster_configuration['cinder']['rbd_store_pool_user'] }}
+      rbd_user: {{ ses_cluster_configuration['cinder']['rbd_store_user'] }}
       rbd_pool: {{ ses_cluster_configuration['cinder']['rbd_store_pool'] }}
       rbd_secret_uuid: {{ libvirt_ceph_cinder_secret_uuid }}
 {{ lookup('template','files/common-images-overrides.yml') | from_yaml | to_nice_yaml(indent=2) }}

--- a/playbooks/roles/deploy-osh/templates/glance.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/glance.yaml.j2
@@ -7,6 +7,6 @@ conf:
     admin_keyring: {{ ceph_admin_keyring_key }}
   glance:
     glance_store:
-      rbd_store_user: {{ ses_cluster_configuration['glance']['rbd_store_pool_user'] }}
+      rbd_store_user: {{ ses_cluster_configuration['glance']['rbd_store_user'] }}
       rbd_store_pool: {{ ses_cluster_configuration['glance']['rbd_store_pool'] }}
 {{ lookup('template','files/common-images-overrides.yml') | from_yaml | to_nice_yaml(indent=2) }}

--- a/playbooks/roles/deploy-osh/templates/libvirt.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/libvirt.yaml.j2
@@ -3,7 +3,7 @@ conf:
     enabled: true
     admin_keyring: {{ ceph_admin_keyring_key }}
     cinder:
-      user: {{ ses_cluster_configuration['cinder']['rbd_store_pool_user'] }}
+      user: {{ ses_cluster_configuration['cinder']['rbd_store_user'] }}
       keyring: {{ suse_ses_cinder_pool_key | default(ceph_admin_keyring_key) }}
       secret_uuid: {{ libvirt_ceph_cinder_secret_uuid }}
 {{ lookup('template','files/common-images-overrides.yml') | from_yaml | to_nice_yaml(indent=2) }}

--- a/playbooks/roles/deploy-osh/templates/nova.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/nova.yaml.j2
@@ -3,7 +3,7 @@ conf:
     enabled: true
     admin_keyring: {{ ceph_admin_keyring_key }}
     cinder:
-      user: {{ ses_cluster_configuration['cinder']['rbd_store_pool_user'] }}
+      user: {{ ses_cluster_configuration['cinder']['rbd_store_user'] }}
       keyring: {{ suse_ses_cinder_pool_key | default(ceph_admin_keyring_key) }}
       secret_uuid: {{ libvirt_ceph_cinder_secret_uuid }}
 {{ lookup('template','files/common-images-overrides.yml') | from_yaml | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
These changes revise the cinder, glance, libvirt, and nova templates to account for the new ses_config.yml format. The example file in workdir/examples has also been updated.