### PR TITLE
Add a new deploy_network step to run.sh

### DIFF
--- a/doc/source/deploy-guide/prepare-localhost.rst
+++ b/doc/source/deploy-guide/prepare-localhost.rst
@@ -241,30 +241,12 @@ Set this for **all** the following scripts in a deployment:
 
 .. code-block:: console
 
+   export SOCOK8S_ENVNAME='foctodoodle'
+   # 'engcloud' is the name in the `clouds.yaml`
    export OS_CLOUD=engcloud
-   # 'engcloud' is the name in the `clouds.yaml`,
    # Set the name of the keypair you created
    export KEYNAME=foctodoodle-key
-   # Set the name of the network you will use in the deployment
-   export INTERNAL_NETWORK=foctodoodle-net
-   # Set the name of the subnet you will use in the deployment
-   export INTERNAL_SUBNET=foctodoodle-subnet
-   # Set the name of the floating ip network you will use in the deployment
    export EXTERNAL_NETWORK=floating
-
-If you haven't created the internal networks/subnets and appropriate routers
-already, do it now (you only have to do it once):
-
-.. code-block:: console
-
-   openstack network create ${INTERNAL_NETWORK}
-   openstack subnet create --network ${INTERNAL_NETWORK} --subnet-range 192.168.100.0/24 ${INTERNAL_SUBNET}
-   openstack router create ${INTERNAL_NETWORK}-router
-   openstack router set --external-gateway floating ${INTERNAL_NETWORK}-router
-   openstack router add subnet ${INTERNAL_NETWORK}-router ${INTERNAL_SUBNET}
-
-Reconfirming that you’ve done all the previous steps to set up now will
-save you some time later.
 
 With this done, proceed to next section of the documentation,
 :ref:`targethosts`.

--- a/heat-templates/openstack-network.yml
+++ b/heat-templates/openstack-network.yml
@@ -1,0 +1,58 @@
+heat_template_version: 2015-04-30
+
+description: >
+  Template to generate the socok8s network including a router
+  to access the external network
+
+parameters:
+  prefix:
+    type: string
+    label: Stack name
+    description: Prefix for the resource names
+  network_external:
+    type: string
+    label: Public network name
+    description: The name of the public network
+    default: floating
+
+resources:
+  network:
+    type: OS::Neutron::Net
+    properties:
+      name:
+        list_join: ['-', [ { get_param: prefix }, 'net']]
+
+  subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: network }
+      cidr: "192.168.100.0/24"
+      ip_version: 4
+      gateway_ip: 192.168.100.1
+      name:
+        list_join: ['-', [ { get_param: prefix }, 'subnet']]
+
+  router:
+    type: OS::Neutron::Router
+    properties:
+      name:
+        list_join: ['-', [ { get_param: prefix }, 'router']]
+      external_gateway_info:
+        network: { get_param: network_external }
+
+  router_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router_id: { get_resource: router }
+      subnet_id: { get_resource: subnet }
+
+outputs:
+  network_name:
+    description: Network name
+    value: { get_resource: network }
+  subnet_name:
+    description: Subnet name
+    value: { get_resource: subnet }
+  router_name:
+    description: Router name
+    value: { get_resource: router }

--- a/playbooks/openstack-cleanup_network.yml
+++ b/playbooks/openstack-cleanup_network.yml
@@ -1,0 +1,18 @@
+---
+- hosts: localhost
+  gather_facts: no
+  connection: local
+  post_tasks:
+    - name: Load generic vars
+      include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
+    - name: Load openstack vars
+      include_vars: "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+
+    - name: Delete openstack network
+      block:
+        - name: delete network stack
+          os_stack:
+            cloud: "{{ deploy_on_openstack_cloudname }}"
+            state: "absent"
+            name: "{{ deploy_on_openstack_network_stackname }}"
+

--- a/playbooks/openstack-deploy_network.yml
+++ b/playbooks/openstack-deploy_network.yml
@@ -1,0 +1,26 @@
+---
+- hosts: localhost
+  gather_facts: no
+  connection: local
+  post_tasks:
+    - name: Load generic vars
+      include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
+    - name: Load openstack vars
+      include_vars: "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+
+    - name: Create/Update openstack network
+      block:
+        - name: create network stack
+          register: network_stack_create_output
+          os_stack:
+            cloud: "{{ deploy_on_openstack_cloudname }}"
+            state: "present"
+            name: "{{ deploy_on_openstack_network_stackname }}"
+            template: "{{ playbook_dir }}/../heat-templates/openstack-network.yml"
+            parameters:
+              prefix: "{{ socok8s_envname }}"
+              network_external: "{{ deploy_on_openstack_external_network }}"
+
+        - name: show network stack output
+          debug:
+            var: network_stack_create_output

--- a/run.sh
+++ b/run.sh
@@ -38,6 +38,9 @@ source ${scripts_absolute_dir}/deployment-actions-${DEPLOYMENT_MECHANISM}.sh
 deployment_action=${1:-"setup_everything"}
 
 case "$deployment_action" in
+    "deploy_network")
+        deploy_network
+        ;;
     "deploy_ses")
         deploy_ses
         ;;
@@ -71,6 +74,7 @@ case "$deployment_action" in
         setup_caasp_workers_for_openstack
         ;;
     "setup_hosts")
+        deploy_network
         deploy_ses
         deploy_caasp
         deploy_ccp_deployer
@@ -94,6 +98,7 @@ case "$deployment_action" in
         deploy_airship update_airship_osh_site
         ;;
     "setup_everything")
+        deploy_network
         deploy_ses
         deploy_caasp
         deploy_ccp_deployer

--- a/script_library/deployment-actions-kvm.sh
+++ b/script_library/deployment-actions-kvm.sh
@@ -8,6 +8,9 @@ set -o errexit
 
 echo "Deploying on KVM"
 
+function deploy_network(){
+    echo "This is not supported yet on KVM"
+}
 function deploy_ses(){
     echo "This just runs ses configuration logic. Please create a SES node manually first."
     run_ansible ${socok8s_absolute_dir}/playbooks/generic-deploy_ses_aio.yml

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -10,6 +10,11 @@ echo "Deploying on OpenStack"
 
 source ${scripts_absolute_dir}/pre-flight-checks.sh check_openstack_env_vars_set
 
+function deploy_network(){
+    echo "Starting the network deployment"
+    run_ansible ${socok8s_absolute_dir}/playbooks/openstack-deploy_network.yml
+    echo "network deployment successful"
+}
 function deploy_ses(){
     source ${scripts_absolute_dir}/pre-flight-checks.sh check_openstack_environment_is_ready_for_deploy
     echo "Starting a SES deploy"
@@ -93,6 +98,8 @@ function clean_openstack(){
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-deploy_caasp.yml -e caasp_stack_delete=True || true
     echo "Delete SES node"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-ses_aio_instance.yml -e ses_node_delete=True
+    echo "Delete network stack"
+    run_ansible ${socok8s_absolute_dir}/playbooks/openstack-cleanup_network.yml
 }
 function clean_userfiles(){
     echo "DANGER ZONE. Set the env var 'DELETE_ANYWAY' to delete everything in your userspace."

--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -22,15 +22,6 @@ check_openstack_env_vars_set (){
         echo "No KEYNAME given. You must give an openstack security keypair name to add to your server. Please export KEYNAME='<name of your keypair>'." && exit 1
     fi
 
-    if [ -z ${INTERNAL_NETWORK+x} ]; then
-        echo "No INTERNAL_NETWORK given. export INTERNAL_NETWORK to match your network. It will be used as network and server names" && exit 1
-    fi
-
-    if [ -z ${INTERNAL_SUBNET+x} ];
-    then
-        echo "INTERNAL_SUBNET name not given. export INTERNAL_SUBNET=..." && exit 1
-    fi
-
     if [ -z ${EXTERNAL_NETWORK+x} ]; then
         echo "No EXTERNAL_NETWORK given. Using 'floating'."
         export EXTERNAL_NETWORK="floating"
@@ -43,8 +34,6 @@ check_openstack_environment_is_ready_for_deploy (){
     which openstack > /dev/null  || (echo "Please install openstack and heat CLI in your PATH"; exit 5)
     openstack stack delete --help > /dev/null || (echo "Please install heat client in your PATH"; exit 6)
     openstack keypair list | grep ${KEYNAME} > /dev/null || (echo "keyname not found. export KEYNAME=" && exit 2)
-    openstack network list | grep "${INTERNAL_NETWORK}" > /dev/null || (echo "network not found. Make sure a network exist matching ${INTERNAL_NETWORK}" && exit 3)
-    openstack subnet list | grep ${INTERNAL_SUBNET} > /dev/null || (echo "subnet not found" && exit 4)
 }
 
 check_ansible_requirements (){

--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -1,9 +1,11 @@
 ---
 deploy_on_openstack_cloudname: "{{ lookup('env','OS_CLOUD') | default('engcloud-cloud-ci', true) }}"
 deploy_on_openstack_external_network: "{{ lookup('env', 'EXTERNAL_NETWORK') | default('floating', true) }}"
-deploy_on_openstack_internal_network: "{{ lookup('env','INTERNAL_NETWORK') | default('ccpci-net', true) }}"
-deploy_on_openstack_internal_subnet: "{{ lookup('env', 'INTERNAL_SUBNET') | default('ccpci-subnet', true) }}"
+deploy_on_openstack_internal_network: "{{ socok8s_envname }}-net"
+deploy_on_openstack_internal_subnet: "{{ socok8s_envname }}-subnet"
 deploy_on_openstack_keypairname: "{{ lookup('env','KEYNAME') }}"
+# the heat stack name that is used for the network stack (which includes net/subnet/router)
+deploy_on_openstack_network_stackname: "{{ socok8s_envname }}-network"
 deploy_on_openstack_sesnode_image: "SLES12-SP3"
 deploy_on_openstack_sesnode_flavor: "d4.xlarge"
 deploy_on_openstack_sesnode_securitygroup: "all-incoming"


### PR DESCRIPTION
This step does deploy a network stack (only OpenStack, no KVM
currently) which can then be used for further deployments (eg SES,
CaaSP, ...).
You can use the new step with:

./run.sh deploy_network

Given that the network setup is a Heat stack, the cleanup is pretty
easy and you don't have to manually delete the network/subnet/router .
Cleanup is also integrated when calling

./run.sh teardown

The variables INTERNAL_NETWORK and INTERNAL_SUBNET are no longer
needed. Theses names are calculated from SOCOK8S_ENVNAME. If needed,
the ansible variables for theses network/subnet names can still be
overwritten.

Note: The new step (deploy_network) is enabled by default. So if you
run "./run.sh", a new network stack will be created.