### PR TITLE
Allow adding a list of patches for dev-patcher in extravars

### DIFF
--- a/doc/source/user/use-custom-patches.rst
+++ b/doc/source/user/use-custom-patches.rst
@@ -1,0 +1,25 @@
+===================
+Use custom patches
+===================
+
+
+If you want to apply upstream patches in your environment, set your patch numbers
+under the `dev_patcher_user_patches` key on `${WORKDIR}/env/extravars`:
+
+.. code-block:: yaml
+
+  dev_patcher_user_patches:
+    # test patch for kyestone
+    - 12345
+    # test patch for cinder
+    - 12345
+
+
+This way, the patches will only be carried in your environment.
+If you want to change the product instead (for developer mode or not),
+please propose a PR to the socok8s repo.
+
+.. note::
+
+    This list of patches provided via extravars will be appended to the default
+    patches list available on the dev-patcher role vars.

--- a/examples/workdir/env/extravars
+++ b/examples/workdir/env/extravars
@@ -19,3 +19,11 @@ redeploy_osh_only: false
 #suse_osh_registry_location: "docker.io"
 #suse_osh_image_version: "pike"
 
+# List of extra patches for the dev-patcher
+# instead of waiting for patch numbers to be added on the main repo
+# you can add patches in your extravars to be applied and they will be
+# added to the list of existing patches to apply
+# merged patches will be skipped
+# unrelated patches will fail (because not cloned)
+# conflicting patches will fail (because need resolving)
+dev_patcher_user_patches: []

--- a/playbooks/roles/dev-patcher/tasks/main.yml
+++ b/playbooks/roles/dev-patcher/tasks/main.yml
@@ -29,7 +29,7 @@
 
 - name: Get patch details
   include_tasks: patch-repos.yml
-  loop: "{{ dev_patcher_patches | default([], True) }}"
+  loop: "{{ (dev_patcher_patches) + (dev_patcher_user_patches | default([])) }}"
   loop_control:
     loop_var: patchnumber
 


### PR DESCRIPTION
currently we either use the default list of patches that comes
with socok8s or we override the list on extravars and have to add
all of those patches are they are not merged together.

This introduces a var dev_patcher_user_patches that allows you to specify
any upstream patches to add without overriding the default list so
you no longer need to keep the extravars in sync with what we have in the
playbook