### PR TITLE
Generate libvirt UUID as a separate task, and replace all static UUIDs

### DIFF
--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -17,6 +17,18 @@
     - always
     - run
 
+# This is an arbitrary UUID value that's passed to the libvirt daemonset setup job for configuring a libvirt secret XML file
+- name: Create Libvirt ceph cinder secret uuid
+  shell: "uuidgen > {{ socok8s_libvirtuuid }}"
+  args:
+    creates: "{{ socok8s_libvirtuuid }}"
+  delegate_to: localhost
+
+- name: Get libvirt secret
+  set_fact:
+    libvirt_ceph_cinder_secret_uuid: "{{ lookup('file', socok8s_libvirtuuid) }}"
+  run_once: True
+
 - name: Set site path
   set_fact:
     site_path: "{{ upstream_repos_clone_folder }}/airship-treasuremap/site/{{ socok8s_site_name }}"

--- a/playbooks/roles/airship-deploy-osh/templates/site/soc/software/charts/osh/openstack-compute-kit/libvirt.yaml
+++ b/playbooks/roles/airship-deploy-osh/templates/site/soc/software/charts/osh/openstack-compute-kit/libvirt.yaml
@@ -28,5 +28,5 @@ data:
         cinder:
           user: {{ ses_cluster_configuration.cinder.rbd_store_user }}
           keyring: {{ ses_cluster_configuration.cinder.key }}
-          secret_uuid: 76f12f7a-16a6-11e9-864e-52540033f343
+          secret_uuid: {{ libvirt_ceph_cinder_secret_uuid }}
 ...

--- a/playbooks/roles/airship-deploy-osh/templates/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
+++ b/playbooks/roles/airship-deploy-osh/templates/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
@@ -80,7 +80,7 @@ data:
         cinder:
           user: {{ ses_cluster_configuration.cinder.rbd_store_user }}
           keyring: {{ ses_cluster_configuration.cinder.key }}
-          secret_uuid: 76f12f7a-16a6-11e9-864e-52540033f343
+          secret_uuid: {{ libvirt_ceph_cinder_secret_uuid }}
       nova:
         libvirt:
           virt_type: qemu


### PR DESCRIPTION
This change replaces all static UUIDs in the OSH value override templates with a dynamically generated UUID that is created as a separate task in the airship-deploy-osh role.