### PR TITLE
Change the armada chart deployment order

### DIFF
--- a/site/soc/software/manifests/ucp-bootstrap.yaml
+++ b/site/soc/software/manifests/ucp-bootstrap.yaml
@@ -14,6 +14,6 @@ data:
     - ucp-core
     - ucp-keystone
     - ucp-shipyard
-    - ucp-armada
     - ucp-deckhand
+    - ucp-armada
 ...


### PR DESCRIPTION
Moved armada chart deployment to the last in UCP site since we are using
armada-api pod status as the check if UCP is fully up.