### PR TITLE
Implemented flag to easily disable all rally tests

### DIFF
--- a/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
@@ -21,7 +21,7 @@ data:
   wait:
     timeout: 3000
   test:
-    enabled: true
+    enabled: {{ run_rally_tests }}
   values:
     bootstrap:
       enabled: false

--- a/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
@@ -17,7 +17,7 @@ metadata:
   storagePolicy: cleartext
 data:
   test:
-    enabled: false
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/neutron-rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/neutron-rabbitmq.yaml
@@ -24,7 +24,7 @@ metadata:
         path: .values.pod.replicas.server
 data:
   test:
-    enabled: false
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/neutron.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/neutron.yaml
@@ -35,6 +35,8 @@ data:
     timeout: 1800
     labels:
       release_group: airship-neutron
+  test:
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/nova-rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova-rabbitmq.yaml
@@ -24,7 +24,7 @@ metadata:
         path: .values.pod.replicas.server
 data:
   test:
-    enabled: false
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
@@ -63,6 +63,8 @@ metadata:
       dest:
         path: .values.pod.replicas.novncproxy
 data:
+  test:
+    enabled: {{ run_rally_tests }}
   values:
     labels:
       agent:

--- a/site/soc/software/charts/osh/openstack-glance/glance.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/glance.yaml
@@ -34,7 +34,7 @@ data:
   wait:
     timeout: 3000
   test:
-    enabled: true
+    enabled: {{ run_rally_tests }}
   values:
     bootstrap:
       enabled: false

--- a/site/soc/software/charts/osh/openstack-glance/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/rabbitmq.yaml
@@ -24,7 +24,7 @@ metadata:
         path: .values.pod.replicas.server
 data:
   test:
-    enabled: false
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-heat/heat.yaml
+++ b/site/soc/software/charts/osh/openstack-heat/heat.yaml
@@ -42,7 +42,7 @@ metadata:
         path: .values.pod.replicas.engine
 data:
   test:
-    enabled: true
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-heat/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-heat/rabbitmq.yaml
@@ -24,7 +24,7 @@ metadata:
         path: .values.pod.replicas.server
 data:
   test:
-    enabled: false
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
@@ -21,6 +21,8 @@ metadata:
       dest:
         path: .values.pod.replicas.api
 data:
+  test:
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-keystone/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/rabbitmq.yaml
@@ -24,7 +24,7 @@ metadata:
         path: .values.pod.replicas.server
 data:
   test:
-    enabled: false
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/armada/armada.yaml
+++ b/site/soc/software/charts/ucp/armada/armada.yaml
@@ -22,6 +22,8 @@ metadata:
 data:
   wait:
     timeout: 1800
+  test:
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/core/rabbitmq.yaml
+++ b/site/soc/software/charts/ucp/core/rabbitmq.yaml
@@ -24,7 +24,7 @@ metadata:
 data:
   timeout: 1800
   test:
-    enabled: false
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/deckhand/barbican.yaml
+++ b/site/soc/software/charts/ucp/deckhand/barbican.yaml
@@ -20,6 +20,8 @@ metadata:
       dest:
         path: .values.pod.replicas.api
 data:
+  test:
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/deckhand/deckhand.yaml
+++ b/site/soc/software/charts/ucp/deckhand/deckhand.yaml
@@ -22,6 +22,8 @@ metadata:
 data:
   wait:
     timeout: 1800
+  test:
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/keystone/keystone.yaml
+++ b/site/soc/software/charts/ucp/keystone/keystone.yaml
@@ -23,6 +23,8 @@ metadata:
 data:
   wait:
     timeout: 1800
+  test:
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/shipyard/shipyard.yaml
+++ b/site/soc/software/charts/ucp/shipyard/shipyard.yaml
@@ -34,6 +34,8 @@ metadata:
 data:
   wait:
     timeout: 1800
+  test:
+    enabled: {{ run_rally_tests }}
   values:
     pod:
       replicas:

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -56,3 +56,6 @@ socok8s_site_name: "soc"
 ucp_keystone_admin_password: 'password123'
 openstack_keystone_admin_password: 'password123'
 ucp_shipyard_keystone_password: 'password123'
+
+# Flag to run pod rally tests (default false)
+run_rally_tests: false


### PR DESCRIPTION
This change provides an easy mechanism for enabling or disabling all pod rally tests. Default is set to 'false' to speed up deployment during development.