### PR TITLE
Consolidate ANSIBLE_RUNNER_DIR setup

### DIFF
--- a/script_library/bootstrap-ansible-if-necessary.sh
+++ b/script_library/bootstrap-ansible-if-necessary.sh
@@ -6,9 +6,22 @@ set -e
 # is packaged for all the distributions.
 
 function install_ansible (){
+    # ansible-runner default locations
     if [[ -z ${ANSIBLE_RUNNER_DIR:-} ]]; then
-        ANSIBLE_RUNNER_DIR=~/suse-socok8s-deploy
+        echo "ANSIBLE_RUNNER_DIR env var is not set, defaulting to '~/suse-socok8s-deploy'"
+        export ANSIBLE_RUNNER_DIR="${HOME}/suse-socok8s-deploy"
     fi
+
+    export extravarsfile=${ANSIBLE_RUNNER_DIR}/env/extravars
+    export inventorydir=${ANSIBLE_RUNNER_DIR}/inventory/
+
+    # This creates a structure that's similar to ansible-runner tool
+    if [[ ! -d ${ANSIBLE_RUNNER_DIR} ]]; then
+        mkdir -p ${ANSIBLE_RUNNER_DIR}/{env,inventory} || true
+        echo "Adding an empty inventory by default"
+        cp ${socok8s_absolute_dir}/examples/workdir/inventory/hosts.yml ${inventorydir}/skeleton-inventory.yml
+    fi
+
     if [[ ! -d ${ANSIBLE_RUNNER_DIR}/.ansiblevenv/ ]]; then
         virtualenv ${ANSIBLE_RUNNER_DIR}/.ansiblevenv/
     fi

--- a/script_library/run-ansible.sh
+++ b/script_library/run-ansible.sh
@@ -4,21 +4,6 @@
 
 function run_ansible(){
     set -x
-    # ansible-runner default locations
-    if [[ -z ${ANSIBLE_RUNNER_DIR+x} ]]; then
-        echo "ANSIBLE_RUNNER_DIR env var is not set, defaulting to '~/suse-socok8s-deploy'"
-        export ANSIBLE_RUNNER_DIR="${HOME}/suse-socok8s-deploy"
-    fi
-
-    extravarsfile=${ANSIBLE_RUNNER_DIR}/env/extravars
-    inventorydir=${ANSIBLE_RUNNER_DIR}/inventory/
-
-    # This creates a structure that's similar to ansible-runner tool
-    if [[ ! -d ${ANSIBLE_RUNNER_DIR} ]]; then
-        mkdir -p ${ANSIBLE_RUNNER_DIR}/{env,inventory} || true
-        echo "Adding an empty inventory by default"
-        cp ${socok8s_absolute_dir}/examples/workdir/inventory/hosts.yml ${inventorydir}/skeleton-inventory.yml
-    fi
 
     if [[ -f ${extravarsfile} ]]; then
         echo "Extra variables file exists: $(realpath ${extravarsfile}). Loading its vars in ansible-playbook call."
@@ -29,6 +14,7 @@ function run_ansible(){
         echo "Inventory directory (${inventorydir}) exists, adding it to the ansible-playbook call."
         inventory="-i ${inventorydir}"
     fi
+
     if [[ ${USE_ARA:-False} == "True" ]]; then
         echo "Loading ARA"
         source ${ANSIBLE_RUNNER_DIR}/.ansiblevenv/ara.rc


### PR DESCRIPTION
There is logic in both install_ansible and run_ansible to check if
ANSIBLE_RUNNER_DIR is set and to some create initial subdirectories.
Since install_ansible will be run first, that logic will set the
variable and create the directory, preventing the logic in run_ansible
from ever running.

Consolidate code from run_ansible into install_ansible so that we have a
single code location for setting a default ANSIBLE_RUNNER_DIR value and
creating the directory if needed.