### PR TITLE
Fix for forbidden error for mariadb service account

### DIFF
--- a/playbooks/roles/airship-configure-caasp/templates/privileged-cluster-role-binding.yml.j2
+++ b/playbooks/roles/airship-configure-caasp/templates/privileged-cluster-role-binding.yml.j2
@@ -74,5 +74,5 @@ subjects:
   name: airship-openstack-mariadb-mariadb
   namespace: {{ openstack_namespace_name }}
 - kind: ServiceAccount
-  name: airship-mariadb-mariadb
+  name: airship-ucp-mariadb-mariadb
   namespace: {{ ucp_namespace_name }}


### PR DESCRIPTION
Error:
"HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"forbidden: User \"system:serviceaccount:ucp:airship-ucp-mariadb-mariadb\" cannot get path \"/version/\"","reason":"Forbidden","details":{},"code":403} "