### PR TITLE
Airship CI: add variables to extravars for airship deployment

### DIFF
--- a/playbooks/generic-airship_prepare.yml
+++ b/playbooks/generic-airship_prepare.yml
@@ -1,0 +1,8 @@
+---
+- hosts: localhost
+  gather_facts: yes
+  any_errors_fatal: true
+  roles:
+    - role: airship-prepare
+      tags:
+        - install

--- a/playbooks/roles/airship-prepare/defaults/main.yml
+++ b/playbooks/roles/airship-prepare/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+# defaults file for prepare airship
+extravars_scale_profile: "ha"
+extravars_redeploy_osh_only: "false"
+extravars_suse_osh_registry_location: "docker.io"
+extravars_suse_osh_image_version: "pike"

--- a/playbooks/roles/airship-prepare/tasks/main.yml
+++ b/playbooks/roles/airship-prepare/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+
+- name: Load standard variables
+  include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
+
+- name: Load existing extravars
+  include_vars: "{{ socok8s_extravars }}"
+
+# set socok8s_dcm_vip to same value as socok8s_ext_vip
+
+# TODO: This should be improved in the future by creating a new VIP
+# on a another network and then set socok8s_dcm_vip to new VIP
+# value
+
+- name: Set socok8s_dcm_vip in extravars
+  lineinfile:
+    path: "{{ socok8s_extravars }}"
+    regexp: "^socok8s_dcm_vip.*"
+    line: "socok8s_dcm_vip: {{ socok8s_ext_vip }}"
+  tags:
+    - install
+
+- name: Set scale profile in extravars
+  lineinfile:
+    path: "{{ socok8s_extravars }}"
+    regexp: "^scale_profile.*"
+    line: "scale_profile: {{ extravars_scale_profile }}"
+  tags:
+    - install
+
+- name: Set redeploy_osh_only in extravars
+  lineinfile:
+    path: "{{ socok8s_extravars }}"
+    regexp: "^redeploy_osh_only.*"
+    line: "redeploy_osh_only: {{ extravars_redeploy_osh_only }}"
+  tags:
+    - install

--- a/run.sh
+++ b/run.sh
@@ -77,6 +77,7 @@ case "$deployment_action" in
         ;;
     "setup_airship")
         setup_caasp_workers_for_openstack
+        airship_prepare
         deploy_airship
         ;;
     "deploy_airship")

--- a/script_library/deployment-actions-kvm.sh
+++ b/script_library/deployment-actions-kvm.sh
@@ -40,6 +40,9 @@ function deploy_osh(){
     echo "Now deploy SUSE version of OSH"
     run_ansible ${socok8s_absolute_dir}/playbooks/generic-deploy_osh.yml
 }
+function airship_prepare(){
+    run_ansible ${socok8s_absolute_dir}/playbooks/generic-airship_prepare.yml
+}
 function deploy_airship(){
     echo "Now deploy SUSE version of Airship"
     tagged_info=''

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -49,6 +49,9 @@ function deploy_osh(){
     echo "Now deploy SUSE version of OSH"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-deploy_osh.yml
 }
+function airship_prepare(){
+    run_ansible ${socok8s_absolute_dir}/playbooks/generic-airship_prepare.yml
+}
 function deploy_airship(){
     echo "Now deploy SUSE version of Airship"
     tagged_info=''


### PR DESCRIPTION
* added an new role airship-prepare to perform any preparation
  tasks before deploying airship.

* airship-prepare  adds following airship variables to extravars

  - socok8s_dcm_vip: vip for the second network.
                     For now set to same value as socok8s_ext_vip
                     but can be set to vip on a another network
                     in the future.

  - redeploy_osh_only:  setting this to true only deploys airship
                        over cloud components.
                        For now set this to 'false'