### PR TITLE
Set default build arguments for Loci

### DIFF
--- a/playbooks/roles/suse-build-images/tasks/build-with-loci.yml
+++ b/playbooks/roles/suse-build-images/tasks/build-with-loci.yml
@@ -15,5 +15,6 @@
       BASE_IMAGE: leap15
       PUSH_TO_REGISTRY: YES
       BUILD_PROJECTS: "{{ ' '.join(loci_build_projects) }}"
+      default_project_extra_build_args: "--build-arg REGISTRY_PROTOCOL=https --build-arg REGISTRY_INSECURE=True --build-arg PYTHON3=yes --force-rm --pull --no-cache"
   tags:
     - skip_ansible_lint


### PR DESCRIPTION
These are set up for local insecure https registry and Python3
(needed for Rocky images)