### PR TITLE
Allow vendor change when updating osh deployer

### DIFF
--- a/playbooks/openstack-osh_hostconfig.yml
+++ b/playbooks/openstack-osh_hostconfig.yml
@@ -14,6 +14,14 @@
         state: present
       loop: "{{ deploy_on_openstack_osh_repos_per_imagename[deploy_on_openstack_oshnode_image] }}"
 
+    - name: Add known vendors
+      blockinfile:
+        path: /etc/zypp/vendors.d/opensuse
+        block: |
+          [main]
+          vendors = suse,opensuse,obs://build.opensuse.org/Cloud:OpenStack,obs://build.opensuse.org/devel:languages:python
+        create: yes
+
     - name: Zypper dist-upgrade
       zypper:
         name: '*'


### PR DESCRIPTION
It is safe because it's us who are setting the repositories.

Current error:

```
Computing distribution upgrade...
5 Problems:
Problem: problem with installed package cloud-init-18.2-lp150.11.1.x86_64
Problem: problem with installed package cloud-init-config-suse-18.2-lp150.11.1.x86_64
Problem: problem with installed package growpart-0.30-lp150.19.1.noarch
Problem: problem with installed package python-rpm-macros-2017.12.22.d9968ab-lp150.52.1.noarch
Problem: problem with installed package python3-jmespath-0.9.3-lp150.33.1.noarch

Problem: problem with installed package cloud-init-18.2-lp150.11.1.x86_64
 Solution 1: install cloud-init-18.2-lp150.1.1.x86_64 (with vendor change)
  obs://build.opensuse.org/Cloud  -->  openSUSE
 Solution 2: keep obsolete cloud-init-18.2-lp150.11.1.x86_64
```