### PR TITLE
update keystone overrides

### DIFF
--- a/playbooks/roles/deploy-osh/templates/keystone.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/keystone.yaml.j2
@@ -2,25 +2,26 @@
 #TODO(itxaka): Remove the developer mode when 647403 is merged
 {% if developer_mode %}
 conf:
-  apache2:
-    binary: apache2ctl
-    start_parameters: -DFOREGROUND -k start
-    site_dir: /etc/apache2/vhosts.d
-    conf_dir: /etc/apache2/conf.d
-    a2enmod:
-      - version
-    security: |
-      <Directory "/var/www">
-      Options Indexes FollowSymLinks
-      AllowOverride All
-      <IfModule !mod_access_compat.c>
-        Require all granted
-      </IfModule>
-      <IfModule mod_access_compat.c>
-        Order allow,deny
-        Allow from all
-      </IfModule>
-      </Directory>
+  software:
+    apache2:
+      binary: apache2ctl
+      start_parameters: -DFOREGROUND -k start
+      site_dir: /etc/apache2/vhosts.d
+      conf_dir: /etc/apache2/conf.d
+      a2enmod:
+        - version
+      security: |
+        <Directory "/var/www">
+          Options Indexes FollowSymLinks
+          AllowOverride All
+        <IfModule !mod_access_compat.c>
+          Require all granted
+        </IfModule>
+        <IfModule mod_access_compat.c>
+          Order allow,deny
+          Allow from all
+        </IfModule>
+        </Directory>
 pod:
   security_context:
     keystone:


### PR DESCRIPTION
as the multi-os spec has landed upstream, the overrides have to be
changed to be in sync.

Mainly the change is that the overrides for apache2 need to be
under conf -> software -> apache2 now