### PR TITLE
Removed brackets from suse_osh_deploy_ses_mons value and .join from storageclass tempate

### DIFF
--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: Create a list of monitors (ip and port) if no override exists for it.
   set_fact:
-    suse_osh_deploy_ceph_mons:  "[{% for ip in ses_cluster_configuration['ceph_conf']['mon_host'].split(',') %}'{{ ip }}:{{ ceph_mon_port | default(6789) }}'{% if not loop.last %},{% endif %}{% endfor %}]"
+    suse_osh_deploy_ceph_mons:  "{% for ip in ses_cluster_configuration['ceph_conf']['mon_host'].split(',') %}'{{ ip }}:{{ ceph_mon_port | default(6789) }}'{% if not loop.last %},{% endif %}{% endfor %}"
   when: suse_osh_deploy_ceph_mons is not defined
   tags:
     - always

--- a/playbooks/roles/deploy-osh/templates/k8s-ses-storageclasses.yml.j2
+++ b/playbooks/roles/deploy-osh/templates/k8s-ses-storageclasses.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: general
 provisioner: kubernetes.io/rbd
 parameters:
-  monitors: {{ ','.join(suse_osh_deploy_ceph_mons) }}
+  monitors: {{ suse_osh_deploy_ceph_mons }}
   adminId: {{ suse_osh_deploy_storage.adminId }}
   adminSecretName: {{ suse_osh_deploy_storage.adminSecretName }}
   adminSecretNamespace: {{ suse_osh_deploy_storage.adminSecretNamespace }}


### PR DESCRIPTION
Since the storageclass template is expecting a string and not an array for the monitors key, I've removed the brackets from suse_osh_deploy_ses_mons. Also, since the port number and comma is being appended to each potential IP in the list during the "Create a list of monitors..." task in main.yml, I've removed the .join from the k8s-ses-storageclasses.yml.j2 template.