### PR TITLE
Keystone: add overrides + patch for suse images

### DIFF
--- a/playbooks/roles/deploy-osh/templates/keystone.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/keystone.yaml.j2
@@ -1,2 +1,46 @@
 ---
-{{ lookup('template','files/common-images-overrides.yml') | from_yaml | to_nice_yaml(indent=2) }}
+#TODO(itxaka): Remove the developer mode when 647403 is merged
+{% if developer_mode %}
+conf:
+  apache2:
+    binary: apache2ctl
+    start_parameters: -DFOREGROUND -k start
+    site_dir: /etc/apache2/vhosts.d
+    conf_dir: /etc/apache2/conf.d
+    a2enmod:
+      - version
+    security: |
+      <Directory "/var/www">
+      Options Indexes FollowSymLinks
+      AllowOverride All
+      <IfModule !mod_access_compat.c>
+        Require all granted
+      </IfModule>
+      <IfModule mod_access_compat.c>
+        Order allow,deny
+        Allow from all
+      </IfModule>
+      </Directory>
+pod:
+  security_context:
+    keystone:
+      pod:
+        runAsUser: 0
+      container:
+        keystone_api:
+          readOnlyRootFilesystem: false
+images:
+  tags:
+    bootstrap: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+    db_init: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+    db_drop: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+    keystone_api: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
+    keystone_bootstrap: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+    keystone_credential_rotate: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
+    keystone_credential_setup: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
+    keystone_db_sync: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
+    keystone_domain_manage: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
+    keystone_fernet_rotate: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
+    keystone_fernet_setup: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
+    ks_user: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+{%  endif %}

--- a/playbooks/roles/dev-patcher/defaults/main.yml
+++ b/playbooks/roles/dev-patcher/defaults/main.yml
@@ -19,8 +19,6 @@ dev_patcher_patches:
   - 640115
   # osh: Remove remaining test pods before new test run
   - 634936
-  # osh: Updating keystone-api to work with opensuse based image
-  - 633847
   # osh: make ceilometer-api work on suse based images
   - 641802
   # osh: Allow more generic overrides for horizon
@@ -35,3 +33,5 @@ dev_patcher_patches:
   - 644821
   # osh: Add heat dashboard if available to horizon
   - 645543
+  # osh: Allow more generic overrides for keystone
+  - 647403

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -9,6 +9,7 @@ socok8s_registry_certkey: "{{ socok8s_workspace }}/certs/domain.key"
 socok8s_caasp_environment_details: "{{ socok8s_workspace }}/environment.json"
 socok8s_libvirtuuid: "{{ socok8s_workspace }}/libvirt.uuid"
 suse_osh_registry_location: "docker.io"
+suse_openstack_image_version: "rocky-opensuse_15"
 
 ######################################################
 # Following variables are used by airship logic only


### PR DESCRIPTION
Adds upstream patch to the dev patcher for keystone to work
plus provides the proper overrides in the keystone template for helm