### PR TITLE
Fix VIP settings for ingress controller

### DIFF
--- a/playbooks/roles/deploy-osh/templates/ingress-kube-system.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/ingress-kube-system.yaml.j2
@@ -12,7 +12,7 @@ network:
     # what type of vip manage machanism will be used
     # possible options: routed, keepalived
     mode: routed
-    interfaces: ingress-vip
-    addrs: {{ socok8s_ext_vip }}
+    interface: ingress-vip
+    addr: {{ socok8s_ext_vip }}
     external_policy_local: true
 {{ lookup('template','files/common-images-overrides.yml') | from_yaml | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
"interfaces" and "addrs" don't seem to be valid attributes for the
ingress chart. It's "interface" and "addr".