### PR TITLE
deploy airship ci: create combined inventory file

### DIFF
--- a/examples/config/inventory-airship.yml
+++ b/examples/config/inventory-airship.yml
@@ -54,7 +54,7 @@ airship-openstack-compute-workers:
     linux-di7u:
       ansible_host: 192.168.89.144
 
-airship-workers:
+caasp-workers:
   children:
     airship-ucp-workers:
     airship-openstack-control-workers:

--- a/examples/workdir/inventory/hosts.yml
+++ b/examples/workdir/inventory/hosts.yml
@@ -11,10 +11,26 @@ caasp-workers:
   vars:
     ansible_user: root
 
-osh-deployer:
+soc-deployer:
   vars:
     ansible_user: root
 
 ses_nodes:
+  vars:
+    ansible_user: root
+
+airship-openstack-compute-workers:
+  vars:
+    ansible_user: root
+
+airship-openstack-control-workers:
+  vars:
+    ansible_user: root
+
+airship-ucp-workers:
+  vars:
+    ansible_user: root
+
+airship-kube-system-workers:
   vars:
     ansible_user: root

--- a/examples/workdir/inventory/hosts_combined_example.yml
+++ b/examples/workdir/inventory/hosts_combined_example.yml
@@ -1,0 +1,76 @@
+---
+caasp-admin:
+  hosts:
+    ccpci-27-admin-ekulfxaq55em:
+      ansible_host: 10.86.3.236
+  vars:
+    ansible_user: root
+caasp-masters:
+  hosts:
+    ccpci-27-master-0:
+      ansible_host: 10.86.3.87
+  vars:
+    ansible_user: root
+caasp-workers:
+  hosts:
+    ccpci-27-worker-0:
+      ansible_host: 10.86.3.206
+    ccpci-27-worker-1:
+      ansible_host: 10.86.3.187
+    ccpci-27-worker-2:
+      ansible_host: 10.86.3.220
+  vars:
+    ansible_user: root
+soc-deployer:
+  hosts:
+    soc-aio:
+      ansible_host: 10.86.3.69
+  vars:
+    ansible_user: root
+ses_nodes:
+  hosts:
+    ses-aio:
+      ansible_host: 10.86.3.154
+  vars:
+    ansible_user: root
+
+# added for airship
+
+airship-openstack-control-workers:
+  hosts:
+    ccpci-27-worker-0:
+      ansible_host: 10.86.3.206
+      primary: yes
+    ccpci-27-worker-1:
+      ansible_host: 10.86.3.187
+  vars:
+    ansible_user: root
+
+airship-ucp-workers:
+  hosts:
+    ccpci-27-worker-0:
+      ansible_host: 10.86.3.206
+      primary: yes
+    ccpci-27-worker-1:
+      ansible_host: 10.86.3.187
+  vars:
+    ansible_user: root
+
+airship-kube-system-workers:
+  hosts:
+    ccpci-27-worker-0:
+      ansible_host: 10.86.3.206
+      primary: yes
+    ccpci-27-worker-1:
+      ansible_host: 10.86.3.187
+  vars:
+    ansible_user: root
+
+airship-openstack-compute-workers:
+  hosts:
+    ccpci-27-worker-2:
+      ansible_host: 10.86.3.220
+      primary: yes
+  vars:
+    ansible_user: root
+

--- a/playbooks/generic-build_images.yml
+++ b/playbooks/generic-build_images.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: osh-deployer[0]
+- hosts: soc-deployer[0]
   gather_facts: yes
   any_errors_fatal: true
   pre_tasks:
@@ -16,8 +16,8 @@
         - imagebuilder
         - upstream_patching
 
-    # The certificate generated before also needs to be known by the osh-deployer
-    - name: If developer mode, configure osh-deployer to include certs
+    # The certificate generated before also needs to be known by the soc-deployer
+    - name: If developer mode, configure soc-deployer to include certs
       include_role:
         name: setup-caasp-workers
         tasks_from: copy-certificates

--- a/playbooks/generic-clean_airship.yml
+++ b/playbooks/generic-clean_airship.yml
@@ -15,13 +15,13 @@
 # under the License.
 #
 
-- hosts: airship-deployer
+- hosts: soc-deployer
   gather_facts: no
   tasks:
     - name: Running cleanup script
       script: "{{ playbook_dir }}/../script_library/clean-airship.sh {{ clean_action | default('') }}"
 
-- hosts: airship-workers
+- hosts: caasp-workers
   gather_facts: no
   any_errors_fatal: true
   tasks:

--- a/playbooks/generic-clean_k8s.yml
+++ b/playbooks/generic-clean_k8s.yml
@@ -15,7 +15,7 @@
 # under the License.
 #
 
-- hosts: osh-deployer
+- hosts: soc-deployer
   gather_facts: no
   tasks:
     - name: Running cleanup script

--- a/playbooks/generic-deploy_airship.yml
+++ b/playbooks/generic-deploy_airship.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: airship-deployer
+- hosts: soc-deployer
   gather_facts: yes
   any_errors_fatal: true
   roles:
@@ -17,7 +17,7 @@
         - install
         - imagebuilder
 
-- hosts: airship-deployer
+- hosts: soc-deployer
   gather_facts: yes
   any_errors_fatal: true
   roles:
@@ -27,7 +27,7 @@
       tags:
         - upstream_patching
 
-- hosts: airship-workers
+- hosts: caasp-workers
   gather_facts: yes
   any_errors_fatal: true
   roles:
@@ -36,7 +36,7 @@
       tags:
         - install
 
-- hosts: airship-deployer
+- hosts: soc-deployer
   gather_facts: yes
   any_errors_fatal: true
   roles:
@@ -46,7 +46,7 @@
         - install
         - imagebuilder
 
-- hosts: airship-deployer
+- hosts: soc-deployer
   gather_facts: yes
   any_errors_fatal: true
   roles:
@@ -55,7 +55,7 @@
       tags:
         - install
 
-- hosts: airship-deployer
+- hosts: soc-deployer
   gather_facts: yes
   any_errors_fatal: true
   roles:
@@ -64,7 +64,7 @@
       tags:
         - install
 
-- hosts: airship-deployer
+- hosts: soc-deployer
   gather_facts: yes
   any_errors_fatal: true
   roles:
@@ -74,7 +74,7 @@
         - install
         - update_airship_ucp_site
 
-- hosts: airship-deployer
+- hosts: soc-deployer
   gather_facts: yes
   any_errors_fatal: true
   roles:

--- a/playbooks/generic-deploy_osh.yml
+++ b/playbooks/generic-deploy_osh.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: osh-deployer
+- hosts: soc-deployer
   gather_facts: yes
   any_errors_fatal: true
   roles:

--- a/playbooks/generic-patch_upstream.yml
+++ b/playbooks/generic-patch_upstream.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: osh-deployer
+- hosts: soc-deployer
   gather_facts: yes
   any_errors_fatal: true
   pre_tasks:

--- a/playbooks/openstack-caasp_instance.yml
+++ b/playbooks/openstack-caasp_instance.yml
@@ -92,6 +92,8 @@
             workerinventory: "{ {% for node in workers %}\"{{ node.Name }}\": { \"ansible_host\":\"{{ node.Networks.split(',')[-1].replace(' ','') }}\" }{% if not loop.last %},{% endif %}{% endfor %} }"
             admininventory: "{ {% for node in admins %}\"{{ node.Name }}\": { \"ansible_host\":\"{{ node.Networks.split(',')[-1].replace(' ','') }}\" }{% if not loop.last %},{% endif %}{% endfor %} }"
             masterinventory: "{ {% for node in masters %}\"{{ node.Name }}\": { \"ansible_host\":\"{{ node.Networks.split(',')[-1].replace(' ','') }}\" }{% if not loop.last %},{% endif %}{% endfor %} }"
+            controlinventory: "{ {% for node in workers %}{% if loop.index <= 2 %}\"{{ node.Name }}\": { \"ansible_host\":\"{{ node.Networks.split(',')[-1].replace(' ','') }}\"{% if loop.first %},\"primary\":\"yes\"{% endif %} }{% if not loop.last %},{% endif %}{% endif %}{% endfor %} }"
+            computeinventory: "{ {% for node in workers %}{% if loop.index == 3 %}\"{{ node.Name }}\": { \"ansible_host\":\"{{ node.Networks.split(',')[-1].replace(' ','') }}\"{% if loop.index == 3 %},\"primary\":\"yes\"{% endif %} } {% if not loop.last %},{% endif %}{% endif %}{% endfor %} }"
 
         # TODO(evrardjp): Replace with stack outputs
         - name: List IDs
@@ -174,6 +176,14 @@
                 hosts: "{{ masterinventory }}"
               caasp-workers:
                 hosts: "{{ workerinventory }}"
+              airship-openstack-control-workers:
+                hosts: "{{ controlinventory }}"
+              airship-ucp-workers:
+                hosts: "{{ controlinventory }}"
+              airship-openstack-compute-workers:
+                hosts: "{{ computeinventory }}"
+              airship-kube-system-workers:
+                hosts: "{{ controlinventory }}"
 
         - name: Add vip with cidr in extravars
           lineinfile:

--- a/playbooks/openstack-enroll_caasp_workers.yml
+++ b/playbooks/openstack-enroll_caasp_workers.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: osh-deployer
+- hosts: soc-deployer
   gather_facts: no
   tasks:
     - name: Load variables

--- a/playbooks/openstack-osh_hostconfig.yml
+++ b/playbooks/openstack-osh_hostconfig.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: osh-deployer
+- hosts: soc-deployer
   gather_facts: no
   tasks:
     - name: Ensure all the vars are loaded

--- a/playbooks/openstack-osh_instance.yml
+++ b/playbooks/openstack-osh_instance.yml
@@ -50,12 +50,12 @@
             src: "{{ socok8s_workspace }}/inventory/skeleton-inventory.yml"
             dest: "{{ socok8s_workspace }}/inventory/osh.yml"
             config_type: yaml
-            config_overrides: "{{ osh_aio_overrides }}"
+            config_overrides: "{{ soc_aio_overrides }}"
           vars:
-            osh_aio_overrides:
-              osh-deployer:
+            soc_aio_overrides:
+              soc-deployer:
                 hosts:
-                  osh-aio:
+                  soc-aio:
                     ansible_host: "{{ osh_floating_ip }}"
 
         - meta: refresh_inventory
@@ -107,9 +107,10 @@
           known_hosts:
             state: absent
             name: "{{ hostvars[item]['ansible_host'] }}"
-          loop: "{{ groups['osh-deployer'] }}"
+          loop: "{{ groups['soc-deployer'] }}"
 
         - name: Delete osh inventory
           file:
             state: absent
             path: "{{ socok8s_workspace }}/inventory/osh.yml"
+

--- a/playbooks/openstack-update_caasp.yml
+++ b/playbooks/openstack-update_caasp.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: osh-deployer
+- hosts: soc-deployer
   gather_facts: no
   tasks:
     - name: Load variables

--- a/playbooks/roles/airship-setup-deployer/defaults/main.yml
+++ b/playbooks/roles/airship-setup-deployer/defaults/main.yml
@@ -12,6 +12,9 @@ suse_airship_deploy_packages:
   - uuid-runtime
   - docker
   - curl
+  - python2-setuptools
+  - python2-pip
+  - python-devel
 
 suse_airship_deploy_python_libs:
   - "cmd2<=0.8.7"

--- a/playbooks/roles/generate-certs/tasks/generate-certs.yml
+++ b/playbooks/roles/generate-certs/tasks/generate-certs.yml
@@ -3,11 +3,11 @@
   setup:
   delegate_to: "{{ item }}"
   delegate_facts: True
-  loop: "{{ groups['osh-deployer'] }}"
+  loop: "{{ groups['soc-deployer'] }}"
 
 - name: Set build_registry
   set_fact:
-    build_registry_host: "{{ hostvars[groups['osh-deployer'][0]]['ansible_fqdn'] }}"
+    build_registry_host: "{{ hostvars[groups['soc-deployer'][0]]['ansible_fqdn'] }}"
 
 # TODO(evrardjp): Convert those to ansible modules
 - name: Generate SSL private and public key

--- a/playbooks/roles/registry-server-setup/defaults/main.yml
+++ b/playbooks/roles/registry-server-setup/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # TODO: may need better way to identify registry server.
-registry_server_hostgroup: "airship-deployer"
+registry_server_hostgroup: "soc-deployer"
 registry_server_hostvars: "{{ hostvars[groups[registry_server_hostgroup][0]] }}"
 registry_server_host_ip: "{{ registry_server_hostvars.ansible_default_ipv4.address | ipaddr('address') }}"
 

--- a/playbooks/roles/setup-caasp-workers/tasks/main.yml
+++ b/playbooks/roles/setup-caasp-workers/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Add OSH deployer in etc hosts for dns resolution
+- name: Add soc deployer in etc hosts for dns resolution
   include_tasks: osh-deployer-in-hosts.yml
 
 - name: Include common vars to know developer_mode value

--- a/playbooks/roles/setup-caasp-workers/tasks/osh-deployer-in-hosts.yml
+++ b/playbooks/roles/setup-caasp-workers/tasks/osh-deployer-in-hosts.yml
@@ -3,7 +3,7 @@
   setup:
   delegate_to: "{{ item }}"
   delegate_facts: True
-  loop: "{{ groups['osh-deployer'] }}"
+  loop: "{{ groups['soc-deployer'] }}"
 
 - name: Configure the hosts for local registry if developer mode is enabled
   lineinfile:
@@ -14,5 +14,5 @@
       {{ hostvars[oshdeploynode]['ansible_fqdn'] }}
       {{ hostvars[oshdeploynode]['ansible_hostname'] }}
   vars:
-    oshdeploynode: "{{ groups['osh-deployer'][0] }}"
+    oshdeploynode: "{{ groups['soc-deployer'][0] }}"
 

--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -53,7 +53,7 @@ deploy_on_openstack_caasp_image: "caasp-3.0.0-GM-OpenStack-qcow"
 deploy_on_openstack_caasp_workers: 3
 deploy_on_openstack_caasp_securitygroup: "{{ deploy_on_openstack_sesnode_securitygroup }}"
 deploy_on_openstack_caasp_stacknamefile: "{{ socok8s_workspace }}/stackname"
-deploy_on_openstack_oshnode_server_name: "{{ deploy_on_openstack_prefix }}-osh"
+deploy_on_openstack_oshnode_server_name: "{{ deploy_on_openstack_prefix }}-soc-deployer"
 deploy_on_openstack_oshnode_image: "openSUSE-Leap-15.0"
 deploy_on_openstack_oshnode_flavor: "m1.large"
 deploy_on_openstack_oshnode_securitygroup: "all-incoming"


### PR DESCRIPTION
deploy airship ci: create combined inventory file

- added an example hosts_combined_example.yml as a proposal to combine "deploy_osh"
  "deploy_airship" inventory files and create a
  combined inventory file that can work for both osh and airship deployment.

- updated examples/inventory/hosts.yml with hosts that are necessary
  or airship deployment.

- extend inventory hosts.yml tasks now also sets following
  host groups required for airship deployment

  'airship-openstack-control-workers' to two caasp worker nodes
  'airship-ucp-worker' to two caasp worker nodes
  'airship-openstack-compute-workers' to third worker node
  'airship-kube-system-workers' to two caasp worker nodes

- switched from 'osh-deployer' host group to 'soc-deployer' in all playbooks.

- switched from  'airship-deployer' host group to 'soc-deployer' in all playbooks.
  * since a deployer can be used for both osh and airship deployment

- switched from 'airship-workers' to 'caasp-workers' in all playbooks.
  * since they are the identical there is no need to have two different
    host groups