### PR TITLE
airship ci: Add setup_airship target to main run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -72,6 +72,10 @@ case "$deployment_action" in
         build_images
         deploy_osh
         ;;
+    "setup_airship")
+        setup_caasp_workers_for_openstack
+        deploy_airship
+        ;;
     "deploy_airship")
         deploy_airship
         ;;

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -51,7 +51,7 @@ function deploy_osh(){
 }
 function deploy_airship(){
     echo "Now deploy SUSE version of Airship"
-    run_ansible -i inventory-airship.ini ${socok8s_absolute_dir}/8_deploy_airship/play.yml
+    run_ansible ${socok8s_absolute_dir}/playbooks/generic-deploy_airship.yml
 }
 function clean_airship_not_images(){
     echo "DANGER ZONE. Set the env var 'DELETE_ANYWAY' to 'YES' to delete airship related everything (excluding local images) in your userspace."


### PR DESCRIPTION
* Add 'setup_airship' target in run.sh to enable
  airship ci.

* Updated 'deploy_airship' in deployment_actions_openstack.sh
  to call generic_deploy_playbook playbook instead of
  non-existent playbook.