### PR TITLE
caasp: add extra configs for apparmor profiles

### DIFF
--- a/playbooks/roles/setup-caasp-workers/defaults/main.yml
+++ b/playbooks/roles/setup-caasp-workers/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 caasp_reboot_timeout: 300
+apparmor_profiles:
+  - usr.sbin.dnsmasq

--- a/playbooks/roles/setup-caasp-workers/files/usr.sbin.dnsmasq
+++ b/playbooks/roles/setup-caasp-workers/files/usr.sbin.dnsmasq
@@ -1,0 +1,5 @@
+# Site-specific additions and overrides for 'usr.sbin.dnsmasq'
+# neutron containers need the following access to launch dnsmasq
+  /etc/neutron/dnsmasq.conf r,
+  /var/lib/neutron/dhcp/ rw,
+  /var/lib/neutron/dhcp/** rw,

--- a/playbooks/roles/setup-caasp-workers/handlers/main.yml
+++ b/playbooks/roles/setup-caasp-workers/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+# ansible-lint: we need to reload the profiel and there is no ansible modules for that yet
+- name: Reload apparmor profile
+  shell: "apparmor_parser -r /etc/apparmor.d/{{ item.item }}"
+  when: item.changed
+  loop: "{{ apparmor_copy.results | flatten(levels=1) }}"
+  loop_control:
+    label: "{{ item.item }}"
+  tags:
+    - skip_ansible_lint

--- a/playbooks/roles/setup-caasp-workers/tasks/apparmor-profiles.yml
+++ b/playbooks/roles/setup-caasp-workers/tasks/apparmor-profiles.yml
@@ -1,0 +1,8 @@
+---
+- name: Copy openstack apparmor profile into the workers
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/apparmor.d/local/{{ item }}"
+  loop: "{{ apparmor_profiles }}"
+  register: apparmor_copy
+  notify: Reload apparmor profile

--- a/playbooks/roles/setup-caasp-workers/tasks/main.yml
+++ b/playbooks/roles/setup-caasp-workers/tasks/main.yml
@@ -15,3 +15,8 @@
   tags:
     - preinstall
 
+- name: Apparmor profiles in worker nodes
+  import_tasks: apparmor-profiles.yml
+  tags:
+    - apparmor
+


### PR DESCRIPTION
Some of our containers may need extra configs for apparmor.
For example, neutron-dhcp launches dnsmasq, which needs access
to the neutron config dir and the /var/lib/neutron/dhcp for leases.

We need a way of extending apparmor profiles with custom directives
for the proper execution of our openstack containers.

This patch allows us to add extra directives for apparmor profiles