### PR TITLE
Add UCP scale profile

### DIFF
--- a/playbooks/roles/airship-deploy-ucp/files/profiles/pod-scale-ha.yaml
+++ b/playbooks/roles/airship-deploy-ucp/files/profiles/pod-scale-ha.yaml
@@ -11,6 +11,78 @@ metadata:
     layer: site
 data:
   pods:
+    ucp:
+      armada:
+        api:
+          min: 2
+          max: 3
+      shipyard:
+        api:
+          min: 2
+          max: 3
+        airflow:
+          worker:
+            min: 2
+            max: 3
+          scheduler:
+            min: 2
+            max: 3
+      deckhand:
+        api:
+          min: 2
+          max: 3
+      #TODO setting to 3 node cluster causes airflow db init to fail.
+      postgresql:
+        server:
+           min: 1
+           max: 1
+           quorum: true
+        prometheus_postgresql_exporter:
+           min: 1
+           max: 2
+      barbican:
+        api:
+          min: 2
+          max: 3
+      ingress:
+        ingress:
+          min: 2
+          max: 3
+        error_page:
+          min: 2
+          max: 3
+      keystone:
+        api:
+          min: 2
+          max: 3
+      mariadb:
+        server:
+           min: 3
+           max: 3
+           quorum: true
+        ingress:
+           min: 2
+           max: 3
+        error_page:
+           min: 2
+           max: 3
+        prometheus_mysql_exporter:
+           min: 1
+           max: 2
+      memcached:
+        server:
+          min: 2
+          max: 3
+        prometheus_memcached_exporter:
+          min: 1
+          max: 2
+      rabbitmq:
+        server:
+          min: 3
+          max: 3
+        prometheus_rabbitmq_exporter:
+          min: 1
+          max: 2
     osh:
       barbican:
         api:
@@ -121,6 +193,6 @@ data:
         server:
           min: 3
           max: 3
-      prometheus_rabbitmq_exporter:
+        prometheus_rabbitmq_exporter:
           min: 1
           max: 2

--- a/playbooks/roles/airship-deploy-ucp/files/profiles/pod-scale-minimal.yaml
+++ b/playbooks/roles/airship-deploy-ucp/files/profiles/pod-scale-minimal.yaml
@@ -14,6 +14,83 @@ metadata:
   #        path: .
 data:
   pods:
+    ucp:
+      armada:
+        api:
+          min: 1
+          max: 1
+      shipyard:
+        api:
+          min: 1
+          max: 1
+        airflow:
+          web:
+            min: 1
+            max: 1
+          worker:
+            min: 1
+            max: 1
+          flower:
+            min: 1
+            max: 1
+          scheduler:
+            min: 1
+            max: 1
+      deckhand:
+        api:
+          min: 1
+          max: 1
+      postgresql:
+        server:
+           min: 1
+           max: 1
+           quorum: true
+        prometheus_postgresql_exporter:
+           min: 1
+           max: 1
+      barbican:
+        api:
+          min: 1
+          max: 1
+      ingress:
+        ingress:
+          min: 1
+          max: 1
+        error_page:
+          min: 1
+          max: 1
+      keystone:
+        api:
+          min: 1
+          max: 1
+      mariadb:
+        server:
+           min: 1
+           max: 1
+           quorum: true
+        ingress:
+           min: 1
+           max: 1
+        error_page:
+           min: 1
+           max: 1
+        prometheus_mysql_exporter:
+           min: 1
+           max: 1
+      memcached:
+        server:
+          min: 1
+          max: 1
+        prometheus_memcached_exporter:
+          min: 1
+          max: 1
+      rabbitmq:
+        server:
+          min: 1
+          max: 1
+        prometheus_rabbitmq_exporter:
+          min: 1
+          max: 1
     osh:
       barbican:
         api:

--- a/site/soc/software/charts/ucp/armada/armada.yaml
+++ b/site/soc/software/charts/ucp/armada/armada.yaml
@@ -12,6 +12,13 @@ metadata:
       - method: merge
         path: .
   storagePolicy: cleartext
+  substitutions:
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.ucp.armada.api.min
+      dest:
+        path: .values.pod.replicas.api
 data:
   wait:
     timeout: 1800

--- a/site/soc/software/charts/ucp/core/ingress.yaml
+++ b/site/soc/software/charts/ucp/core/ingress.yaml
@@ -14,20 +14,19 @@ metadata:
       - method: merge
         path: .
   storagePolicy: cleartext
-  #TOD(JG) tie to scal eprofile
-  # substitutions:
-  # - src:
-  #     schema: pegleg/PodScaleProfile/v1
-  #     name: pod-scale-profile
-  #     path: .pods.ucp.ingress.ingress.min
-  #   dest:
-  #     path: .values.pod.replicas.ingress
-  # - src:
-  #     schema: pegleg/PodScaleProfile/v1
-  #     name: pod-scale-profile
-  #     path: .pods.ucp.ingress.error_page.min
-  #   dest:
-  #     path: .values.pod.replicas.error_page
+  substitutions:
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.ucp.ingress.ingress.min
+      dest:
+        path: .values.pod.replicas.ingress
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.ucp.ingress.error_page.min
+      dest:
+        path: .values.pod.replicas.error_page
 data:
   values:
     pod:

--- a/site/soc/software/charts/ucp/core/mariadb.yaml
+++ b/site/soc/software/charts/ucp/core/mariadb.yaml
@@ -12,6 +12,13 @@ metadata:
       - method: merge
         path: .
   storagePolicy: cleartext
+  substitutions:
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.ucp.mariadb.server.min
+      dest:
+        path: .values.pod.replicas.server
 data:
   wait:
     timeout: 1800

--- a/site/soc/software/charts/ucp/core/postgresql.yaml
+++ b/site/soc/software/charts/ucp/core/postgresql.yaml
@@ -11,6 +11,19 @@ metadata:
     actions:
       - method: merge
         path: .
+  substitutions:
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.osh.postgresql.server.min
+      dest:
+        path: .values.pod.replicas.server
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.osh.postgresql.prometheus_postgresql_exporter.min
+      dest:
+        path: .values.pod.replicas.prometheus_postgresql_exporter
   storagePolicy: cleartext
 data:
   wait:
@@ -19,4 +32,8 @@ data:
     storage:
       pvc:
         size: 2Gi
+    pod:
+      replicas:
+        server: 1
+        prometheus_postgresql_exporter: 1
 ...

--- a/site/soc/software/charts/ucp/core/postgresql.yaml
+++ b/site/soc/software/charts/ucp/core/postgresql.yaml
@@ -15,13 +15,13 @@ metadata:
     - src:
         schema: pegleg/PodScaleProfile/v1
         name: pod-scale-profile
-        path: .pods.osh.postgresql.server.min
+        path: .pods.ucp.postgresql.server.min
       dest:
         path: .values.pod.replicas.server
     - src:
         schema: pegleg/PodScaleProfile/v1
         name: pod-scale-profile
-        path: .pods.osh.postgresql.prometheus_postgresql_exporter.min
+        path: .pods.ucp.postgresql.prometheus_postgresql_exporter.min
       dest:
         path: .values.pod.replicas.prometheus_postgresql_exporter
   storagePolicy: cleartext

--- a/site/soc/software/charts/ucp/core/rabbitmq.yaml
+++ b/site/soc/software/charts/ucp/core/rabbitmq.yaml
@@ -13,6 +13,13 @@ metadata:
         path: .test
       - method: merge
         path: .
+  substitutions:
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.ucp.rabbitmq.server.min
+      dest:
+        path: .values.pod.replicas.server
   storagePolicy: cleartext
 data:
   timeout: 1800

--- a/site/soc/software/charts/ucp/deckhand/barbican.yaml
+++ b/site/soc/software/charts/ucp/deckhand/barbican.yaml
@@ -12,14 +12,13 @@ metadata:
       - method: merge
         path: .
   storagePolicy: cleartext
-  #TODO(JG) Tie to scale profile in all ucp pods
-  # substitutions:
-  # - src:
-  #     schema: pegleg/PodScaleProfile/v1
-  #     name: pod-scale-profile
-  #     path: .pods.ucp.barbican.api.min
-  #   dest:
-  #     path: .values.pod.replicas.api
+  substitutions:
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.ucp.barbican.api.min
+      dest:
+        path: .values.pod.replicas.api
 data:
   values:
     pod:

--- a/site/soc/software/charts/ucp/deckhand/deckhand.yaml
+++ b/site/soc/software/charts/ucp/deckhand/deckhand.yaml
@@ -12,6 +12,13 @@ metadata:
       - method: merge
         path: .
   storagePolicy: cleartext
+  substitutions:
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.ucp.deckhand.api.min
+      dest:
+        path: .values.pod.replicas.api
 data:
   wait:
     timeout: 1800

--- a/site/soc/software/charts/ucp/keystone/keystone.yaml
+++ b/site/soc/software/charts/ucp/keystone/keystone.yaml
@@ -13,6 +13,13 @@ metadata:
       - method: merge
         path: .
   storagePolicy: cleartext
+  substitutions:
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.ucp.keystone.api.min
+      dest:
+        path: .values.pod.replicas.api
 data:
   wait:
     timeout: 1800

--- a/site/soc/software/charts/ucp/keystone/memcached.yaml
+++ b/site/soc/software/charts/ucp/keystone/memcached.yaml
@@ -12,6 +12,19 @@ metadata:
       - method: merge
         path: .
   storagePolicy: cleartext
+  substitutions:
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.ucp.memcached.server.min
+      dest:
+        path: .values.pod.replicas.server
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.ucp.memcached.prometheus_memcached_exporter.min
+      dest:
+        path: .values.pod.replicas.prometheus_memcached_exporter
 data:
   wait:
     timeout: 1800

--- a/site/soc/software/charts/ucp/shipyard/shipyard.yaml
+++ b/site/soc/software/charts/ucp/shipyard/shipyard.yaml
@@ -12,6 +12,25 @@ metadata:
       - method: merge
         path: .
   storagePolicy: cleartext
+  substitutions:
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.ucp.shipyard.api.min
+      dest:
+        path: .values.pod.replicas.api
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.ucp.shipyard.airflow.worker.min
+      dest:
+        path: .values.pod.replicas.airflow.worker
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .pods.ucp.shipyard.airflow.scheduler.min
+      dest:
+        path: .values.pod.replicas.airflow.scheduler
 data:
   wait:
     timeout: 1800
@@ -20,9 +39,7 @@ data:
       replicas:
         api: 1
         airflow:
-          web: 1
           worker: 1
-          flower: 1
           scheduler: 1
     conf:
       shipyard:


### PR DESCRIPTION
Added UCP charts in the pod scale profile minimal and ha, and added in the ucp charts to use the replica value defined in the scale profile. With this change, the user can control the scale factor for the UCP the same way for the openstack control plane. 