### PR TITLE
Remove all references of non-workdir folders


### DIFF
--- a/doc/source/deploy-guide/prepare-localhost.rst
+++ b/doc/source/deploy-guide/prepare-localhost.rst
@@ -70,7 +70,7 @@ release that ansible is using. (e.g. on Tumbleweed, Ansible is using Python 3,
 so install the "python3-" variant of the packages)
 
 If those optional software aren't installed, they will be installed in a
-venv in `~/.socok8svenv`.
+venv in `~/suse-socok8s-deploy/.ansiblevenv`.
 
 Cloning this repository
 -----------------------
@@ -229,7 +229,7 @@ Enable mitogen
 ~~~~~~~~~~~~~~
 
 To improve deployment speed, enable mitogen strategy and connection plugin.
-First install mitogen in your venv (e.g. `~/.socok8svenv/` or your local
+First install mitogen in your venv (e.g. `~/suse-socok8s-deploy/.ansiblevenv/` or your local
 ansible environment), then enable it using environment variables.
 
 Alternatively, enable it for all your ansible calls by adding it to your
@@ -238,7 +238,7 @@ ansible configuration:
 .. code-block:: console
 
    cat < EOF >> ~/.ansible.cfg
-   strategy_plugins=/root/.socok8s/lib/python3.6/site-packages/ansible_mitogen/plugins/strategy
+   strategy_plugins=${HOME}/suse-socok8s-deploy/.ansiblevenv/lib/python3.6/site-packages/ansible_mitogen/plugins/strategy
    strategy = mitogen_linear
    EOF
 

--- a/playbooks/generic-clean_userfiles.yml
+++ b/playbooks/generic-clean_userfiles.yml
@@ -1,0 +1,34 @@
+---
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+- hosts: localhost
+  gather_facts: no
+  connection: local
+  vars_prompt:
+    - name: "delete_anyway"
+      prompt: "Delete all files in workspace?"
+      default: "no"
+  tasks:
+    - name: Load workspace var
+      include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
+      when: delete_anyway | bool
+    - name: Deleting files in workspace
+      file:
+        path: "{{ socok8s_workspace }}"
+        state: absent
+      when:
+        - "delete_anyway | bool"

--- a/script_library/bootstrap-ansible-if-necessary.sh
+++ b/script_library/bootstrap-ansible-if-necessary.sh
@@ -6,10 +6,13 @@ set -e
 # is packaged for all the distributions.
 
 function install_ansible (){
-    if [[ ! -d ~/.socok8svenv ]]; then
-        virtualenv ~/.socok8svenv
+    if [[ -z ${ANSIBLE_RUNNER_DIR:-} ]]; then
+        ANSIBLE_RUNNER_DIR=~/suse-socok8s-deploy
     fi
-    source ~/.socok8svenv/bin/activate
+    if [[ ! -d ${ANSIBLE_RUNNER_DIR}/.ansiblevenv/ ]]; then
+        virtualenv ${ANSIBLE_RUNNER_DIR}/.ansiblevenv/
+    fi
+    source ${ANSIBLE_RUNNER_DIR}/.ansiblevenv/bin/activate
     pip install --upgrade -r $(dirname "$0")/script_library/requirements.txt
-    python -m ara.setup.env > ~/.socok8svenv/ara.rc
+    python -m ara.setup.env > ${ANSIBLE_RUNNER_DIR}/.ansiblevenv/ara.rc
 }

--- a/script_library/deployment-actions-kvm.sh
+++ b/script_library/deployment-actions-kvm.sh
@@ -68,9 +68,9 @@ function clean_kvm(){
 function clean_userfiles(){
     echo "DANGER ZONE. Set the env var 'DELETE_ANYWAY' to delete everything in your userspace."
     if [[ ${DELETE_ANYWAY:-"NO"} == "YES" ]]; then
-        echo "DELETE_ANYWAY is set, deleting user files"
-        rm -rf ~/suse-socok8s-deploy/
+        extra_arg="-e delete_anyway='yes'"
     fi
+    run_ansible ${socok8s_absolute_dir}/playbooks/generic-clean_userfiles.yml ${extra_arg:-}
 }
 function teardown(){
     clean_kvm

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -91,9 +91,9 @@ function clean_openstack(){
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-ses_aio_instance.yml -e ses_node_delete=True
 }
 function clean_userfiles(){
-    echo "DANGER ZONE. Set the env var 'DELETE_ANYWAY' to 'YES' to delete everything in your userspace."
+    echo "DANGER ZONE. Set the env var 'DELETE_ANYWAY' to delete everything in your userspace."
     if [[ ${DELETE_ANYWAY:-"NO"} == "YES" ]]; then
-        echo "DELETE_ANYWAY is set, deleting user files"
-        rm -rf ~/suse-socok8s-deploy/
+        extra_arg="-e delete_anyway='yes'"
     fi
+    run_ansible ${socok8s_absolute_dir}/playbooks/generic-clean_userfiles.yml ${extra_arg:-}
 }

--- a/script_library/run-ansible.sh
+++ b/script_library/run-ansible.sh
@@ -31,7 +31,7 @@ function run_ansible(){
     fi
     if [[ ${USE_ARA:-False} == "True" ]]; then
         echo "Loading ARA"
-        source ${HOME}/.socok8svenv/ara.rc
+        source ${ANSIBLE_RUNNER_DIR}/.ansiblevenv/ara.rc
     fi
 
     pushd ${socok8s_absolute_dir}


### PR DESCRIPTION


This ensures all the files which were outside the work directory
(ANSIBLE_RUNNER_DIR) are now inside it.

This allows a self-contained build, reproducible in CI.
It also changes the user documentation acccordingly.

