### PR TITLE
SCRD-8345 Use random passwod in soc airship deployment

### DIFF
--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -93,7 +93,7 @@
     chdir: '{{ upstream_repos_clone_folder }}/airship-shipyard'
   environment:
     SHIPYARD_IMAGE: "{{ shipyard_image }}"
-    OS_PASSWORD: "{{ ucp_shipyard_keystone_password }}"
+    OS_PASSWORD: "{{ lookup('password', secrets_location + '/ucp_shipyard_keystone_password length=20 chars=ascii_letters,digits,_') }}"
   register: shipyard_create_config
   failed_when:
     - shipyard_create_config.stdout.find('Error') == 0
@@ -110,7 +110,7 @@
     chdir: '{{ upstream_repos_clone_folder }}/airship-shipyard'
   environment:
     SHIPYARD_IMAGE: "{{ shipyard_image }}"
-    OS_PASSWORD: "{{ ucp_shipyard_keystone_password }}"
+    OS_PASSWORD: "{{ lookup('password', secrets_location + '/ucp_shipyard_keystone_password length=20 chars=ascii_letters,digits,_') }}"
   when:
     - "no_revision_error_msg not in shipyard_create_config.stdout"
   register: shipyard_commit_config
@@ -127,7 +127,7 @@
     chdir: '{{ upstream_repos_clone_folder }}/airship-shipyard'
   environment:
     SHIPYARD_IMAGE: "{{ shipyard_image }}"
-    OS_PASSWORD: "{{ ucp_shipyard_keystone_password }}"
+    OS_PASSWORD: "{{ lookup('password', secrets_location + '/ucp_shipyard_keystone_password length=20 chars=ascii_letters,digits,_') }}"
   register: shipyard_update_software
   failed_when: shipyard_update_software.stdout.find('Error') == 0
   tags:
@@ -171,7 +171,7 @@
     chdir: '{{ upstream_repos_clone_folder }}/airship-shipyard'
   environment:
     SHIPYARD_IMAGE: "{{ shipyard_image }}"
-    OS_PASSWORD: "{{ ucp_shipyard_keystone_password }}"
+    OS_PASSWORD: "{{ lookup('password', secrets_location + '/ucp_shipyard_keystone_password length=20 chars=ascii_letters,digits,_') }}"
   register: shipyard_desc_action
   until: shipyard_desc_action.stdout.find('Processing') < 0 and shipyard_desc_action.stdout.find('running') < 0
   retries: 240

--- a/playbooks/roles/airship-deploy-ucp/defaults/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 scale_profile: "{{ lookup('env','scale_profile') | default('minimal') }}"
-airship_pegleg_image: "{{ suse_airship_registry_location }}/airshipit/pegleg:{{suse_airship_components_image_tag}}"
+airship_pegleg_image: "{{ suse_airship_registry_location }}/airshipit/pegleg:{{ suse_airship_components_image_tag }}"
 suse_osh_image_version: "pike"

--- a/playbooks/roles/airship-setup-deployer/tasks/main.yml
+++ b/playbooks/roles/airship-setup-deployer/tasks/main.yml
@@ -93,6 +93,7 @@
     - /etc/openstack
 
 - name: Copy clouds.yml
+  become: yes
   template:
     src: clouds.yml.j2
     dest: /etc/openstack/clouds.yaml

--- a/playbooks/roles/airship-setup-deployer/templates/clouds.yml.j2
+++ b/playbooks/roles/airship-setup-deployer/templates/clouds.yml.j2
@@ -4,7 +4,7 @@ clouds:
     identity_api_version: 3
     auth:
       username: 'admin'
-      password: {{ ucp_keystone_admin_password }}
+      password: {{ lookup('password', secrets_location + '/ucp_keystone_admin_password length=20 chars=ascii_letters,digits,_') }}
       project_name: 'admin'
       project_domain_name: 'default'
       user_domain_name: 'default'
@@ -14,7 +14,7 @@ clouds:
     identity_api_version: 3
     auth:
       username: 'admin'
-      password: {{ openstack_keystone_admin_password }}
+      password: {{ lookup('password', secrets_location + '/osh_keystone_admin_password length=20 chars=ascii_letters,digits,_') }}
       project_name: 'admin'
       project_domain_name: 'default'
       user_domain_name: 'default'

--- a/script_library/clean-airship.sh
+++ b/script_library/clean-airship.sh
@@ -101,6 +101,7 @@ fi
 
 if [[ ${clean_action} == *"clean_ucp"* ]]; then
     sudo rm -rf /opt/airship-*
+    sudo rm -rf ${ANSIBLE_RUNNER_DIR}/secrets
 fi
 
 if [[ ${clean_action} == *"clean_openstack"* ]]; then

--- a/site/soc/secrets/passphrases/ceph_swift_keystone_password.yaml
+++ b/site/soc/secrets/passphrases/ceph_swift_keystone_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ceph_swift_keystone_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ipmi_admin_password.yaml
+++ b/site/soc/secrets/passphrases/ipmi_admin_password.yaml
@@ -9,5 +9,5 @@ metadata:
   labels:
     name: ipmi-admin-password-site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ipmi_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_barbican_oslo_db_password.yaml
+++ b/site/soc/secrets/passphrases/osh_barbican_oslo_db_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_barbican_oslo_db_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_barbican_oslo_messaging_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_barbican_oslo_messaging_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_barbican_oslo_messaging_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_barbican_oslo_messaging_password.yaml
+++ b/site/soc/secrets/passphrases/osh_barbican_oslo_messaging_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_barbican_oslo_messaging_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_barbican_password.yaml
+++ b/site/soc/secrets/passphrases/osh_barbican_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_barbican_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_barbican_rabbitmq_erlang_cookie.yaml
+++ b/site/soc/secrets/passphrases/osh_barbican_rabbitmq_erlang_cookie.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_barbican_rabbitmq_erlang_cookie length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_cinder_oslo_db_password.yaml
+++ b/site/soc/secrets/passphrases/osh_cinder_oslo_db_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_cinder_oslo_db_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_cinder_oslo_messaging_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_cinder_oslo_messaging_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_cinder_oslo_messaging_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_cinder_oslo_messaging_password.yaml
+++ b/site/soc/secrets/passphrases/osh_cinder_oslo_messaging_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_cinder_oslo_messaging_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_cinder_password.yaml
+++ b/site/soc/secrets/passphrases/osh_cinder_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_cinder_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_cinder_rabbitmq_erlang_cookie.yaml
+++ b/site/soc/secrets/passphrases/osh_cinder_rabbitmq_erlang_cookie.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_cinder_rabbitmq_erlang_cookie length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_glance_oslo_db_password.yaml
+++ b/site/soc/secrets/passphrases/osh_glance_oslo_db_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_glance_oslo_db_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_glance_oslo_messaging_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_glance_oslo_messaging_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_glance_oslo_messaging_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_glance_oslo_messaging_password.yaml
+++ b/site/soc/secrets/passphrases/osh_glance_oslo_messaging_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_glance_oslo_messaging_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_glance_password.yaml
+++ b/site/soc/secrets/passphrases/osh_glance_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_glance_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_glance_rabbitmq_erlang_cookie.yaml
+++ b/site/soc/secrets/passphrases/osh_glance_rabbitmq_erlang_cookie.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_glance_rabbitmq_erlang_cookie length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_heat_oslo_db_password.yaml
+++ b/site/soc/secrets/passphrases/osh_heat_oslo_db_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_heat_oslo_db_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_heat_oslo_messaging_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_heat_oslo_messaging_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_heat_oslo_messaging_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_heat_oslo_messaging_password.yaml
+++ b/site/soc/secrets/passphrases/osh_heat_oslo_messaging_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_heat_oslo_messaging_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_heat_password.yaml
+++ b/site/soc/secrets/passphrases/osh_heat_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_heat_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_heat_rabbitmq_erlang_cookie.yaml
+++ b/site/soc/secrets/passphrases/osh_heat_rabbitmq_erlang_cookie.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_heat_rabbitmq_erlang_cookie length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_heat_stack_user_password.yaml
+++ b/site/soc/secrets/passphrases/osh_heat_stack_user_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_heat_stack_user_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_heat_trustee_password.yaml
+++ b/site/soc/secrets/passphrases/osh_heat_trustee_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_heat_trustee_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_horizon_oslo_db_password.yaml
+++ b/site/soc/secrets/passphrases/osh_horizon_oslo_db_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_horizon_oslo_db_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_infra_elasticsearch_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_infra_elasticsearch_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_infra_elasticsearch_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_infra_grafana_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_infra_grafana_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_infra_grafana_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_infra_grafana_oslo_db_password.yaml
+++ b/site/soc/secrets/passphrases/osh_infra_grafana_oslo_db_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_infra_grafana_oslo_db_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_infra_grafana_oslo_db_session_password.yaml
+++ b/site/soc/secrets/passphrases/osh_infra_grafana_oslo_db_session_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_infra_grafana_oslo_db_session_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_infra_kibana_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_infra_kibana_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_infra_kibana_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_infra_nagios_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_infra_nagios_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_infra_nagios_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_infra_openstack_exporter_password.yaml
+++ b/site/soc/secrets/passphrases/osh_infra_openstack_exporter_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_infra_openstack_exporter_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_infra_oslo_db_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_infra_oslo_db_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_infra_oslo_db_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_infra_oslo_db_exporter_password.yaml
+++ b/site/soc/secrets/passphrases/osh_infra_oslo_db_exporter_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_infra_oslo_db_exporter_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_infra_prometheus_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_infra_prometheus_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_infra_prometheus_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_keystone_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_keystone_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: {{ openstack_keystone_admin_password }}
+data: {{ lookup('password', secrets_location + '/osh_keystone_admin_password length=20 chars=ascii_letters,digits,_') }} 
 ...

--- a/site/soc/secrets/passphrases/osh_keystone_ldap_password.yaml
+++ b/site/soc/secrets/passphrases/osh_keystone_ldap_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_keystone_ldap_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_keystone_oslo_db_password.yaml
+++ b/site/soc/secrets/passphrases/osh_keystone_oslo_db_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_keystone_oslo_db_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_keystone_oslo_messaging_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_keystone_oslo_messaging_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_keystone_oslo_messaging_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_keystone_oslo_messaging_password.yaml
+++ b/site/soc/secrets/passphrases/osh_keystone_oslo_messaging_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_keystone_oslo_messaging_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_keystone_rabbitmq_erlang_cookie.yaml
+++ b/site/soc/secrets/passphrases/osh_keystone_rabbitmq_erlang_cookie.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_keystone_rabbitmq_erlang_cookie length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_neutron_oslo_db_password.yaml
+++ b/site/soc/secrets/passphrases/osh_neutron_oslo_db_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_neutron_oslo_db_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_neutron_oslo_messaging_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_neutron_oslo_messaging_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_neutron_oslo_messaging_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_neutron_oslo_messaging_password.yaml
+++ b/site/soc/secrets/passphrases/osh_neutron_oslo_messaging_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_neutron_oslo_messaging_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_neutron_password.yaml
+++ b/site/soc/secrets/passphrases/osh_neutron_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_neutron_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_neutron_rabbitmq_erlang_cookie.yaml
+++ b/site/soc/secrets/passphrases/osh_neutron_rabbitmq_erlang_cookie.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_neutron_rabbitmq_erlang_cookie length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_nova_oslo_db_password.yaml
+++ b/site/soc/secrets/passphrases/osh_nova_oslo_db_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_nova_oslo_db_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_nova_oslo_messaging_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_nova_oslo_messaging_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_nova_oslo_messaging_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_nova_oslo_messaging_password.yaml
+++ b/site/soc/secrets/passphrases/osh_nova_oslo_messaging_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_nova_oslo_messaging_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_nova_password.yaml
+++ b/site/soc/secrets/passphrases/osh_nova_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_nova_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_nova_rabbitmq_erlang_cookie.yaml
+++ b/site/soc/secrets/passphrases/osh_nova_rabbitmq_erlang_cookie.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_nova_rabbitmq_erlang_cookie length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_oslo_cache_secret_key.yaml
+++ b/site/soc/secrets/passphrases/osh_oslo_cache_secret_key.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_oslo_cache_secret_key length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_oslo_db_admin_password.yaml
+++ b/site/soc/secrets/passphrases/osh_oslo_db_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_oslo_db_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_oslo_db_exporter_password.yaml
+++ b/site/soc/secrets/passphrases/osh_oslo_db_exporter_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_oslo_db_exporter_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/osh_placement_password.yaml
+++ b/site/soc/secrets/passphrases/osh_placement_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/osh_placement_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_airflow_oslo_messaging_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_airflow_oslo_messaging_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_airflow_oslo_messaging_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_airflow_postgres_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_airflow_postgres_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_airflow_postgres_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_armada_keystone_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_armada_keystone_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_armada_keystone_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_barbican_keystone_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_barbican_keystone_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_barbican_keystone_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_barbican_oslo_db_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_barbican_oslo_db_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_barbican_oslo_db_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_deckhand_keystone_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_deckhand_keystone_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_deckhand_keystone_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_deckhand_postgres_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_deckhand_postgres_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_deckhand_postgres_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_keystone_admin_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_keystone_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: {{ ucp_keystone_admin_password }}
+data: {{ lookup('password', secrets_location + '/ucp_keystone_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_keystone_oslo_db_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_keystone_oslo_db_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_keystone_oslo_db_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_openstack_exporter_keystone_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_openstack_exporter_keystone_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_openstack_exporter_keystone_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_oslo_db_admin_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_oslo_db_admin_password.yaml
@@ -7,5 +7,4 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
-...
+data: {{ lookup('password', secrets_location + '/ucp_oslo_db_admin_password length=20 chars=ascii_letters,digits,_') }}

--- a/site/soc/secrets/passphrases/ucp_oslo_messaging_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_oslo_messaging_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_oslo_messaging_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_postgres_admin_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_postgres_admin_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_postgres_admin_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_promenade_keystone_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_promenade_keystone_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_promenade_keystone_password length=20 chars=ascii_letters,digits,_') }} 
 ...

--- a/site/soc/secrets/passphrases/ucp_rabbitmq_erlang_cookie.yaml
+++ b/site/soc/secrets/passphrases/ucp_rabbitmq_erlang_cookie.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_rabbitmq_erlang_cookie length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/site/soc/secrets/passphrases/ucp_shipyard_keystone_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_shipyard_keystone_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: {{ ucp_shipyard_keystone_password }}
+data: {{ lookup('password', secrets_location + '/ucp_shipyard_keystone_password length=20 chars=ascii_letters,digits,_') }} 
 ...

--- a/site/soc/secrets/passphrases/ucp_shipyard_postgres_password.yaml
+++ b/site/soc/secrets/passphrases/ucp_shipyard_postgres_password.yaml
@@ -7,5 +7,5 @@ metadata:
     abstract: false
     layer: site
   storagePolicy: cleartext
-data: password123
+data: {{ lookup('password', secrets_location + '/ucp_shipyard_postgres_password length=20 chars=ascii_letters,digits,_') }}
 ...

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -53,10 +53,8 @@ suse_airship_components_image_tag: "{%- if suse_airship_build_local_images or su
 
 socok8s_site_name: "soc"
 
-#TODO(JG) change ro randomized password 
-ucp_keystone_admin_password: 'password123'
-openstack_keystone_admin_password: 'password123'
-ucp_shipyard_keystone_password: 'password123'
-
 # Flag to run pod rally tests (default false)
 run_rally_tests: false
+
+# where the generated secrets are stored
+secrets_location: "{{ socok8s_workspace }}/secrets"


### PR DESCRIPTION
Change hard coded default passwords to generated random passwords for
all deployed airship and openstack services.