### PR TITLE
Fixed Ansible Lint errors (ucp branch)

### DIFF
--- a/playbooks/generic-clean_airship.yml
+++ b/playbooks/generic-clean_airship.yml
@@ -27,7 +27,7 @@
   tasks:
     - name: Clean airship related existing images on worker node
       shell: |
-        set -e
+        set -eo pipefail
         if [[ $(docker images -a | grep "airship" | wc -c) > 0 ]]; then
           docker images -a | grep "airship" | awk '{print $3}' | xargs docker rmi -f
         fi

--- a/playbooks/generic-deploy_airship.yml
+++ b/playbooks/generic-deploy_airship.yml
@@ -4,7 +4,7 @@
   any_errors_fatal: true
   roles:
     - role: airship-setup-deployer
-      when: redeploy_osh_only is not defined or redeploy_osh_only != true
+      when: redeploy_osh_only is not defined or not redeploy_osh_only
 
 - hosts: all
   gather_facts: false
@@ -17,7 +17,7 @@
   any_errors_fatal: true
   roles:
     - role: dev-patcher
-      when: redeploy_osh_only is not defined or redeploy_osh_only != true
+      when: redeploy_osh_only is not defined or not redeploy_osh_only
       become: yes
 
 - hosts: airship-workers
@@ -25,7 +25,7 @@
   any_errors_fatal: true
   roles:
     - role: airship-configure-worker
-      when: redeploy_osh_only is not defined or redeploy_osh_only != true
+      when: redeploy_osh_only is not defined or not redeploy_osh_only
 
 - hosts: airship-deployer
   gather_facts: yes
@@ -39,21 +39,21 @@
   any_errors_fatal: true
   roles:
     - role: airship-configure-caasp
-      when: redeploy_osh_only is not defined or redeploy_osh_only != true
+      when: redeploy_osh_only is not defined or not redeploy_osh_only
 
 - hosts: airship-deployer
   gather_facts: yes
   any_errors_fatal: true
   roles:
     - role: airship-configure-ceph
-      when: redeploy_osh_only is not defined or redeploy_osh_only != true
+      when: redeploy_osh_only is not defined or not redeploy_osh_only
 
 - hosts: airship-deployer
   gather_facts: yes
   any_errors_fatal: true
   roles:
     - role: airship-deploy-ucp
-      when: redeploy_osh_only is not defined or redeploy_osh_only != true
+      when: redeploy_osh_only is not defined or not redeploy_osh_only
 
 - hosts: airship-deployer
   gather_facts: yes

--- a/playbooks/roles/airship-configure-caasp/tasks/main.yml
+++ b/playbooks/roles/airship-configure-caasp/tasks/main.yml
@@ -16,8 +16,11 @@
 
 - name: create namespaces in CaaSP
   command: "kubectl apply -f /tmp/namespaces.yaml --overwrite=true"
+  register: create_namespaces_result
+  changed_when: "create_namespaces_result.stdout|search('created')"
   tags:
     - run
+    - skip_ansible_lint
 
 - name: Create privileged ClusterRoleBinding yaml
   template:
@@ -29,5 +32,8 @@
 
 - name: Create privileged ClusterRoleBinding in CaaSP
   command: "kubectl apply -f /tmp/privileged-cluster-role-binding.yml --overwrite=true"
+  register: create_privileged_cluster_role_binding_result
+  changed_when: "create_privileged_cluster_role_binding_result.stdout|search('created')"
   tags:
     - run
+    - skip_ansible_lint

--- a/playbooks/roles/airship-configure-caasp/tasks/privileged-cluster-role-binding.yml
+++ b/playbooks/roles/airship-configure-caasp/tasks/privileged-cluster-role-binding.yml
@@ -7,3 +7,7 @@
 
 - name: Apply privileged ClusterRoleBinding
   command: "kubectl apply -f /tmp/privileged-cluster-role-binding.yml --overwrite=true"
+  register: create_privileged_cluster_role_binding_result
+  changed_when: "create_privileged_cluster_role_binding_result.stdout|search('created')"
+  tags:
+    - skip_ansible_lint

--- a/playbooks/roles/airship-configure-ceph/tasks/main.yml
+++ b/playbooks/roles/airship-configure-ceph/tasks/main.yml
@@ -34,14 +34,19 @@
     dest: "/tmp/ceph-storage-classes.yaml"
     mode: "0600"
 
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: "Apply ceph {{ item }} yaml"
   command: "kubectl apply -f /tmp/ceph-{{ item }}.yaml --overwrite=true"
   with_items:
     - secrets
     - storage-classes
+  tags:
+    - skip_ansible_lint
 
-
+# TODO(aagate): Add a changed_when: to help idempotency
 # This is an arbitrary UUID value that's passed to the libvirt daemonset setup job for configuring a libvirt secret XML file
 - name: Create Libvirt ceph cinder secret uuid
-  shell: uuidgen
+  command: uuidgen
   register: libvirt_ceph_cinder_secret_uuid
+  tags:
+    - skip_ansible_lint

--- a/playbooks/roles/airship-configure-worker/tasks/main.yml
+++ b/playbooks/roles/airship-configure-worker/tasks/main.yml
@@ -48,7 +48,7 @@
 - name: Enroll node for Airship Openstack control plane primary class
   shell: |
     kubectl label nodes {{ inventory_hostname }} openstack-helm-node-class=primary
-  when: 
+  when:
     - ('airship-openstack-control-workers' in group_names)
     - hostvars[inventory_hostname].primary is defined
     - hostvars[inventory_hostname].primary == 'yes'

--- a/playbooks/roles/airship-configure-worker/tasks/subvolumes-setup.yml
+++ b/playbooks/roles/airship-configure-worker/tasks/subvolumes-setup.yml
@@ -22,12 +22,14 @@
     force: yes
 
 - name: Execute subvolume setup script
-  shell: /tmp/caasp_worker_node_set_subvolumes.sh
+  command: /tmp/caasp_worker_node_set_subvolumes.sh
   register: subvolume_cmd_out
   failed_when: subvolume_cmd_out.rc != 0
+  tags:
+    - skip_ansible_lint
 
 - name: Reboot node after successful subvolumes creation
-  reboot: 
+  reboot:
     msg: "Ansible triggered reboot after making subvolumes for Nova, Neutron and Libvirt"
     test_command: "kubectl get nodes"
   when: subvolume_cmd_out.stdout.find('reboot') >= 0

--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -17,7 +17,8 @@
     - always
     - run
 
-- set_fact:
+- name: Set site path
+  set_fact:
     site_path: "{{ upstream_repos_clone_folder }}/airship-treasuremap/site/{{ suse_airship_deploy_site_name }}"
 
 - name: Ensure site directory for {{ suse_airship_deploy_site_name }} exists
@@ -47,18 +48,24 @@
   tags:
     - install
 
-- set_fact:
+- name: Set pegleg parameters
+  set_fact:
     treasuremap_dir: '{{ upstream_repos_clone_folder }}/airship-treasuremap'
-    pegleg_image: "{{airship_pegleg_image}}"
+    pegleg_image: "{{ airship_pegleg_image }}"
     pegleg: '../airship-pegleg/tools/pegleg.sh '
     pegleg_output: 'peggles'
 
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: Pegleg lint the site manifests
-  shell: 'IMAGE={{ pegleg_image }} TERM_OPTS=" " {{ pegleg }} site -r . lint "{{ suse_airship_deploy_site_name }}" -x P001 -x P009'
+  command: '{{ pegleg }} site -r . lint "{{ suse_airship_deploy_site_name }}" -x P001 -x P009'
   args:
     chdir: '{{ treasuremap_dir }}'
+  environment:
+    IMAGE: '{{ pegleg_image }}'
+    TERM_OPTS: ' '
   tags:
     - install
+    - skip_ansible_lint
 
 - name: Create Pegleg output directory
   become: yes
@@ -68,10 +75,16 @@
   tags:
     - install
 
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: Collect site config
-  shell: 'IMAGE={{ pegleg_image }} TERM_OPTS="-l info" {{ pegleg }} site -r . collect {{ suse_airship_deploy_site_name }} -s {{ pegleg_output }}'
+  command: '{{ pegleg }} site -r . collect {{ suse_airship_deploy_site_name }} -s {{ pegleg_output }}'
   args:
     chdir: '{{ treasuremap_dir }}'
+  environment:
+    IMAGE: '{{ pegleg_image }}'
+    TERM_OPTS: '-l info'
+  tags:
+    - skip_ansible_lint
 
 - name: Copy site to Shipyard
   become: yes
@@ -81,13 +94,15 @@
   tags:
     - install
 
-- set_fact:
+- name: Set up shipyard shell script
+  set_fact:
     shipyard: './tools/shipyard.sh'
   tags:
     - install
 
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: Create config docs in Shipyard
-  shell: '{{ shipyard }} create configdocs {{ suse_airship_deploy_site_name }}-design --replace --directory=/target/{{ pegleg_output }}'
+  command: '{{ shipyard }} create configdocs {{ suse_airship_deploy_site_name }}-design --replace --directory=/target/{{ pegleg_output }}'
   args:
     chdir: '{{ upstream_repos_clone_folder }}/airship-shipyard'
   environment:
@@ -96,10 +111,11 @@
   failed_when: shipyard_create_config.stdout.find('Error') == 0
   tags:
     - install
+    - skip_ansible_lint
 
-
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: Commit config docs in Shipyard
-  shell: '{{ shipyard }} commit configdocs'
+  command: '{{ shipyard }} commit configdocs'
   args:
     chdir: '{{ upstream_repos_clone_folder }}/airship-shipyard'
   environment:
@@ -108,9 +124,11 @@
   failed_when: shipyard_commit_config.stdout.find('Error') == 0
   tags:
     - install
+    - skip_ansible_lint
 
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: Create update software action in Shipyard
-  shell: '{{ shipyard }} create action update_software --allow-intermediate-commits'
+  command: '{{ shipyard }} create action update_software --allow-intermediate-commits'
   args:
     chdir: '{{ upstream_repos_clone_folder }}/airship-shipyard'
   environment:
@@ -119,6 +137,7 @@
   failed_when: shipyard_update_software.stdout.find('Error') == 0
   tags:
     - install
+    - skip_ansible_lint
 
 - name: Print Shipyard action information
   debug:
@@ -145,8 +164,9 @@
   tags:
     - install
 
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: Wait for update software action to complete... it can take up from 30-60 minutes
-  shell: '{{ shipyard }} describe {{ shipyard_action_key }}'
+  command: '{{ shipyard }} describe {{ shipyard_action_key }}'
   args:
     chdir: '{{ upstream_repos_clone_folder }}/airship-shipyard'
   environment:
@@ -156,6 +176,8 @@
   retries: 240
   delay: 15
   ignore_errors: yes
+  tags:
+    - skip_ansible_lint
 
 - name: Print Shipyard update software action status
   debug:

--- a/playbooks/roles/airship-deploy-ucp/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/tasks/main.yml
@@ -84,9 +84,12 @@
     - install
 
 - name: Apply Armada cluster role binding
-  shell: "kubectl apply -f {{ socok8s_deploy_config_location }}/armada-cluster-role-binding.yaml"
+  command: "kubectl apply -f {{ socok8s_deploy_config_location }}/armada-cluster-role-binding.yaml"
+  register: armada_cluster_role_binding_result
+  changed_when: "armada_cluster_role_binding_result.stdout|search('created')"
   tags:
     - install
+    - skip_ansible_lint
 
 # TODO JG add override for armada image
 - name: Create Armada deployment yaml
@@ -97,19 +100,25 @@
     - install
 
 - name: Deploy Armada pod to CaaSP
-  shell: "kubectl apply -f {{ socok8s_deploy_config_location }}/armada.yaml"
+  command: "kubectl apply -f {{ socok8s_deploy_config_location }}/armada.yaml"
+  register: armada_pod_deploy_result
+  changed_when: "armada_pod_deploy_result.stdout|search('created')"
   tags:
     - install
+    - skip_ansible_lint
 
 - name: Get Armada pod name
-  shell: 'kubectl get pod -l app=armada -n {{ ucp_namespace_name }} -o jsonpath="{.items[0].metadata.name}"'
+  command: 'kubectl get pod -l app=armada -n {{ ucp_namespace_name }} -o jsonpath="{.items[0].metadata.name}"'
   register: armada_results
   until: armada_results.stdout.find('armada-') == 0
   retries: 60
   delay: 10
   ignore_errors: yes
+  tags:
+    - skip_ansible_lint
 
-- set_fact: armada_pod_name={{ armada_results.stdout }}
+- name: Set Armada pod name
+  set_fact: armada_pod_name={{ armada_results.stdout }}
 
 - debug:
     msg: "Armada pod found: {{ armada_pod_name }}"
@@ -130,8 +139,11 @@
   retries: 30
   delay: 10
   ignore_errors: yes
+  tags:
+    - skip_ansible_lint
 
-- file:
+- name: Create manifests directory
+  file:
     path: "{{ socok8s_deploy_config_location }}/manifests"
     state: directory
   tags:
@@ -144,6 +156,7 @@
   tags:
     - install
 
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: Copy Airship UCP content to Armada pod
   command: "{{ item }}"
   loop:
@@ -160,30 +173,39 @@
     - kubectl cp {{ upstream_repos_clone_folder }}/openstack-helm-infra {{ ucp_namespace_name }}/{{ armada_pod_name }}:/armada/airship-components/
   tags:
     - install
+    - skip_ansible_lint
 
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: Deploy Airship UCP ... quick coffee break, maybe?
-  shell: 'kubectl exec {{ armada_pod_name }} -n ucp -- armada apply /armada/manifests/airship.yaml'
+  command: 'kubectl exec {{ armada_pod_name }} -n ucp -- armada apply /armada/manifests/airship.yaml'
   tags:
     - install
+    - skip_ansible_lint
 
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: Wait until Armada api pod is deployed
-  shell: 'kubectl get pod -l application=armada,component=api -n {{ ucp_namespace_name }} -o jsonpath="{.items[0].metadata.name}"'
+  command: 'kubectl get pod -l application=armada,component=api -n {{ ucp_namespace_name }} -o jsonpath="{.items[0].metadata.name}"'
   register: armada_results
   until: armada_results.stdout.find('armada-api-') == 0
   retries: 180
   delay: 10
   ignore_errors: yes
+  tags:
+    - skip_ansible_lint
 
-- set_fact: armada_api_pod_name={{ armada_results.stdout }}
+- name: Set armada api pod name
+  set_fact: armada_api_pod_name={{ armada_results.stdout }}
 
 - debug:
     msg: "armada-api pod found: {{ armada_api_pod_name }}"
 
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: Wait until Airship api becomes ready
-  shell: "kubectl get pod {{ armada_api_pod_name }} -n {{ ucp_namespace_name }} -o jsonpath='{.status.containerStatuses[].ready}'"
+  command: "kubectl get pod {{ armada_api_pod_name }} -n {{ ucp_namespace_name }} -o jsonpath='{.status.containerStatuses[].ready}'"
   register: armada_api_pod_status
   until: armada_api_pod_status.stdout == "true"
   retries: 60
   delay: 10
   ignore_errors: yes
-
+  tags:
+    - skip_ansible_lint

--- a/playbooks/roles/airship-setup-deployer/tasks/kubectl-install.yml
+++ b/playbooks/roles/airship-setup-deployer/tasks/kubectl-install.yml
@@ -76,7 +76,7 @@
         src: "{{ kubeconfig_file_path }}"
         dest: "{{ ansible_user_dir }}/.kube/config"
         mode: "0600"
-      when: new_config.stat.exists and (old_config.stat.exists == False or old_config.stat.mtime < new_config.stat.mtime)
+      when: new_config.stat.exists and (not old_config.stat.exists or old_config.stat.mtime < new_config.stat.mtime)
 
 - name: Test kubectl
   command: kubectl cluster-info

--- a/playbooks/roles/deploy-osh/tasks/kubectl-install.yml
+++ b/playbooks/roles/deploy-osh/tasks/kubectl-install.yml
@@ -76,7 +76,7 @@
         src: "{{ kubeconfig_file_path }}"
         dest: "{{ ansible_user_dir }}/.kube/config"
         mode: "0600"
-      when: new_config.stat.exists and (old_config.stat.exists == False or old_config.stat.mtime < new_config.stat.mtime)
+      when: new_config.stat.exists and (not old_config.stat.exists or old_config.stat.mtime < new_config.stat.mtime)
 
 - name: Test kubectl
   command: kubectl cluster-info

--- a/playbooks/roles/registry-server-setup/tasks/apply-certs.yml
+++ b/playbooks/roles/registry-server-setup/tasks/apply-certs.yml
@@ -7,6 +7,7 @@
   become: yes
   register: _copy_ssc_result
 
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: Update CA certificates on node
   command: >
     update-ca-certificates
@@ -15,6 +16,8 @@
     - restart docker
   when:
     - _copy_ssc_result.changed
+  tags:
+    - skip_ansible_lint
 
 - name: Ensure registry server host DNS resolution is set in /etc/hosts
   become: yes

--- a/playbooks/roles/registry-server-setup/tasks/local-registry-setup.yml
+++ b/playbooks/roles/registry-server-setup/tasks/local-registry-setup.yml
@@ -18,21 +18,27 @@
     name: docker
     state: started
 
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: Check if local docker registry server is running
   become: yes
   shell: |
+    set -o pipefail
     docker ps | grep {{ local_registry_name }}
   register: registry_running_cmd_status
   failed_when: false
   tags:
     - run
+    - skip_ansible_lint
 
+# TODO(aagate): Add a changed_when: to help idempotency
 - name: Start local docker registry if not running
   become: yes
   shell: |
     docker run -d -p {{ local_registry_port }}:{{ local_registry_port }} --name {{ local_registry_name }} \
-      --restart always -v {{ suse_registry_certs_dir}}:{{ suse_registry_certs_dir}} \
-      -e REGISTRY_HTTP_TLS_CERTIFICATE={{ suse_registry_certs_dir}}/domain.crt \
+      --restart always -v {{ suse_registry_certs_dir }}:{{ suse_registry_certs_dir }} \
+      -e REGISTRY_HTTP_TLS_CERTIFICATE={{ suse_registry_certs_dir }}/domain.crt \
       -e REGISTRY_HTTP_TLS_KEY={{ suse_registry_certs_dir }}/domain.key registry:2
   when:
     - registry_running_cmd_status.rc != 0
+  tags:
+    - skip_ansible_lint


### PR DESCRIPTION
- various ansible lint errors were fixed
- added missing whitespace in variable names {{ }}
- replaced 'shell' with 'command' in cases where there
  were no shell features like pipe (|) being used.
- added 'skip_ansible_lint' tag where
  there was no alternative but use 'command' or
  'shell' to invoke say kubectl or airship scripts.
- added TODO section to add 'changed_when' to
  help with idempotency in some tasks.