### PR TITLE
Horizon: add overrides + patches for suse images

### DIFF
--- a/playbooks/roles/deploy-osh/templates/horizon.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/horizon.yaml.j2
@@ -1,2 +1,31 @@
 ---
-{{ lookup('template','files/common-images-overrides.yml') | from_yaml | to_nice_yaml(indent=2) }}
+{% if developer_mode %}
+conf:
+  apache2:
+    binary: apache2ctl
+    start_parameters: -DFOREGROUND -k start
+    site_dir: /etc/apache2/vhosts.d
+    conf_dir: /etc/apache2/conf.d
+    a2enmod:
+      - rewrite
+      - version
+  horizon:
+    security: |
+      <Directory "/var/www">
+      Options Indexes FollowSymLinks
+      AllowOverride All
+      <IfModule !mod_access_compat.c>
+        Require all granted
+      </IfModule>
+      <IfModule mod_access_compat.c>
+        Order allow,deny
+        Allow from all
+      </IfModule>
+      </Directory>
+images:
+  tags:
+    db_drop: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+    db_init: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+    horizon_db_sync: "{{ suse_osh_registry_location }}/openstackhelm/horizon:{{ suse_openstack_image_version }}"
+    horizon: "{{ suse_osh_registry_location }}/openstackhelm/horizon:{{ suse_openstack_image_version }}"
+{%  endif %}

--- a/playbooks/roles/dev-patcher/defaults/main.yml
+++ b/playbooks/roles/dev-patcher/defaults/main.yml
@@ -35,3 +35,5 @@ dev_patcher_patches:
   - 645543
   # osh: Allow more generic overrides for keystone
   - 647403
+  # osh: Remove overlapping Listen directives on apache >= 2.4
+  - 645189


### PR DESCRIPTION
Adds 2 upstream patches to the dev patcher for horizon to work
plus provides the proper overrides in the horizon template for helm

Also removes an old horizon patch that is now abandoned in favor of
the new ones