### PR TITLE
Add overrides for neutron

### DIFF
--- a/playbooks/roles/deploy-osh/defaults/main.yml
+++ b/playbooks/roles/deploy-osh/defaults/main.yml
@@ -96,3 +96,4 @@ suse_osh_deploy_memcached_yaml_overrides: {}
 suse_osh_deploy_nova_yaml_overrides: {}
 suse_osh_deploy_ovs_yaml_overrides: {}
 suse_osh_deploy_rabbitmq_yaml_overrides: {}
+suse_osh_deploy_neutron_yaml_overrides: {}

--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -341,6 +341,17 @@
     - libvirt
     - run
 
+# we need to deploy the extra values for neutron so on the next task they are picked up
+- name: Deploy neutron overrides
+  import_tasks: component-install.yml
+  vars:
+    _cmpnt_template: neutron.yaml
+    _cmpnt_overrides: "{{ suse_osh_deploy_neutron_yaml_overrides }}"
+    _cmpnt_runcommand: "/bin/true" # we only want to create the template, not run anything
+  tags:
+    - neutron
+    - run
+
 # TODO(evrardjp): Check if need to have our own dummy overrides
 # In that case, try to split the shell script upstream in two scripts.
 # Compute kit deploys nova and neutron but only nova needs overrides
@@ -352,6 +363,7 @@
     _cmpnt_runcommand: "./tools/deployment/multinode/140-compute-kit.sh"
   environment:
     OSH_EXTRA_HELM_ARGS_NOVA: "{{ lookup('env', 'OSH_EXTRA_HELM_ARGS_NOVA') | default('', True) }} --values /tmp/socok8s-nova.yaml"
+    OSH_EXTRA_HELM_ARGS_NEUTRON: "{{ lookup('env', 'OSH_EXTRA_HELM_ARGS_NEUTRON') | default('', True) }} --values /tmp/socok8s-neutron.yaml"
   tags:
     - nova
     - neutron

--- a/playbooks/roles/deploy-osh/templates/neutron.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/neutron.yaml.j2
@@ -1,0 +1,2 @@
+conf:
+{{ lookup('template','files/common-images-overrides.yml') | from_yaml | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
When deploying the compute kit we cannot override the images used
for neutron currently as we are not passing any values to the
compute-kit script

This adds a task that will deploy the socok8s-neutron.yaml config
into the deployer and uses as part of the environment variables
when executing the nova compute-kit deploy script