### PR TITLE
Fix errors when running deploy_osh role 

### DIFF
--- a/playbooks/openstack-deploy_caasp.yml
+++ b/playbooks/openstack-deploy_caasp.yml
@@ -179,7 +179,7 @@
           lineinfile:
             path: "{{ socok8s_extravars }}"
             regexp: "^socok8s_ext_vip.*"
-            line: "socok8s_ext_vip: {{ _vipip.stdout }}/24"
+            line: "socok8s_ext_vip: {{ _vipip.stdout }}"
 
         - meta: refresh_inventory
 

--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -21,7 +21,6 @@
       - ceph_admin_keyring_b64key is defined
       - ceph_user_keyring_b64key is defined
       - socok8s_ext_vip is defined
-      - socok8s_dcm_vip is defined
   tags:
     - always
 


### PR DESCRIPTION
- removed /24 when socok8s_ext_vip is set in extravars
- removed socok8s_dcm_vip from preflight check for deploy_osh role