### PR TITLE
Make sure ANSIBLE_RUNNER_DIR has a skeleton inventory

### DIFF
--- a/script_library/run-ansible.sh
+++ b/script_library/run-ansible.sh
@@ -18,6 +18,11 @@ function run_ansible(){
         mkdir -p ${ANSIBLE_RUNNER_DIR}/{env,inventory} || true
         echo "Adding an empty inventory by default"
         cp ${socok8s_absolute_dir}/examples/workdir/inventory/hosts.yml ${inventorydir}/skeleton-inventory.yml
+    else
+	if [[ ! -f ${inventorydir}/skeleton-inventory.yml ]]; then
+            echo "No skeleton inventory found, adding one"
+            cp ${socok8s_absolute_dir}/examples/workdir/inventory/hosts.yml ${inventorydir}/skeleton-inventory.yml
+	fi
     fi
 
     if [[ -f ${extravarsfile} ]]; then


### PR DESCRIPTION
If ANSIBLE_RUNNER_DIR exists but does not have a skeleton inventory,
copy the default file into place.

This supports the use case of creating a custom ansible runner venv
without also needing to create a custom inventory template file.