### PR TITLE
Added cinder-volume service account to PrivilegedRoleBinding template to allow required privilege escalation

### DIFF
--- a/playbooks/roles/airship-configure-caasp/templates/privileged-cluster-role-binding.yml.j2
+++ b/playbooks/roles/airship-configure-caasp/templates/privileged-cluster-role-binding.yml.j2
@@ -12,6 +12,9 @@ subjects:
   name: cinder-backup
   namespace: {{ openstack_namespace_name }}
 - kind: ServiceAccount
+  name: cinder-volume
+  namespace: {{ openstack_namespace_name }}
+- kind: ServiceAccount
   name: nova-novncproxy
   namespace: {{ openstack_namespace_name }}
 - kind: ServiceAccount


### PR DESCRIPTION
This change adds the service account 'cinder-volume' to the 'PrivilegedRoleBinding' template. The cinder-volume deployment now requires privilege escalation due to an upstream change to the cinder deployment-volume.yaml template. (https://github.com/openstack/openstack-helm/commit/f5bf6ec2deb0bf3a3803a4cb441c197fe19abe3b)