### PR TITLE
deploy_ses ci: ses_osh role fixes

### DIFF
--- a/examples/workdir/ses_config.yml
+++ b/examples/workdir/ses_config.yml
@@ -8,7 +8,7 @@ ceph_conf:
   public_network: 192.168.111.0/24
 cinder:
   key: AQCDH9tbV49jDxAAk+d2wdxsXRcSFzjf0DHWyw==
-  rbd_store_pool: cinder
+  rbd_store_pool: volumes
   rbd_store_user: cinder
 cinder-backup:
   key: AQCSH9tbx9YzNBAA65C+mwyNdmqaRwokMcHAlQ==
@@ -16,12 +16,8 @@ cinder-backup:
   rbd_store_user: cinder-backup
 glance:
   key: AQCuH9tbCNUuLBAAImRsG9tgH2ArPPlu4pt0EQ==
-  rbd_store_pool: glance
+  rbd_store_pool: images
   rbd_store_user: glance
-libvirt:
-  key: AQCDH9tbV49jDxAAk+d2wdxsXRcSFzjf0DHWyw==
-  rbd_store_pool: vms
-  rbd_store_user: cinder
 nova:
   rbd_store_pool: nova
 radosgw_urls: []

--- a/playbooks/roles/ses-osh/tasks/main.yml
+++ b/playbooks/roles/ses-osh/tasks/main.yml
@@ -9,7 +9,31 @@
     content: "{{ item.content | b64decode }}"
     mode: 0644
   with_items:
-    - "{{ hostvars['ses'].ceph_files.results }}"
+    - "{{ hostvars['ses-aio'].ceph_files.results }}"
+
+- name: Fetch client cinder key for ses-config.yml
+  delegate_to: localhost
+  slurp:
+    src: "{{ socok8s_workspace }}/ceph.client.cinder.keyring"
+  register: client_cinder_file
+
+- name: Fetch client cinder backup key for ses-config.yml
+  delegate_to: localhost
+  slurp:
+    src: "{{ socok8s_workspace }}/ceph.client.cinder_backup.keyring"
+  register: client_cinder_backup_file
+
+- name: Fetch client glance key for ses-config.yml
+  delegate_to: localhost
+  slurp:
+    src: "{{ socok8s_workspace }}/ceph.client.glance.keyring"
+  register: client_glance_file
+
+- name: Set client key facts for ses-config.yml
+  set_fact:
+    client_cinder_file_key: "{{ client_cinder_file['content'] | b64decode | regex_findall('\\bkey\\b\\s*=\\s*(.*)') | first }}"
+    client_cinder_backup_file_key: "{{ client_cinder_backup_file['content'] | b64decode | regex_findall('\\bkey\\b\\s*=\\s*(.*)') | first }}"
+    client_glance_file_key: "{{ client_glance_file['content'] | b64decode | regex_findall('\\bkey\\b\\s*=\\s*(.*)') | first }}"
 
 - name: Generate ses-config.yml
   delegate_to: localhost

--- a/playbooks/roles/ses-osh/templates/ses-config.yml.j2
+++ b/playbooks/roles/ses-osh/templates/ses-config.yml.j2
@@ -6,20 +6,23 @@ ceph_conf:
   mon_initial_members: {{ hostvars[groups['ses_nodes'][0]].conf_options.stdout_lines.1 }}
   public_network: {{ hostvars[groups['ses_nodes'][0]].conf_options.stdout_lines.3 }}
 cinder:
-  key: "{{ lookup('ini', 'key section=client.cinder file={{ socok8s_workspace }}/ceph.client.cinder.keyring') }}"
-  rbd_store_pool: cinder
+  key: {{ client_cinder_file_key }}
+  rbd_store_pool: volumes
   rbd_store_user: cinder
 cinder-backup:
-  key: "{{ lookup('ini', 'key section=client.cinder_backup file={{ socok8s_workspace 
-}}/ceph.client.cinder_backup.keyring') }}"
-  rbd_store_pool: backups
-  rbd_store_user: cinder_backup
+  key: {{ client_cinder_backup_file_key }}
+  rbd_store_pool: cinder_backup
+  rbd_store_user: cinder-backup
 nova:
   rbd_store_pool: nova
 glance:
-  key: "{{ lookup('ini', 'key section=client.glance file={{ socok8s_workspace }}/ceph.client.glance.keyring') }}"
-  rbd_store_pool: glance
+  key: {{ client_glance_file_key }}
+  rbd_store_pool: images
   rbd_store_user: glance
+libvirt:
+  key: {{ client_cinder_file_key }}
+  rbd_store_pool: vms
+  rbd_store_user: cinder
 {% if radosgw_keystone %}
 radosgw_urls: "http://{{ hostvars[groups['ses_nodes'][0]].ansible_default_ipv4.address }}:8080/swift/v1"
 {% endif %}


### PR DESCRIPTION
CI Deployment: deploy_ses: ses_osh role fixes

- changed hostvars to pull ceph_files.results from 'ses-aio'
  instead of 'ses', to prevent failure with "hostvars['ses']\" is undefined"
  error.
- changed pool names for cinder and glance, to match the pool names
  that are created by 'ses' role.
- removed lookup('ini', ..)  from ses_config.yml template, since
  keyring file is not a valid ini file.
- removed [libvirt] section from ses_config.yml in examples and
  ses_config.yml.j2 template, since it is not being used.