### PR TITLE
Clean up run test flag

### DIFF
--- a/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
@@ -21,7 +21,7 @@ data:
   wait:
     timeout: 3000
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     bootstrap:
       enabled: false

--- a/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
@@ -17,7 +17,7 @@ metadata:
   storagePolicy: cleartext
 data:
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/neutron-rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/neutron-rabbitmq.yaml
@@ -24,7 +24,7 @@ metadata:
         path: .values.pod.replicas.server
 data:
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/neutron.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/neutron.yaml
@@ -36,7 +36,7 @@ data:
     labels:
       release_group: airship-neutron
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/nova-rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova-rabbitmq.yaml
@@ -24,7 +24,7 @@ metadata:
         path: .values.pod.replicas.server
 data:
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
@@ -64,7 +64,7 @@ metadata:
         path: .values.pod.replicas.novncproxy
 data:
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     labels:
       agent:

--- a/site/soc/software/charts/osh/openstack-glance/glance.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/glance.yaml
@@ -34,7 +34,7 @@ data:
   wait:
     timeout: 3000
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     bootstrap:
       enabled: false

--- a/site/soc/software/charts/osh/openstack-glance/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/rabbitmq.yaml
@@ -24,7 +24,7 @@ metadata:
         path: .values.pod.replicas.server
 data:
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-heat/heat.yaml
+++ b/site/soc/software/charts/osh/openstack-heat/heat.yaml
@@ -42,7 +42,7 @@ metadata:
         path: .values.pod.replicas.engine
 data:
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-heat/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-heat/rabbitmq.yaml
@@ -24,7 +24,7 @@ metadata:
         path: .values.pod.replicas.server
 data:
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
@@ -22,7 +22,7 @@ metadata:
         path: .values.pod.replicas.api
 data:
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-keystone/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/rabbitmq.yaml
@@ -24,7 +24,7 @@ metadata:
         path: .values.pod.replicas.server
 data:
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/armada/armada.yaml
+++ b/site/soc/software/charts/ucp/armada/armada.yaml
@@ -23,7 +23,7 @@ data:
   wait:
     timeout: 1800
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/core/rabbitmq.yaml
+++ b/site/soc/software/charts/ucp/core/rabbitmq.yaml
@@ -24,7 +24,7 @@ metadata:
 data:
   timeout: 1800
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/deckhand/barbican.yaml
+++ b/site/soc/software/charts/ucp/deckhand/barbican.yaml
@@ -21,7 +21,7 @@ metadata:
         path: .values.pod.replicas.api
 data:
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/deckhand/deckhand.yaml
+++ b/site/soc/software/charts/ucp/deckhand/deckhand.yaml
@@ -23,7 +23,7 @@ data:
   wait:
     timeout: 1800
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/keystone/keystone.yaml
+++ b/site/soc/software/charts/ucp/keystone/keystone.yaml
@@ -24,7 +24,7 @@ data:
   wait:
     timeout: 1800
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/shipyard/shipyard.yaml
+++ b/site/soc/software/charts/ucp/shipyard/shipyard.yaml
@@ -35,7 +35,7 @@ data:
   wait:
     timeout: 1800
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests }}
   values:
     pod:
       replicas:

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -58,5 +58,5 @@ ucp_keystone_admin_password: 'password123'
 openstack_keystone_admin_password: 'password123'
 ucp_shipyard_keystone_password: 'password123'
 
-# Flag to run pod rally tests (default false)
-run_rally_tests: false
+# Flag to run pod tests in Aiship OSH deployment (default true)
+run_tests: true


### PR DESCRIPTION
Changed default value to true so tests will run by default for
verification and debugging purpose. Also renamed to run_tests as it
enables the test pod and all tests if configured for/by the test pod will
run which includes rally and tempest.