### PR TITLE
Adding latest helm client install when min version is specified

### DIFF
--- a/playbooks/roles/airship-setup-deployer/defaults/main.yml
+++ b/playbooks/roles/airship-setup-deployer/defaults/main.yml
@@ -4,6 +4,13 @@
 # Location of the kubeconfig file, fetched from velum UI.
 kubeconfig_file_path: "{{ socok8s_deploy_config_location }}/kubeconfig"
 
+# Sets latest helm client version to be installed in case when helm client and
+# server version are exact match. Provided version is checked to see if its
+# already installed or not? In case of different versions, already latest client
+# version is installed.
+# Set to empty string "" when don't need to have client version.
+helm_client_min_version: "v2.13.0"
+
 suse_airship_deploy_packages:
   - ca-certificates
   - make

--- a/playbooks/roles/airship-setup-deployer/tasks/helm-install.yml
+++ b/playbooks/roles/airship-setup-deployer/tasks/helm-install.yml
@@ -16,20 +16,44 @@
     helm_state: 'to_install'
   when:  _helmcheck.stdout == '0'
 
-- name: Helm has to be updated
+- name: Check if client latest version needs to be installed forcefully
+  shell: |
+    set -o pipefail
+    helm version --client | awk '$2 ~/{{ helm_client_min_version }}/ {print $2}' | wc -l
+  register: _helm_client_min_check
+  when:
+  - _helmcheck.stdout == '1'
+  - (helm_client_min_version | default('', True) != '')
+
+- name: Check if Helm client and server version matches
   set_fact:
     helm_state: 'ready'
-  when:  _helmcheck.stdout == '1'
+  when:
+    - _helmcheck.stdout == '1'
 
-- name: Helm has to be updated
+- name: Helm has to be updated (different client and server version)
   set_fact:
     helm_state: 'to_update'
   when:  _helmcheck.stdout == '2'
+
+- name: Helm has to be updated for forced client version
+  set_fact:
+    helm_state: 'to_update'
+  when:
+  - _helm_client_min_check is defined
+  - _helm_client_min_check.stdout == '0'
 
 - name: Fail if state is unknown
   fail:
     msg: "Unknown helm state"
   when: _helmcheck.stdout not in ['0','1','2']
+
+- name: Stop running helm serve service for update case
+  systemd:
+    state: stopped
+    name: helm-serve
+    enabled: yes
+  when: helm_state == 'to_update'
 
 # TODO(evrardjp): Move this to get_url or to a package install (to be decided)
 # error of linting: not using get_url.


### PR DESCRIPTION
Upstream airship is updated to latest client version and existing
logic does not update when client and server version matches.

Now forcing latest client install when both client and server version
are matching and min version is secified (non empty value)

Also to apply update, helm serve needs to be stopped in case of
helm client update. Gives error as it says install location file is
busy.