### PR TITLE
cleanup: fix default filter call

### DIFF
--- a/playbooks/roles/airship-deploy-ucp/defaults/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-scale_profile: "{{ lookup('env','scale_profile') | default('minimal') }}"
+scale_profile: "{{ lookup('env','scale_profile') | default('minimal', true) }}"
 airship_pegleg_image: "{{ suse_airship_registry_location }}/airshipit/pegleg:{{ suse_airship_components_image_tag }}"
 suse_osh_image_version: "pike"


### PR DESCRIPTION
We need to pass 'true' as a second parameter when using the default
filter after a lookup call.