### PR TITLE
Command to just update airship osh site deployment only

### DIFF
--- a/playbooks/generic-deploy_airship.yml
+++ b/playbooks/generic-deploy_airship.yml
@@ -5,12 +5,17 @@
   roles:
     - role: airship-setup-deployer
       when: redeploy_osh_only is not defined or not redeploy_osh_only
+      tags:
+        - install
 
 - hosts: all
   gather_facts: false
   any_errors_fatal: true
   roles:
-    - registry-server-setup
+    - role: registry-server-setup
+      tags:
+        - install
+        - imagebuilder
 
 - hosts: airship-deployer
   gather_facts: yes
@@ -19,6 +24,8 @@
     - role: dev-patcher
       when: redeploy_osh_only is not defined or not redeploy_osh_only
       become: yes
+      tags:
+        - upstream_patching
 
 - hosts: airship-workers
   gather_facts: yes
@@ -26,6 +33,8 @@
   roles:
     - role: airship-configure-worker
       when: redeploy_osh_only is not defined or not redeploy_osh_only
+      tags:
+        - install
 
 - hosts: airship-deployer
   gather_facts: yes
@@ -33,6 +42,9 @@
   roles:
     - role: suse-build-images
       when: build_airship_images | default('False') | bool
+      tags:
+        - install
+        - imagebuilder
 
 - hosts: airship-deployer
   gather_facts: yes
@@ -40,6 +52,8 @@
   roles:
     - role: airship-configure-caasp
       when: redeploy_osh_only is not defined or not redeploy_osh_only
+      tags:
+        - install
 
 - hosts: airship-deployer
   gather_facts: yes
@@ -47,6 +61,8 @@
   roles:
     - role: airship-configure-ceph
       when: redeploy_osh_only is not defined or not redeploy_osh_only
+      tags:
+        - install
 
 - hosts: airship-deployer
   gather_facts: yes
@@ -54,9 +70,14 @@
   roles:
     - role: airship-deploy-ucp
       when: redeploy_osh_only is not defined or not redeploy_osh_only
+      tags:
+        - install
+        - update_airship_ucp_site
 
 - hosts: airship-deployer
   gather_facts: yes
   any_errors_fatal: true
   roles:
-    - airship-deploy-osh
+    - role: airship-deploy-osh
+      tags:
+        - install

--- a/playbooks/roles/airship-configure-ceph/tasks/main.yml
+++ b/playbooks/roles/airship-configure-ceph/tasks/main.yml
@@ -1,16 +1,22 @@
 ---
 - name: Load standard variables
   include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
+  tags:
+    - always
 
 - name: Create ses_cluster_configuration
   set_fact:
     ses_cluster_configuration: "{{ lookup('file', socok8s_ses_pools_details) | from_yaml }}"
+  tags:
+    - always
 
 - name: Pre-flight checks for the role
   assert:
     that:
       - ceph_admin_keyring_b64key is defined
       - ceph_user_keyring_b64key is defined
+  tags:
+    - always
 
 - name: Create a list of monitors (ip and port) if no override exists for it.
   set_fact:
@@ -25,11 +31,15 @@
   args:
     creates: "{{ socok8s_libvirtuuid }}"
   delegate_to: localhost
+  tags:
+    - always
 
 - name: Get libvirt secret
   set_fact:
     libvirt_ceph_cinder_secret_uuid: "{{ lookup('file', socok8s_libvirtuuid) }}"
   run_once: True
+  tags:
+    - always
 
 #TODO JG move to ceph provisioner chart
 - name: Create ceph secrets yaml

--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -4,10 +4,14 @@
 #TODO JG move to a common role/task
 - name: Load standard variables
   include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
+  tags:
+    - always
 
 - name: Create ses_cluster_configuration
   set_fact:
     ses_cluster_configuration: "{{ lookup('file', socok8s_ses_pools_details) | from_yaml }}"
+  tags:
+    - always
 
 - name: Create a list of monitors (ip and port) if no override exists for it.
   set_fact:
@@ -21,6 +25,8 @@
   set_fact:
     site_path: "{{ upstream_repos_clone_folder }}/airship-treasuremap/site/{{ socok8s_site_name }}"
     no_revision_error_msg: "{{ socok8s_site_name }}-design added no new revision"
+  tags:
+    - always
 
 - name: Set pegleg parameters
   set_fact:
@@ -28,6 +34,8 @@
     pegleg_image: "{{ airship_pegleg_image }}"
     pegleg: '../airship-pegleg/tools/pegleg.sh '
     pegleg_output: 'peggles'
+  tags:
+    - always
 
 # TODO(aagate): Add a changed_when: to help idempotency
 - name: Pegleg lint the site manifests
@@ -40,6 +48,7 @@
   tags:
     - install
     - skip_ansible_lint
+    - update_airship_osh_site
 
 - name: Create Pegleg output directory
   become: yes
@@ -59,6 +68,7 @@
     TERM_OPTS: '-l info'
   tags:
     - skip_ansible_lint
+    - update_airship_osh_site
 
 - name: Copy site to Shipyard
   become: yes
@@ -67,12 +77,14 @@
     dest: '{{ upstream_repos_clone_folder }}/airship-shipyard'
   tags:
     - install
+    - update_airship_osh_site
 
 - name: Set up shipyard shell script
   set_fact:
     shipyard: './tools/shipyard.sh'
   tags:
     - install
+    - always
 
 # TODO(aagate): Add a changed_when: to help idempotency
 - name: Create config docs in Shipyard
@@ -89,6 +101,7 @@
   tags:
     - install
     - skip_ansible_lint
+    - update_airship_osh_site
 
 # TODO(aagate): Add a changed_when: to help idempotency
 - name: Commit config docs in Shipyard
@@ -105,6 +118,7 @@
   tags:
     - install
     - skip_ansible_lint
+    - update_airship_osh_site
 
 # TODO(aagate): Add a changed_when: to help idempotency
 - name: Create update software action in Shipyard
@@ -119,18 +133,21 @@
   tags:
     - install
     - skip_ansible_lint
+    - update_airship_osh_site
 
 - name: Print Shipyard action information
   debug:
     msg: "{{ shipyard_update_software.stdout_lines }}"
   tags:
     - install
+    - update_airship_osh_site
 
 - name: Get action key
   set_fact:
     shipyard_action_key: '{{ shipyard_update_software.stdout_lines[1].split()[1] }}'
   tags:
     - install
+    - update_airship_osh_site
 
 - name: Write site records
   template:
@@ -138,12 +155,14 @@
     dest: '{{ socok8s_deploy_config_location }}/{{ socok8s_site_name }}-keys.yaml'
   tags:
     - install
+    - update_airship_osh_site
 
 - name: Wait 10 minutes before checking the action status
   pause:
     minutes: 10
   tags:
     - install
+    - update_airship_osh_site
 
 # TODO(aagate): Add a changed_when: to help idempotency
 - name: Wait for update software action to complete... it can take up from 30-60 minutes
@@ -160,7 +179,10 @@
   ignore_errors: yes
   tags:
     - skip_ansible_lint
+    - update_airship_osh_site
 
 - name: Print Shipyard update software action status
   debug:
     msg: "{{ shipyard_desc_action.stdout_lines }}"
+  tags:
+    - update_airship_osh_site

--- a/playbooks/roles/airship-deploy-ucp/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/tasks/main.yml
@@ -2,10 +2,14 @@
 # tasks file for suse-airship-deploy
 - name: Load standard variables
   include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
+  tags:
+    - always
 
 - name: Set site path
   set_fact:
     site_path: "{{ upstream_repos_clone_folder }}/airship-treasuremap/site/{{ socok8s_site_name }}"
+  tags:
+    - always
 
 - name: Ensure site directory for {{ socok8s_site_name }} is empty
   become: yes
@@ -49,6 +53,7 @@
     dest: '{{ site_path }}'
   tags:
     - install
+    - update_airship_osh_site
 
 - name: Create site software manifests
   become: yes
@@ -59,6 +64,7 @@
   when: item.state == 'file'
   tags:
     - install
+    - update_airship_osh_site
 
 - name: Create site secrets manifests
   become: yes
@@ -69,6 +75,7 @@
   when: item.state == 'file'
   tags:
     - install
+    - update_airship_osh_site
 
 - name: Create pod scale profile
   become: yes
@@ -211,6 +218,8 @@
     pegleg_image: "{{ airship_pegleg_image }}"
     pegleg: '../airship-pegleg/tools/pegleg.sh '
     pegleg_output: 'peggles'
+  tags:
+    - always
 
 - name: Collect ucp site manifest
   command: '{{ pegleg }} site -r . render "{{ socok8s_site_name }}" -o {{ socok8s_site_name }}-ucp.yaml'

--- a/run.sh
+++ b/run.sh
@@ -79,6 +79,9 @@ case "$deployment_action" in
     "deploy_airship")
         deploy_airship
         ;;
+    "update_airship_osh")
+        deploy_airship update_airship_osh_site
+        ;;
     "setup_everything")
         deploy_ses
         deploy_caasp

--- a/script_library/deployment-actions-kvm.sh
+++ b/script_library/deployment-actions-kvm.sh
@@ -42,7 +42,14 @@ function deploy_osh(){
 }
 function deploy_airship(){
     echo "Now deploy SUSE version of Airship"
-    run_ansible ${socok8s_absolute_dir}/playbooks/generic-deploy_airship.yml
+    tagged_info=''
+    tags='all'
+    if [[ "${1:-default}" != 'default' ]]; then
+        tagged_info=" --tags $1"
+        tags=$1
+        echo "Now deploy SUSE version of Airship for specific tags ( ${tags} )"
+    fi
+    run_ansible ${socok8s_absolute_dir}/playbooks/generic-deploy_airship.yml ${tagged_info}
 }
 function clean_k8s(){
     echo "DANGER ZONE. Set the env var 'DELETE_ANYWAY' to 'YES' to delete everything in your userspace."

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -51,13 +51,14 @@ function deploy_osh(){
 }
 function deploy_airship(){
     echo "Now deploy SUSE version of Airship"
-    run_ansible ${socok8s_absolute_dir}/playbooks/generic-deploy_airship.yml
-}
-function clean_airship_not_images(){
-    echo "DANGER ZONE. Set the env var 'DELETE_ANYWAY' to 'YES' to delete airship related everything (excluding local images) in your userspace."
-    if [[ ${DELETE_ANYWAY:-"NO"} == "YES" ]]; then
-        run_ansible ${socok8s_absolute_dir}/playbooks/generic-clean_airship.yml -e clean_action=$1
+    tagged_info=''
+    tags='all'
+    if [[ "${1:-default}" != 'default' ]]; then
+        tagged_info=" --tags $1"
+        tags=$1
+        echo "Now deploy SUSE version of Airship for specific tags ( ${tags} )"
     fi
+    run_ansible ${socok8s_absolute_dir}/playbooks/generic-deploy_airship.yml ${tagged_info}
 }
 function clean_airship(){
     clean_action=''


### PR DESCRIPTION
In an existing airship deployment, a user may only want to apply
changes in existing osh (overcloud) site e.g. changing service
configuration, scale out or scale in number of service pods.

Using tags to execute only those ansible steps which are needed for
updating an osh site in a exsiting airship deployment.
Tag used is 'update_airship_osh_site'

Removing unused clean_airship_not_images in openstack deployment
mechanism as its not used (was left in error).