### PR TITLE
Rabbitmq Add images overrides


### DIFF
--- a/playbooks/roles/deploy-osh/templates/rabbitmq.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/rabbitmq.yaml.j2
@@ -1,1 +1,6 @@
 ---
+image:
+  tags:
+    prometheus_rabbitmq_exporter_helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+    rabbitmq_init: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+


### PR DESCRIPTION


We still don't want to fork "official images", but all the rest
should be overriden. Therefore, neither prometheus_rabbitmq_exporter
[1] nor rabbitmq itself is updated here

[1]: prometheus_rabbitmq_exporter: docker.io/kbudde/rabbitmq-exporter

