### PR TITLE
Appliying conflicting changes from ucp branch to master

### DIFF
--- a/examples/workdir/env/extravars
+++ b/examples/workdir/env/extravars
@@ -6,4 +6,8 @@ ceph_user_keyring_b64key: QVFDZWoySmNBQUFBQUJBQWlhSTZJZEw2Nml4S1FINEVlOTBTbXc9PQ
 suse_osh_deploy_ceph_mons: ['192.168.50.10:6789']
 # This is the VIP that will be used for the openstack deployment on kubernetes
 # (ingress controller)
-suse_osh_deploy_vip_with_cidr: 192.168.50.46/24
+# Deployment goal is either 'airship' or 'osh'
+socok8s_deployment_goal: airship
+socok8s_deploy_vip_with_cidr: 192.168.50.46/24
+suse_airship_deploy_site_name: soc-minimal
+redeploy_osh_only: false

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -1,0 +1,49 @@
+---
+upstream_repos_clone_folder: "/opt"
+suse_osh_registry_location: "{{ lookup('env','OPENSTACK_HELM_IMAGE_REGISTRY_LOCATION') | default('docker.io', true) }}"
+suse_osh_image_version: "{{ lookup('env','OPENSTACK_HELM_IMAGE_VERSION') | default('pike', true) }}"
+suse_libvirt_image_version: "{{ lookup('env','OPENSTACK_HELM_LIBVIRT_IMAGE_VERSION') | default('ubuntu-xenial-1.3.1-1ubuntu10.24', true) }}"
+suse_ovs_image_version: "{{ lookup('env','OPENSTACK_HELM_OPENVSWITCH_IMAGE_VERSION') | default('v2.8.1', true) }}"
+
+developer_mode: "{{ (lookup('env','SOCOK8S_DEVELOPER_MODE') | default('False', true) ) | bool }}"
+
+socok8s_workspace: "{{ lookup('env','ANSIBLE_RUNNER_DIR') | default('~/suse-socok8s-deploy', true) }}"
+socok8s_extravars: "{{ socok8s_workspace }}/env/extravars"
+socok8s_ses_pools_details: "{{ socok8s_workspace }}/ses_config.yml"
+socok8s_registry_cert: "{{ socok8s_workspace }}/certs/domain.crt"
+socok8s_registry_certkey: "{{ socok8s_workspace }}/certs/domain.key"
+socok8s_caasp_environment_details: "{{ socok8s_workspace }}/environment.json"
+socok8s_libvirtuuid: "{{ socok8s_workspace }}/libvirt.uuid"
+
+socok8s_deploy_config_location: "{{ socok8s_workspace }}"
+socok8s_airship_deploy_site_name: soc-minimal
+
+ucp_namespace_name: "{{ ucp_namespace | default('ucp') }}"
+
+suse_distro_identifier: opensuse
+suse_airship_components_base_image: "opensuse/leap:15.0"
+
+# check if argument is set in commandline for airship_local_images_flag value
+# otherwise use corresponding environment variable to determine it
+suse_airship_build_local_images: "{%- if airship_local_images_flag is defined -%}
+                                    {{ airship_local_images_flag | bool }}
+                                  {%- else -%}
+                                    {{ lookup('env','AIRSHIP_BUILD_LOCAL_IMAGES') | default('False', true) | bool }}
+                                  {%- endif -%}
+                                 "
+
+# Flag to be used when just want to use previously built local airship component images
+# without need of re-building them.
+suse_airship_use_local_images: "{{ lookup('env','AIRSHIP_USE_LOCAL_IMAGES') | default('False', true) | bool }}"
+
+suse_airship_registry_location: "{%- if suse_airship_build_local_images or suse_airship_use_local_images -%}
+                                   {{ ansible_hostname }}:5000
+                                 {%- else -%}
+                                   quay.io
+                                 {%- endif -%}"
+
+suse_airship_components_image_tag: "{%- if suse_airship_build_local_images or suse_airship_use_local_images -%}
+                                      opensuse_15_latest
+                                    {%- else -%}
+                                      latest
+                                    {%- endif -%}"

--- a/playbooks/openstack-deploy_caasp.yml
+++ b/playbooks/openstack-deploy_caasp.yml
@@ -178,8 +178,8 @@
         - name: Add vip with cidr in extravars
           lineinfile:
             path: "{{ socok8s_extravars }}"
-            regexp: "^suse_osh_deploy_vip_with_cidr.*"
-            line: "suse_osh_deploy_vip_with_cidr: {{ _vipip.stdout }}/24"
+            regexp: "^socok8s_deploy_vip_with_cidr.*"
+            line: "socok8s_deploy_vip_with_cidr: {{ _vipip.stdout }}/24"
 
         - meta: refresh_inventory
 

--- a/playbooks/roles/deploy-osh/defaults/main.yml
+++ b/playbooks/roles/deploy-osh/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for deploy-osh
 
 # Location of the kubeconfig file, fetched from velum UI.
-kubeconfig_file_path: "~/suse-osh-deploy/kubeconfig"
+kubeconfig_file_path: "{{ socok8s_workspace }}/kubeconfig"
 
 suse_osh_deploy_packages:
   - python-setuptools

--- a/playbooks/roles/deploy-osh/tasks/kubectl-install.yml
+++ b/playbooks/roles/deploy-osh/tasks/kubectl-install.yml
@@ -1,9 +1,11 @@
 ---
 - name: Download latest stable kubectl
+  become: yes
   shell: >-
-    kubectl version || (curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl &&
+    kubectl version --client || (curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl &&
     chmod 0755 ./kubectl &&
-    mv ./kubectl /usr/local/bin/kubectl)
+    mv ./kubectl /usr/local/bin/kubectl &&
+    ln -s /usr/local/bin/kubectl /usr/bin/kubectl)
   register: _kubectldl
   args:
     executable: /bin/bash
@@ -61,12 +63,20 @@
       stat:
         path: "{{ kubeconfig_file_path }}"
       delegate_to: localhost
+      register: new_config
+
+    - name: Find if an existing .kube/config file
+      stat:
+        path: "{{ ansible_user_dir }}/.kube/config"
+      delegate_to: localhost
+      register: old_config
 
     - name: Copy local runner kubeconfig file to deploy node
       copy:
         src: "{{ kubeconfig_file_path }}"
         dest: "{{ ansible_user_dir }}/.kube/config"
         mode: "0600"
+      when: new_config.stat.exists and (old_config.stat.exists == False or old_config.stat.mtime < new_config.stat.mtime)
 
 - name: Test kubectl
   command: kubectl cluster-info

--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -13,12 +13,12 @@
   tags:
     - always
 
-- name: Pre-fligt checks for the role
+- name: Pre-flight checks for the role
   assert:
     that:
       - ceph_admin_keyring_b64key is defined
       - ceph_user_keyring_b64key is defined
-      - suse_osh_deploy_vip_with_cidr is defined
+      - socok8s_deploy_vip_with_cidr is defined
   tags:
     - always
 
@@ -74,14 +74,14 @@
   blockinfile:
     path: /etc/hosts
     block: |
-      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} keystone keystone.openstack.svc.cluster.local
-      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} glance glance.openstack.svc.cluster.local
-      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} cinder cinder.openstack.svc.cluster.local
-      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} nova nova.openstack.svc.cluster.local
-      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} neutron neutron.openstack.svc.cluster.local
-      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} neutron-server neutron-server.openstack.svc.cluster.local
-      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} horizon horizon.openstack.svc.cluster.local
-      {{ suse_osh_deploy_vip_with_cidr | ipaddr('address') }} heat heat.openstack.svc.cluster.local
+      {{ socok8s_deploy_vip_with_cidr | ipaddr('address') }} keystone keystone.openstack.svc.cluster.local
+      {{ socok8s_deploy_vip_with_cidr | ipaddr('address') }} glance glance.openstack.svc.cluster.local
+      {{ socok8s_deploy_vip_with_cidr | ipaddr('address') }} cinder cinder.openstack.svc.cluster.local
+      {{ socok8s_deploy_vip_with_cidr | ipaddr('address') }} nova nova.openstack.svc.cluster.local
+      {{ socok8s_deploy_vip_with_cidr | ipaddr('address') }} neutron neutron.openstack.svc.cluster.local
+      {{ socok8s_deploy_vip_with_cidr | ipaddr('address') }} neutron-server neutron-server.openstack.svc.cluster.local
+      {{ socok8s_deploy_vip_with_cidr | ipaddr('address') }} horizon horizon.openstack.svc.cluster.local
+      {{ socok8s_deploy_vip_with_cidr | ipaddr('address') }} heat heat.openstack.svc.cluster.local
 
 # Developers have patched code, and don't need fetching product sources
 - name: Fetch OSH code

--- a/playbooks/roles/deploy-osh/templates/ingress-kube-system.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/ingress-kube-system.yaml.j2
@@ -13,6 +13,6 @@ network:
     # possible options: routed, keepalived
     mode: routed
     interface: ingress-vip
-    addr: {{ suse_osh_deploy_vip_with_cidr }}
+    addr: {{ socok8s_deploy_vip_with_cidr }}
     external_policy_local: true
 {{ lookup('template','files/common-images-overrides.yml') | from_yaml | to_nice_yaml(indent=2) }}

--- a/playbooks/roles/dev-patcher/tasks/main.yml
+++ b/playbooks/roles/dev-patcher/tasks/main.yml
@@ -29,6 +29,17 @@
 
 - name: Get patch details
   include_tasks: patch-repos.yml
-  loop: "{{ dev_patcher_patches }}"
+  loop: "{{ dev_patcher_patches | default([], True) }}"
   loop_control:
     loop_var: patchnumber
+
+- name: Check if there is local code change to cloned repos on deployer
+  stat:
+    path: "{{ role_path }}/files/repos/"
+  register: local_change_repos
+
+- name: Copy local code changes to cloned repos on deployer
+  synchronize:
+    src: "{{ role_path }}/files/repos/"
+    dest: "{{ upstream_repos_clone_folder }}/"
+  when: local_change_repos.stat.exists

--- a/script_library/run-ansible.sh
+++ b/script_library/run-ansible.sh
@@ -6,8 +6,8 @@ function run_ansible(){
     set -x
     # ansible-runner default locations
     if [[ -z ${ANSIBLE_RUNNER_DIR+x} ]]; then
-        echo "ANSIBLE_RUNNER_DIR env var is not set, defaulting to '~/suse-osh-deploy'"
-        export ANSIBLE_RUNNER_DIR="${HOME}/suse-osh-deploy"
+        echo "ANSIBLE_RUNNER_DIR env var is not set, defaulting to '~/suse-socok8s-deploy'"
+        export ANSIBLE_RUNNER_DIR="${HOME}/suse-socok8s-deploy"
     fi
 
     extravarsfile=${ANSIBLE_RUNNER_DIR}/env/extravars

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -1,10 +1,19 @@
 ---
-upstream_repos_clone_folder: /opt
-developer_mode: "{{ (lookup('env','OSH_DEVELOPER_MODE') | default('False', true) ) | bool }}"
-socok8s_workspace: "{{ lookup('env','ANSIBLE_RUNNER_DIR') | default('~/suse-osh-deploy', true) }}"
+upstream_repos_clone_folder: "/opt"
+suse_osh_registry_location: "{{ lookup('env','OPENSTACK_HELM_IMAGE_REGISTRY_LOCATION') | default('docker.io', true) }}"
+suse_osh_image_version: "{{ lookup('env','OPENSTACK_HELM_IMAGE_VERSION') | default('pike', true) }}"
+suse_libvirt_image_version: "{{ lookup('env','OPENSTACK_HELM_LIBVIRT_IMAGE_VERSION') | default('ubuntu-xenial-1.3.1-1ubuntu10.24', true) }}"
+suse_ovs_image_version: "{{ lookup('env','OPENSTACK_HELM_OPENVSWITCH_IMAGE_VERSION') | default('v2.8.1', true) }}"
+
+developer_mode: "{{ (lookup('env','SOCOK8S_DEVELOPER_MODE') | default('False', true) ) | bool }}"
+
+socok8s_workspace: "{{ lookup('env','ANSIBLE_RUNNER_DIR') | default('~/suse-socok8s-deploy', true) }}"
 socok8s_extravars: "{{ socok8s_workspace }}/env/extravars"
 socok8s_ses_pools_details: "{{ socok8s_workspace }}/ses_config.yml"
 socok8s_registry_cert: "{{ socok8s_workspace }}/certs/domain.crt"
 socok8s_registry_certkey: "{{ socok8s_workspace }}/certs/domain.key"
 socok8s_caasp_environment_details: "{{ socok8s_workspace }}/environment.json"
 socok8s_libvirtuuid: "{{ socok8s_workspace }}/libvirt.uuid"
+
+socok8s_deploy_config_location: "{{ socok8s_workspace }}"
+socok8s_airship_deploy_site_name: soc-minimal

--- a/vars/manifest.yml
+++ b/vars/manifest.yml
@@ -12,3 +12,18 @@ upstream_repos:
   loci:
     src: https://github.com/openstack/loci
     version: c94e1dfc86cae044a4582f321bb1721846419a00
+  airship-armada:
+    src: https://github.com/openstack/airship-armada
+    version: master
+  airship-shipyard:
+    src: https://github.com/openstack/airship-shipyard
+    version: master
+  airship-deckhand:
+    src: https://github.com/openstack/airship-deckhand
+    version: master
+  airship-pegleg:
+    src: https://github.com/openstack/airship-pegleg
+    version: master
+  airship-treasuremap:
+    src: https://github.com/openstack/airship-treasuremap
+    version: master


### PR DESCRIPTION
Syncing common variable change from ucp branch into master.
Now variables are named to socok8s instead of having osh_ or
airship_ namespace in prefix of their names.
Variables which are not shared between and are unique to osh
or airship deployment are left untouched.

Also getting changes from roles which are common and are changed in
ucp branch to bring attention in this review.