### PR TITLE
Add openstack-cinder chart to soc site

### DIFF
--- a/playbooks/roles/airship-deploy-osh/templates/site/soc/software/charts/osh/openstack-cinder/chart-group.yaml
+++ b/playbooks/roles/airship-deploy-osh/templates/site/soc/software/charts/osh/openstack-cinder/chart-group.yaml
@@ -1,0 +1,22 @@
+---
+schema: armada/ChartGroup/v1
+metadata:
+  schema: metadata/Document/v1
+  name: openstack-cinder-soc
+  layeringDefinition:
+    abstract: false
+    layer: site
+    parentSelector:
+      name: openstack-cinder-chart-group-global
+      component: cinder
+    actions:
+      - method: merge
+        path: .sequenced
+      - method: replace
+        path: .chart_group
+  storagePolicy: cleartext
+data:
+  sequenced: true
+  chart_group:
+    - cinder-rabbitmq-soc
+    - cinder-soc

--- a/playbooks/roles/airship-deploy-osh/templates/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
+++ b/playbooks/roles/airship-deploy-osh/templates/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
@@ -1,0 +1,52 @@
+---
+schema: armada/Chart/v1
+metadata:
+  schema: metadata/Document/v1
+  name: cinder-soc
+  layeringDefinition:
+    abstract: false
+    layer: site
+    parentSelector:
+      name: cinder-global
+      component: cinder
+    actions:
+      - method: merge
+        path: .
+      - method: replace
+        path: .values.pod
+      - method: delete
+        path: .values.ceph_client
+  storagePolicy: cleartext
+data:
+  wait:
+    timeout: 3000
+  test:
+    enabled: true
+  values:
+    bootstrap:
+      enabled: false
+    pod:
+      replicas:
+        api: 1
+        registry: 1
+    storage: rbd
+    conf:
+      ceph:
+        enabled: true
+        monitors: {{ ','.join(suse_airship_deploy_ceph_mons) }}
+        admin_keyring: {{ ceph_admin_keyring_b64key | b64decode }}
+      cinder:
+        DEFAULT:
+          debug: true
+          backup_driver: cinder.backup.drivers.ceph
+          backup_ceph_user: {{ ses_cluster_configuration['cinder-backup']['rbd_store_user'] }}
+          backup_ceph_pool: {{ ses_cluster_configuration['cinder-backup']['rbd_store_pool'] }}
+      backends:
+        rbd1:
+          volume_driver: cinder.volume.drivers.rbd.RBDDriver
+          volume_backend_name: rbd1
+          rbd_ceph_conf: "/etc/ceph/ceph.conf"
+          rbd_user: {{ ses_cluster_configuration['cinder']['rbd_store_user'] }}
+          rbd_pool: {{ ses_cluster_configuration['cinder']['rbd_store_pool'] }}
+          rbd_secret_uuid: 76f12f7a-16a6-11e9-864e-52540033f343
+...

--- a/playbooks/roles/airship-deploy-osh/templates/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
+++ b/playbooks/roles/airship-deploy-osh/templates/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
@@ -48,5 +48,5 @@ data:
           rbd_ceph_conf: "/etc/ceph/ceph.conf"
           rbd_user: {{ ses_cluster_configuration['cinder']['rbd_store_user'] }}
           rbd_pool: {{ ses_cluster_configuration['cinder']['rbd_store_pool'] }}
-          rbd_secret_uuid: 76f12f7a-16a6-11e9-864e-52540033f343
+          rbd_secret_uuid: {{ libvirt_ceph_cinder_secret_uuid }}
 ...

--- a/playbooks/roles/airship-deploy-osh/templates/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
+++ b/playbooks/roles/airship-deploy-osh/templates/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
@@ -1,0 +1,28 @@
+---
+schema: armada/Chart/v1
+metadata:
+  schema: metadata/Document/v1
+  name: cinder-rabbitmq-soc
+  layeringDefinition:
+    abstract: false
+    layer: site
+    parentSelector:
+      name: cinder-rabbitmq-global
+      component: cinder
+    actions:
+      - method: delete
+        path: .values.labels.prometheus_rabbitmq_exporter
+      - method: merge
+        path: .
+  storagePolicy: cleartext
+data:
+  test:
+    enabled: false
+  values:
+    pod:
+      replicas:
+        server: 1
+    monitoring:
+      prometheus:
+        enabled: false
+...

--- a/playbooks/roles/airship-deploy-osh/templates/site/soc/software/manifests/full-site.yaml
+++ b/playbooks/roles/airship-deploy-osh/templates/site/soc/software/manifests/full-site.yaml
@@ -22,6 +22,7 @@ data:
     - openstack-keystone-soc
     - openstack-ceph-config-soc
     - openstack-glance-soc
+    - openstack-cinder-soc
     - openstack-compute-kit-soc
     - openstack-heat-soc
     - openstack-horizon-soc


### PR DESCRIPTION
This change adds an Armada chart for openstack-cinder to the 'soc' site design so that cinder will be deployed along with the rest of the openstack services in the airship-deploy-osh role. Creating this chart at the 'site' layer allows us to pass in the value overrides required to use an external SES cluster for storage. The principle is essentially the same as when passing in the individual value override yaml files (templates from deploy-osh role), but in Airship, those overrides are included under the 'values' key in the Armada chart directly.