### PR TITLE
add missing novncproxy to /etc/hosts

### DIFF
--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -84,6 +84,7 @@
       {{ socok8s_ext_vip }} neutron-server.openstack.svc.cluster.local neutron-server
       {{ socok8s_ext_vip }} horizon.openstack.svc.cluster.local horizon
       {{ socok8s_ext_vip }} heat.openstack.svc.cluster.local heat
+      {{ socok8s_ext_vip }} novncproxy.openstack.svc.cluster.local novncproxy
 
 # Developers have patched code, and don't need fetching product sources
 - name: Fetch OSH code


### PR DESCRIPTION
novncsproxy is missing from the /etc/hosts