### PR TITLE
images: do not override the tempest+rally images

### DIFF
--- a/playbooks/roles/deploy-osh/files/common-images-overrides.yml
+++ b/playbooks/roles/deploy-osh/files/common-images-overrides.yml
@@ -76,5 +76,3 @@ images:
     senlin_api: "{{ suse_osh_registry_location }}/openstackhelm/senlin:{{ suse_osh_image_version }}"
     senlin_db_sync: "{{ suse_osh_registry_location }}/openstackhelm/senlin:{{ suse_osh_image_version }}"
     senlin_engine: "{{ suse_osh_registry_location }}/openstackhelm/senlin:{{ suse_osh_image_version }}"
-    tempest: "{{ suse_osh_registry_location }}/kolla/ubuntu-source-tempest:{{ suse_osh_image_version }}"
-    test: "{{ suse_osh_registry_location }}/kolla/ubuntu-source-rally:{{ suse_osh_image_version }}"


### PR DESCRIPTION
We are not building nor plan to do for the moment so we should just
use the default tempest and test(xrally) images