### PR TITLE
Fix issues when running OSH deploy steps in parallel

### DIFF
--- a/playbooks/openstack-caasp_instance.yml
+++ b/playbooks/openstack-caasp_instance.yml
@@ -60,7 +60,7 @@
         # Do not reuse to prevent ssh issues or race conditions when running
         # multiple of those jobs at the same time.
         - name: Get a floating ip for the workers
-          loop: "{{ _workernodeswithnofloating.stdout | from_json }}"
+          loop: "{{ _workernodeswithnofloating.stdout | default('[]') | from_json }}"
           os_floating_ip:
             cloud: "{{ deploy_on_openstack_cloudname }}"
             server: "{{ item.ID }}"

--- a/playbooks/roles/deploy-osh/tasks/kubectl-install.yml
+++ b/playbooks/roles/deploy-osh/tasks/kubectl-install.yml
@@ -84,6 +84,9 @@
   command: kubectl cluster-info
   changed_when: false
   register: _kubectlclusterinfo
+  retries: 10
+  until: _kubectlclusterinfo is succeeded
+  delay: 5
 
 - name: Show kubectl cluster-info
   debug:


### PR DESCRIPTION
Running `deploy_ses`, `deploy_caasp` and `deploy_ccp_deployer` in parallel (using a jenkins job) raised the following issues:
  - deploy-osh: In some cases the cluster is not ready to reply back the cluster-info
query.
  - delete-caasp-stack: Although the `Get a floating ip for the workers` task is skipped it
requires to template the loop parameter which fails as one of the varaibles
is defined by a task that is skipped and does not have `stdout`.
  - deploy-caasp: Running deploy CaaSP in parallel with other steps fails as the extravars
file is not created yet

This PR contains fixes for those issues.