### PR TITLE
Conditionally use addrs instead of addr


### DIFF
--- a/playbooks/roles/deploy-osh/templates/ingress-kube-system.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/ingress-kube-system.yaml.j2
@@ -12,7 +12,13 @@ network:
     # what type of vip manage machanism will be used
     # possible options: routed, keepalived
     mode: routed
+    {# Remove this condition when https://review.openstack.org/#/c/640115 merges #}
+    {% if developer_mode | bool %}
     interfaces: ingress-vip
     addrs: {{ socok8s_ext_vip }}
+    {% else %}
+    interface: ingress-vip
+    addr: {{ socok8s_ext_vip }}
+    {% endif %}
     external_policy_local: true
 {{ lookup('template','files/common-images-overrides.yml') | from_yaml | to_nice_yaml(indent=2) }}


### PR DESCRIPTION


This patch [1] is only applied when developer mode is enabled.
The patch changes the interface to use.

We therefore leverage the change only when developer mode is applied.

In the future, when the patch [1] is applied at all times, we can
remove the conditional.

[1]: https://review.openstack.org/#/c/640115

