### PR TITLE
Corrected key names and added loop for multiple mon_hosts

### DIFF
--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: Create a list of monitors (ip and port) if no override exists for it.
   set_fact:
-    suse_osh_deploy_ceph_mons: "[{{ ses_cluster_configuration['conf_options']['ses_mon_host'] }}:{{ ceph_mon_port | default(6789) }}]"
+    suse_osh_deploy_ceph_mons:  "[{% for ip in ses_cluster_configuration['ceph_conf']['mon_host'].split(',') %}'{{ ip }}:{{ ceph_mon_port | default(6789) }}'{% if not loop.last %},{% endif %}{% endfor %}]"
   when: suse_osh_deploy_ceph_mons is not defined
   tags:
     - always


### PR DESCRIPTION
This is a change I didn't catch in the previous PR and corrects the key names for locating the ceph mon_hosts in the ses_config.yml file, and it also adds a loop in case multiple mon_hosts are listed, as in the example file:
---
ceph_conf:
  cluster_network: 10.84.56.0/21
  fsid: d5d7c7cb-5858-3218-a36f-d028df7b0673
  mon_host: 10.84.56.8, 10.84.56.9, 10.84.56.7