### PR TITLE
Registry server setup needs to run on all worker nodes and deployer.

### DIFF
--- a/playbooks/generic-deploy_airship.yml
+++ b/playbooks/generic-deploy_airship.yml
@@ -8,7 +8,7 @@
       tags:
         - install
 
-- hosts: all
+- hosts: soc-deployer:caasp-workers
   gather_facts: false
   any_errors_fatal: true
   roles:


### PR DESCRIPTION
As inventory file has changed and looks like we missed this to change.