### PR TITLE
update horizon overrides

### DIFF
--- a/playbooks/roles/deploy-osh/templates/horizon.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/horizon.yaml.j2
@@ -1,14 +1,14 @@
 ---
-{% if developer_mode %}
 conf:
-  apache2:
-    binary: apache2ctl
-    start_parameters: -DFOREGROUND -k start
-    site_dir: /etc/apache2/vhosts.d
-    conf_dir: /etc/apache2/conf.d
-    a2enmod:
-      - rewrite
-      - version
+  software:
+    apache2:
+      binary: apache2ctl
+      start_parameters: -DFOREGROUND -k start
+      site_dir: /etc/apache2/vhosts.d
+      conf_dir: /etc/apache2/conf.d
+      a2enmod:
+        - rewrite
+        - version
   horizon:
     security: |
       <Directory "/var/www">
@@ -28,4 +28,3 @@ images:
     db_init: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
     horizon_db_sync: "{{ suse_osh_registry_location }}/openstackhelm/horizon:{{ suse_openstack_image_version }}"
     horizon: "{{ suse_osh_registry_location }}/openstackhelm/horizon:{{ suse_openstack_image_version }}"
-{%  endif %}

--- a/playbooks/roles/dev-patcher/defaults/main.yml
+++ b/playbooks/roles/dev-patcher/defaults/main.yml
@@ -21,8 +21,6 @@ dev_patcher_patches:
   - 634936
   # osh: make ceilometer-api work on suse based images
   - 641802
-  # osh: Allow more generic overrides for horizon
-  - 645141
   # osh: Fix indent filter not properly adding a newline after toYaml
   - 642844
   # osh: Allow more generic overrides for nova placement-api
@@ -35,7 +33,5 @@ dev_patcher_patches:
   - 645543
   # osh: Allow more generic overrides for keystone
   - 647403
-  # osh: Remove overlapping Listen directives on apache >= 2.4
-  - 645189
   # osh: Add an option to the health probe to test all pids
   - 644907


### PR DESCRIPTION
as the multi-os spec has landed upstream, the overrides have to be
changed to be in sync.

Mainly the change is that the overrides for apache2 need to be
under conf -> software -> apache2 now