### PR TITLE
Fixes a bug in ansible template to add overrides to nova

### DIFF
--- a/playbooks/roles/deploy-osh/files/nova_extra_overrides.yaml
+++ b/playbooks/roles/deploy-osh/files/nova_extra_overrides.yaml
@@ -1,0 +1,28 @@
+# due to a bug in ansible config template[0] we cannot currently pass multiline overrides onto a merged
+# template as they will be mangled so we need to have a different file to pass to helm
+# https://bugs.launchpad.net/openstack-ansible/+bug/1819974
+conf:
+  nova_placement_apache_config: |
+    <Directory "/srv/www">
+      Options Indexes FollowSymLinks
+      AllowOverride All
+      <IfModule !mod_access_compat.c>
+        Require all granted
+      </IfModule>
+      <IfModule mod_access_compat.c>
+        Order allow,deny
+        Allow from all
+      </IfModule>
+    </Directory>
+
+    <Directory "/var/www">
+      Options Indexes FollowSymLinks
+      AllowOverride All
+      <IfModule !mod_access_compat.c>
+        Require all granted
+      </IfModule>
+      <IfModule mod_access_compat.c>
+        Order allow,deny
+        Allow from all
+      </IfModule>
+    </Directory>

--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -352,6 +352,11 @@
     - neutron
     - run
 
+- name: Copy extra nova overrides
+  copy:
+    src: nova_extra_overrides.yaml
+    dest: /tmp/nova_extra_overrides.yaml
+
 # TODO(evrardjp): Check if need to have our own dummy overrides
 # In that case, try to split the shell script upstream in two scripts.
 # Compute kit deploys nova and neutron but only nova needs overrides
@@ -362,7 +367,7 @@
     _cmpnt_overrides: "{{ suse_osh_deploy_nova_yaml_overrides }}"
     _cmpnt_runcommand: "./tools/deployment/multinode/140-compute-kit.sh"
   environment:
-    OSH_EXTRA_HELM_ARGS_NOVA: "{{ lookup('env', 'OSH_EXTRA_HELM_ARGS_NOVA') | default('', True) }} --values /tmp/socok8s-nova.yaml"
+    OSH_EXTRA_HELM_ARGS_NOVA: "{{ lookup('env', 'OSH_EXTRA_HELM_ARGS_NOVA') | default('', True) }} --values /tmp/socok8s-nova.yaml --values /tmp/nova_extra_overrides.yaml"
     OSH_EXTRA_HELM_ARGS_NEUTRON: "{{ lookup('env', 'OSH_EXTRA_HELM_ARGS_NEUTRON') | default('', True) }} --values /tmp/socok8s-neutron.yaml"
   tags:
     - nova


### PR DESCRIPTION
due to a bug in ansible config template[0] we cannot currently pass
multiline overrides onto a merged template as they will be mangled so
we need to have a different file to pass to helm

This depends on https://review.openstack.org/#/c/642067/ to work. If the
pathc is not applied it wont break anything but also dont expect the placement
api to work :D

[0] https://bugs.launchpad.net/openstack-ansible/+bug/1819974