### PR TITLE
dev-patcher: set git user.name and user.email if needed

### DIFF
--- a/playbooks/roles/dev-patcher/tasks/main.yml
+++ b/playbooks/roles/dev-patcher/tasks/main.yml
@@ -27,6 +27,25 @@
   register: _gitclone
   until: _gitclone is succeeded
 
+- name: Read git config settings
+  git_config:
+    list_all: yes
+  register: git_config
+
+- name: Set user.name if needed
+  git_config:
+    name: user.name
+    scope: global
+    value: "Dev Patcher"
+  when: "'user.name' not in git_config['config_values'].keys()"
+
+- name: Set user.email if needed
+  git_config:
+    name: user.email
+    scope: global
+    value: "dev-patcher@{{ ansible_hostname }}"
+  when: "'user.email' not in git_config['config_values'].keys()"
+
 - name: Get patch details
   include_tasks: patch-repos.yml
   loop: "{{ (dev_patcher_patches) + (dev_patcher_user_patches | default([])) }}"


### PR DESCRIPTION
If either user.name or user.email is not set, then the upcoming
cherry-pick in patch-repos.yml will fail. Previously, this was a manual
configuration step. This change sets them to sane service-user values
in the event that they have not already been configured.