### PR TITLE
Split inventory into multiple files of a single folder


### DIFF
--- a/playbooks/openstack-caasp_instance.yml
+++ b/playbooks/openstack-caasp_instance.yml
@@ -162,8 +162,8 @@
 
         - name: Extend inventory in workspace with newly created caasp nodes
           config_template:
-            src: "{{ socok8s_workspace }}/inventory/hosts.yml"
-            dest: "{{ socok8s_workspace }}/inventory/hosts.yml"
+            src: "{{ socok8s_workspace }}/inventory/skeleton-inventory.yml"
+            dest: "{{ socok8s_workspace }}/inventory/caasp.yml"
             config_type: yaml
             config_overrides: "{{ caasp_overrides }}"
           vars:
@@ -232,3 +232,4 @@
           loop:
             - "{{ socok8s_caasp_environment_details }}"
             - "{{ deploy_on_openstack_caasp_stacknamefile }}"
+            - "{{ socok8s_workspace }}/inventory/caasp.yml"

--- a/playbooks/openstack-osh_instance.yml
+++ b/playbooks/openstack-osh_instance.yml
@@ -47,8 +47,8 @@
         # exporting ANSIBLE_RUNNER_DIR
         - name: Extend inventory in workspace with newly created OSH deployer node
           config_template:
-            src: "{{ socok8s_workspace }}/inventory/hosts.yml"
-            dest: "{{ socok8s_workspace }}/inventory/hosts.yml"
+            src: "{{ socok8s_workspace }}/inventory/skeleton-inventory.yml"
+            dest: "{{ socok8s_workspace }}/inventory/osh.yml"
             config_type: yaml
             config_overrides: "{{ osh_aio_overrides }}"
           vars:
@@ -108,3 +108,8 @@
             state: absent
             name: "{{ hostvars[item]['ansible_host'] }}"
           loop: "{{ groups['osh-deployer'] }}"
+
+        - name: Delete osh inventory
+          file:
+            state: absent
+            path: "{{ socok8s_workspace }}/inventory/osh.yml"

--- a/playbooks/openstack-ses_aio_instance.yml
+++ b/playbooks/openstack-ses_aio_instance.yml
@@ -46,8 +46,8 @@
         # exporting ANSIBLE_RUNNER_DIR
         - name: Extend inventory in workspace with newly created SES node
           config_template:
-            src: "{{ socok8s_workspace }}/inventory/hosts.yml"
-            dest: "{{ socok8s_workspace }}/inventory/hosts.yml"
+            src: "{{ socok8s_workspace }}/inventory/skeleton-inventory.yml"
+            dest: "{{ socok8s_workspace }}/inventory/ses.yml"
             config_type: yaml
             config_overrides: "{{ ses_aio_overrides }}"
           vars:
@@ -108,3 +108,7 @@
             name: "{{ hostvars[item]['ansible_host'] }}"
           loop: "{{ groups['ses_nodes'] }}"
 
+        - name: Remove SES inventory hosts
+          file:
+            state: absent
+            path: "{{ socok8s_workspace }}/inventory/ses.yml"

--- a/script_library/run-ansible.sh
+++ b/script_library/run-ansible.sh
@@ -17,7 +17,7 @@ function run_ansible(){
     if [[ ! -d ${ANSIBLE_RUNNER_DIR} ]]; then
         mkdir -p ${ANSIBLE_RUNNER_DIR}/{env,inventory} || true
         echo "Adding an empty inventory by default"
-        cp ${socok8s_absolute_dir}/examples/workdir/inventory/hosts.yml ${inventorydir}
+        cp ${socok8s_absolute_dir}/examples/workdir/inventory/hosts.yml ${inventorydir}/skeleton-inventory.yml
     fi
 
     if [[ -f ${extravarsfile} ]]; then


### PR DESCRIPTION


For CI (run steps in parallel) it will be useful to split the
inventory file into multiple files, so that we don't have
race conditions during editions.

The documentation and examples is NOT updated, on purpose.
We will keep the "hosts.yml" as a example skeleton file of inventory.
It is easier to include the inventory in documentation that way,
and therefore explain to the users the expected groups.

