### PR TITLE
An extra writable subvolume is needed for libvirt pod

### DIFF
--- a/playbooks/roles/setup-caasp-workers/files/caasp_cp_node_set_subvolumes.sh
+++ b/playbooks/roles/setup-caasp-workers/files/caasp_cp_node_set_subvolumes.sh
@@ -28,6 +28,7 @@ create_subvolume(){
 create_subvolume /var/lib/nova
 create_subvolume /var/lib/neutron
 create_subvolume /var/lib/libvirt
+create_subvolume /var/lib/openstack-helm
 
 if [ -n "$mounted_snapshot" ]; then
   btrfs property set -ts /.snapshots/$mounted_snapshot/snapshot ro true


### PR DESCRIPTION
Lousily copied from commit 7d078e0b8252154c6fc766bcc6b5cfca630d4bdd

Ideally we would drop this `caasp_cp_node_set_subvolumes.sh` and use `roles/airship-configure-worker/tasks/subvolumes-setup.yml`