### PR TITLE
Ensure the boostrap armada pod is on the ucp contol plane worker node.

### DIFF
--- a/playbooks/roles/airship-deploy-ucp/templates/armada.yaml.j2
+++ b/playbooks/roles/airship-deploy-ucp/templates/armada.yaml.j2
@@ -21,3 +21,5 @@ spec:
         image: '{{ suse_airship_registry_location }}/airshipit/armada:{{ suse_airship_components_image_tag }}'
         ports:
         - containerPort: 8000
+      nodeSelector:
+        ucp-control-plane: enabled


### PR DESCRIPTION
Add node selection for the bootstrap armda pod to ensure it is on the
ucp contol plane worker node.