### PR TITLE
rabbitmq: Don't use common-images-overrides.yml

### DIFF
--- a/playbooks/roles/deploy-osh/templates/rabbitmq.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/rabbitmq.yaml.j2
@@ -1,2 +1,1 @@
 ---
-{{ lookup('template','files/common-images-overrides.yml') | from_yaml | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
The RabbitMQ charts in openstack-helm-infra rely on a different images
than what we define in our common overrides (which seems to be mostly
targetting openstack images).
Specifically the "scripted_test" image for rabbitmq needs
"rabbitmq-management" an not  the heat image we're using in the common
overrides file.