### PR TITLE
Add a override workaround to disable memcached on nova

### DIFF
--- a/playbooks/roles/deploy-osh/templates/nova.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/nova.yaml.j2
@@ -1,4 +1,9 @@
 conf:
+  nova:
+    cache:
+      # workaround for memcached not working under python3, remove once this patch is merged:
+      # https://review.openstack.org/#/c/640500/
+      enabled: false
   ceph:
     enabled: true
     admin_keyring: {{ ceph_admin_keyring_key }}


### PR DESCRIPTION
Seems like the oslo_cache lib has some problems in python3

Lets override and disable the cache until the upstream fix[0] is
accepted

[0] https://review.openstack.org/#/c/640500/