### PR TITLE
Removing uwsgi param and changing postgres pod user back to root

### DIFF
--- a/playbooks/roles/airship-deploy-ucp/templates/airship.yaml.j2
+++ b/playbooks/roles/airship-deploy-ucp/templates/airship.yaml.j2
@@ -199,6 +199,11 @@ data:
     pod:
       replicas:
         server: 1
+      # TODO(arunkant) Temporary workaround for upstream change and failure seen on caasp node
+      # https://review.openstack.org/#/c/635070/  (More investigation needed)
+      security:
+        server:
+          runAsUser: 0
   source:
     type: local
     location: /armada/airship-components/openstack-helm-infra
@@ -291,8 +296,6 @@ data:
             nginx.ingress.kubernetes.io/proxy-body-size: '10m'
             nginx.ingress.kubernetes.io/configuration-snippet: |
               more_clear_headers "Server";
-              uwsgi_read_timeout 600;
-
     images:
       tags:
         deckhand: '{{ suse_airship_registry_location }}/airshipit/deckhand:{{ suse_airship_components_image_tag }}'
@@ -331,7 +334,6 @@ data:
             nginx.ingress.kubernetes.io/proxy-body-size: '10m'
             nginx.ingress.kubernetes.io/configuration-snippet: |
               more_clear_headers "Server";
-              uwsgi_read_timeout 600;
     images:
       tags:
         shipyard:         '{{ suse_airship_registry_location }}/airshipit/shipyard:{{ suse_airship_components_image_tag }}'

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -20,7 +20,7 @@ socok8s_deploy_config_location: "{{ socok8s_workspace }}"
 ucp_namespace_name: "{{ ucp_namespace | default('ucp') }}"
 
 # Variables used for building airship images locally
-suse_distro_identifier: opensuse
+suse_distro_identifier: opensuse_leap15
 suse_airship_components_base_image: "opensuse/leap:15.0"
 
 # check if argument is set in commandline for airship_local_images_flag value
@@ -43,7 +43,7 @@ suse_airship_registry_location: "{%- if suse_airship_build_local_images or suse_
                                  {%- endif -%}"
 
 suse_airship_components_image_tag: "{%- if suse_airship_build_local_images or suse_airship_use_local_images -%}
-                                      opensuse_15_latest
+                                      opensuse_15.0
                                     {%- else -%}
                                       latest
                                     {%- endif -%}"


### PR DESCRIPTION
uwsgi_read_timeout parameter is not recognized by nginx server running
in ucp ingress pod. So removing this config param setting which was
added earlier to resolve shipyard cli 504 timeout issue.

Updating postgres pod to run as root user instead of upstream change
of using 999 (postgres user) as we are seeing permission denied
when 999 user tries to change permission of directory
/var/lib/postgreslq/data directory.


Updated openSUSE image tag with version.