### PR TITLE
Add a connection timeout to the SES node reboot

### DIFF
--- a/playbooks/openstack-ses_aio_hostconfig.yml
+++ b/playbooks/openstack-ses_aio_hostconfig.yml
@@ -64,6 +64,7 @@
     - name: Reboot host
       reboot:
         reboot_timeout: 900
+        connect_timeout: 90
 
     - name: Install extra software
       zypper:


### PR DESCRIPTION
During the SES deploy, I have been seeing this reboot hang for a long
time before failing the entire playbook. Adding a short connection
timeout triggers a reconnection attempt that resolves the task timeout.