### PR TITLE
Remove unnecessary 'skip_ansible_lint' tags (ucp branch)

### DIFF
--- a/playbooks/roles/airship-configure-caasp/tasks/main.yml
+++ b/playbooks/roles/airship-configure-caasp/tasks/main.yml
@@ -20,7 +20,6 @@
   changed_when: "create_namespaces_result.stdout|search('created')"
   tags:
     - run
-    - skip_ansible_lint
 
 - name: Create privileged ClusterRoleBinding yaml
   template:
@@ -36,4 +35,3 @@
   changed_when: "create_privileged_cluster_role_binding_result.stdout|search('created')"
   tags:
     - run
-    - skip_ansible_lint

--- a/playbooks/roles/airship-configure-caasp/tasks/privileged-cluster-role-binding.yml
+++ b/playbooks/roles/airship-configure-caasp/tasks/privileged-cluster-role-binding.yml
@@ -9,5 +9,3 @@
   command: "kubectl apply -f /tmp/privileged-cluster-role-binding.yml --overwrite=true"
   register: create_privileged_cluster_role_binding_result
   changed_when: "create_privileged_cluster_role_binding_result.stdout|search('created')"
-  tags:
-    - skip_ansible_lint

--- a/playbooks/roles/airship-deploy-ucp/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/tasks/main.yml
@@ -89,7 +89,6 @@
   changed_when: "armada_cluster_role_binding_result.stdout|search('created')"
   tags:
     - install
-    - skip_ansible_lint
 
 # TODO JG add override for armada image
 - name: Create Armada deployment yaml
@@ -105,7 +104,6 @@
   changed_when: "armada_pod_deploy_result.stdout|search('created')"
   tags:
     - install
-    - skip_ansible_lint
 
 - name: Get Armada pod name
   command: 'kubectl get pod -l app=armada -n {{ ucp_namespace_name }} -o jsonpath="{.items[0].metadata.name}"'


### PR DESCRIPTION
Remove unnecessary 'skip_ansible_lint' tags, when there is a valid 'changed_when' statement