### PR TITLE
Fix patch order so they dont clash

### DIFF
--- a/playbooks/roles/dev-patcher/defaults/main.yml
+++ b/playbooks/roles/dev-patcher/defaults/main.yml
@@ -23,10 +23,10 @@ dev_patcher_patches:
   - 641802
   # osh: Allow more generic overrides for horizon
   - 645141
-  # osh: Allow more generic overrides for nova placement-api
-  - 642067
   # osh: Fix indent filter not properly adding a newline after toYaml
   - 642844
+  # osh: Allow more generic overrides for nova placement-api
+  - 642067
   # osh-images: Add rocky release script
   - 642415
   # osh: change the nova cache to dogpile.cache.memcached


### PR DESCRIPTION
as one patch is based of the other we need to maintain the same
ordering when applying them into the repos as to not have merge
conflicts