### PR TITLE
Changed var name to run_tests, moved location to extravars, set default value to true

### DIFF
--- a/doc/source/user/customize-testing-behavior.rst
+++ b/doc/source/user/customize-testing-behavior.rst
@@ -1,0 +1,30 @@
+=================================
+Customizing Helm Testing Behavior
+=================================
+
+By default, all tests that have been defined for each helm chart will be run
+as part of that chart's deployment operations. However, it may be desirable in
+some scenarios to prevent these tests from running. To disable helm tests, define
+the following key in `${WORKDIR}/env/extravars` and set it to `false`:
+
+.. code-block:: yaml
+
+   run_tests: false
+
+.. note::
+
+   This will disable all helm tests in all charts during a full site deployment.
+   Tests for individual helm charts can still be run by using the helm CLI and the
+   release name, such as:
+
+.. code-block:: console
+
+   helm test airship-glance
+
+Additionally, the default timeout value of 300s for test completion can be 
+customized by adding the following key in `${WORKDIR}/env/extravars` and 
+providing a value, in seconds:
+
+.. code-block:: yaml
+
+   test_timeout: 1200

--- a/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
@@ -21,7 +21,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     bootstrap:
       enabled: false

--- a/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
@@ -19,7 +19,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/neutron-rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/neutron-rabbitmq.yaml
@@ -26,7 +26,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/neutron.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/neutron.yaml
@@ -11,7 +11,7 @@ metadata:
       component: neutron
     actions:
       - method: merge
-        path: .values.pod
+        path: .
       - method: replace
         path: .values.labels.agent.l3
       - method: replace
@@ -36,7 +36,8 @@ data:
     labels:
       release_group: airship-neutron
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/nova-rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova-rabbitmq.yaml
@@ -26,7 +26,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
@@ -15,7 +15,7 @@ metadata:
       - method: delete
         path: .values.ceph_client
       - method: merge
-        path: .values.conf
+        path: .
       - method: replace
         path: .values.pod
   storagePolicy: cleartext
@@ -66,7 +66,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     labels:
       agent:

--- a/site/soc/software/charts/osh/openstack-glance/glance.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/glance.yaml
@@ -34,7 +34,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     bootstrap:
       enabled: false

--- a/site/soc/software/charts/osh/openstack-glance/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/rabbitmq.yaml
@@ -26,7 +26,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-heat/heat.yaml
+++ b/site/soc/software/charts/osh/openstack-heat/heat.yaml
@@ -42,7 +42,8 @@ metadata:
         path: .values.pod.replicas.engine
 data:
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-heat/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-heat/rabbitmq.yaml
@@ -24,7 +24,8 @@ metadata:
         path: .values.pod.replicas.server
 data:
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
@@ -24,7 +24,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-keystone/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/rabbitmq.yaml
@@ -26,7 +26,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-mariadb/mariadb.yaml
+++ b/site/soc/software/charts/osh/openstack-mariadb/mariadb.yaml
@@ -11,7 +11,7 @@ metadata:
       component: mariadb
     actions:
       - method: merge
-        path: .values.pod
+        path: .
       - method: delete
         path: .values.labels.prometheus_mysql_exporter
   storagePolicy: cleartext
@@ -25,6 +25,9 @@ metadata:
 data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
+  test:
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/armada/armada.yaml
+++ b/site/soc/software/charts/ucp/armada/armada.yaml
@@ -23,7 +23,8 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/core/rabbitmq.yaml
+++ b/site/soc/software/charts/ucp/core/rabbitmq.yaml
@@ -25,7 +25,8 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/deckhand/barbican.yaml
+++ b/site/soc/software/charts/ucp/deckhand/barbican.yaml
@@ -23,7 +23,8 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/deckhand/deckhand.yaml
+++ b/site/soc/software/charts/ucp/deckhand/deckhand.yaml
@@ -23,7 +23,8 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/keystone/keystone.yaml
+++ b/site/soc/software/charts/ucp/keystone/keystone.yaml
@@ -24,7 +24,8 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/shipyard/shipyard.yaml
+++ b/site/soc/software/charts/ucp/shipyard/shipyard.yaml
@@ -35,7 +35,8 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   test:
-    enabled: {{ run_rally_tests }}
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:


### PR DESCRIPTION
This change allows users to customize the behavior of helm tests during a site deployment. Adding the key run_tests to env/extravars and setting it to false will disable all helm tests for all charts during the deployment (they can still be run individually using the helm CLI), and adding the key test_timeout will allow users to specify a custom timeout value that tiller will wait before terminating a test (default is 300s). Documentation on the use of these variables is provided in source/user/customize-testing-behavior.rst