### PR TITLE
Use unique servernames


### DIFF
--- a/doc/source/deploy-guide/prepare-localhost.rst
+++ b/doc/source/deploy-guide/prepare-localhost.rst
@@ -164,33 +164,32 @@ OpenStack CLI’s ``openstack keypair create``) for accessing the
 instances created. Remember the name of this keypair (which appears as
 ``foctodoodle-key`` in the example below)
 
-Set this for all the following scripts:
+Set this for **all** the following scripts in a deployment:
 
 .. code-block:: console
 
-   export OS_CLOUD=engcloud # Assuming you followed the example for clouds.yaml
-   # Your username plus whatever else you would like, will be used for naming
-   # objects you create in the cloud
-   export PREFIX=foctodoodle
+   export OS_CLOUD=engcloud
+   # 'engcloud' is the name in the `clouds.yaml`,
    # Set the name of the keypair you created
    export KEYNAME=foctodoodle-key
-   # Set the name of the subnet you created
-   export INTERNAL_SUBNET=${PREFIX}-subnet
+   # Set the name of the network you will use in the deployment
+   export INTERNAL_NETWORK=foctodoodle-net
+   # Set the name of the subnet you will use in the deployment
+   export INTERNAL_SUBNET=foctodoodle-subnet
+   # Set the name of the floating ip network you will use in the deployment
+   export EXTERNAL_NETWORK=floating
 
-Now create a network, a subnet, a router and a connection to the
-floating network (you only have to do it once):
+If you haven't created the internal networks/subnets and appropriate routers
+already, do it now (you only have to do it once):
 
 .. code-block:: console
 
-   openstack network create ${PREFIX}-net
-   openstack subnet create --network ${PREFIX}-net --subnet-range 192.168.100.0/24 ${PREFIX}-subnet
-   openstack router create ${PREFIX}-router
-   openstack router set --external-gateway floating ${PREFIX}-router
-   openstack router add subnet ${PREFIX}-router ${PREFIX}-subnet
+   openstack network create ${INTERNAL_NETWORK}
+   openstack subnet create --network ${INTERNAL_NETWORK} --subnet-range 192.168.100.0/24 ${INTERNAL_SUBNET}
+   openstack router create ${INTERNAL_NETWORK}-router
+   openstack router set --external-gateway floating ${INTERNAL_NETWORK}-router
+   openstack router add subnet ${INTERNAL_NETWORK}-router ${INTERNAL_SUBNET}
 
-Prior to executing scripts, be aware that you may need to do some
-cleanup prior to retrying scripts or playbooks should they fail. In some
-steps a teardown script is provided to clean up any created resources.
 Reconfirming that you’ve done all the previous steps to set up now will
 save you some time later.
 

--- a/playbooks/openstack-caasp_instance.yml
+++ b/playbooks/openstack-caasp_instance.yml
@@ -2,6 +2,8 @@
 - hosts: localhost
   gather_facts: no
   connection: local
+  vars:
+    stackname_suffix: "caasp"
   tasks:
     - name: Load generic vars
       include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
@@ -10,26 +12,13 @@
 
     - name: Define stackname to create
       set_fact:
-        stackname: "{{ deploy_on_openstack_prefix }}-{{ lookup('env', 'BUILD_NUMBER') | default(65000 | random, true) }}"
-
-    - name: Check if a stack already exists
-      stat:
-        path: "{{ deploy_on_openstack_caasp_stacknamefile }}"
-      register: _stackfile
+        stackname: "{{ deploy_on_openstack_prefix }}-{{ stackname_suffix }}"
 
     - name: Handle creation if not exists
       when:
         - not ((caasp_stack_delete | default('false'))| bool)
       block:
-        - name: Ensure no stack existed before continuing
-          assert:
-            that:
-              - not _stackfile.stat.exists
-            fail_msg: "A stack already exists, please remove all your stacks and your file {{ deploy_on_openstack_caasp_stacknamefile }} first"
-            success_msg: "No stack exists, we can continue"
-
         - name: Create stack
-          register: stackcreate
           os_stack:
             cloud: "{{ deploy_on_openstack_cloudname }}"
             state: "present"
@@ -43,12 +32,6 @@
               security_group: "{{ deploy_on_openstack_caasp_securitygroup }}"
               keypair: "{{ deploy_on_openstack_keypairname }}"
               worker_count: "{{ deploy_on_openstack_caasp_workers }}"
-
-        # Keep that as close to stack create, to prevent failures from not creating a lock
-        - name: Save stackname for later (for deletion)
-          copy:
-            content: "{{ stackname }}"
-            dest: "{{ deploy_on_openstack_caasp_stacknamefile }}"
 
         # TODO(evrardjp) Remove this when all the nodes have floating IPs in the template
         - name: Get all the node with no floating ips
@@ -238,7 +221,12 @@
         - name: Delete stack
           os_stack:
             cloud: "{{ deploy_on_openstack_cloudname }}"
-            name: "{{ lookup('file',deploy_on_openstack_caasp_stacknamefile) }}"
+            name: "{{ stackname }}"
+            state: absent
+
+        - name: Delete extra vip
+          os_port:
+            name: "{{ stackname }}-vip"
             state: absent
 
         - name: Remove host from known hosts
@@ -253,5 +241,4 @@
             path: "{{ item }}"
           loop:
             - "{{ socok8s_caasp_environment_details }}"
-            - "{{ deploy_on_openstack_caasp_stacknamefile }}"
             - "{{ socok8s_workspace }}/inventory/caasp.yml"

--- a/playbooks/openstack-osh_instance.yml
+++ b/playbooks/openstack-osh_instance.yml
@@ -11,7 +11,7 @@
   roles:
     - role: handle-nodes-on-openstack
       vars:
-        servername: "{{ deploy_on_openstack_oshnode_server_name }}"
+        servername_suffix: "deployer"
         flavor: "{{ deploy_on_openstack_oshnode_flavor }}"
         image: "{{ deploy_on_openstack_oshnode_image }}"
         network: "{{ deploy_on_openstack_internal_network }}"

--- a/playbooks/openstack-osh_instance.yml
+++ b/playbooks/openstack-osh_instance.yml
@@ -2,109 +2,21 @@
 - hosts: localhost
   gather_facts: no
   connection: local
-  tasks:
+  pre_tasks:
     - name: Load generic vars
-      include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
-    - name: Load openstack vars
-      include_vars: "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
-
-    - name: Handle creation
-      when:
-        - not ((osh_node_delete | default('false'))| bool)
-      block:
-        - name: Create volume
-          os_volume:
-            cloud: "{{ deploy_on_openstack_cloudname }}"
-            display_name: "{{ deploy_on_openstack_oshnode_volume_name }}"
-            size: 80
-            state: "present"
-        - name: Create server
-          os_server:
-            cloud: "{{ deploy_on_openstack_cloudname }}"
-            flavor: "{{ deploy_on_openstack_oshnode_flavor }}"
-            image: "{{ deploy_on_openstack_oshnode_image }}"
-            key_name: "{{ deploy_on_openstack_keypairname }}"
-            name: "{{ deploy_on_openstack_oshnode_server_name }}"
-            network: "{{ deploy_on_openstack_internal_network }}"
-            security_groups:
-              - "{{ deploy_on_openstack_oshnode_securitygroup }}"
-            auto_ip: True
-            state: present
-            timeout: 300
-            volumes:
-              - "{{ deploy_on_openstack_oshnode_volume_name }}"
-            userdata: "{{ deploy_on_openstack_oshnode_userdata | default(omit) }}"
-          register: _osh_server_create
-        - name: Show the server data
-          debug:
-            var: _osh_server_create
-        - name: Get server floating IP
-          set_fact:
-            osh_floating_ip: "{{ _osh_server_create['openstack']['accessIPv4'] }}"
-        - name: Extend inventory in workspace with newly created OSH deployer node
-          copy:
-            content: "{{ soc_aio_overrides }}"
-            dest: "{{ socok8s_workspace }}/inventory/osh.yml"
-          vars:
-            soc_aio_overrides: |
-              soc-deployer:
-                hosts:
-                  soc-aio:
-                    ansible_host: {{ osh_floating_ip }}
-
-        - meta: refresh_inventory
-
-        - name: Wait for a SSH to be properly started
-          wait_for:
-            host: "{{ osh_floating_ip }}"
-            port: 22
-            search_regex: OpenSSH
-            state: started
-            delay: 10
-            timeout: 180
-
-        - name: Get pubkey, and add it to known hosts
-          command: "ssh-keyscan -H {{ osh_floating_ip | quote }}"
-          register: _oshfloatingkey
-          retries: 10
-          delay: 10
-          until: _oshfloatingkey.stdout and _oshfloatingkey.stdout.strip()
-
-
-        - name: Insert known host
-          known_hosts:
-            state: present
-            name: "{{ osh_floating_ip }}"
-            key: "{{ _oshfloatingkey.stdout }}"
-
-    - name: Handle deletion
-      when:
-        - (osh_node_delete | default('false')) | bool
-      block:
-        - name: Delete server
-          os_server:
-            cloud: "{{ deploy_on_openstack_cloudname }}"
-            delete_fip: yes
-            name: "{{ deploy_on_openstack_oshnode_server_name }}"
-            state: absent
-            timeout: 300
-
-        - name: Delete volume
-          os_volume:
-            cloud: "{{ deploy_on_openstack_cloudname }}"
-            display_name: "{{ deploy_on_openstack_oshnode_volume_name }}"
-            state: "absent"
-
-        # Looping will avoid the need to create a condition if no hosts
-        # exists in the inventory.
-        - name: Remove all hosts from this group known hosts
-          known_hosts:
-            state: absent
-            name: "{{ hostvars[item]['ansible_host'] }}"
-          loop: "{{ groups['soc-deployer'] }}"
-
-        - name: Delete osh inventory
-          file:
-            state: absent
-            path: "{{ socok8s_workspace }}/inventory/osh.yml"
-
+      include_vars: "{{ item }}"
+      loop:
+        - "{{ playbook_dir }}/../vars/common-vars.yml"
+        - "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+  roles:
+    - role: handle-nodes-on-openstack
+      vars:
+        servername: "{{ deploy_on_openstack_oshnode_server_name }}"
+        flavor: "{{ deploy_on_openstack_oshnode_flavor }}"
+        image: "{{ deploy_on_openstack_oshnode_image }}"
+        network: "{{ deploy_on_openstack_internal_network }}"
+        securitygroups:
+          - "{{ deploy_on_openstack_oshnode_securitygroup }}"
+        groupname_for_inventory: "soc-deployer"
+        userdata: "{{ deploy_on_openstack_oshnode_userdata }}"
+        delete: "{{ ((osh_node_delete | default('False')) | bool) }}"

--- a/playbooks/openstack-ses_aio_instance.yml
+++ b/playbooks/openstack-ses_aio_instance.yml
@@ -2,107 +2,20 @@
 - hosts: localhost
   gather_facts: no
   connection: local
-  tasks:
+  pre_tasks:
     - name: Load generic vars
-      include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
-    - name: Load openstack vars
-      include_vars: "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
-
-    - name: Handle creation
-      when:
-        - not ((ses_node_delete | default('false'))| bool)
-      block:
-        - name: Create volume
-          os_volume:
-            cloud: "{{ deploy_on_openstack_cloudname }}"
-            display_name: "{{ deploy_on_openstack_sesnode_volume_name }}"
-            size: 80
-            state: "present"
-        - name: Create server
-          os_server:
-            cloud: "{{ deploy_on_openstack_cloudname }}"
-            flavor: "{{ deploy_on_openstack_sesnode_flavor }}"
-            image: "{{ deploy_on_openstack_sesnode_image }}"
-            key_name: "{{ deploy_on_openstack_keypairname }}"
-            name: "{{ deploy_on_openstack_sesnode_server_name }}"
-            network: "{{ deploy_on_openstack_internal_network }}"
-            security_groups:
-              - "{{ deploy_on_openstack_sesnode_securitygroup }}"
-            auto_ip: True
-            state: present
-            timeout: 300
-            volumes:
-              - "{{ deploy_on_openstack_sesnode_volume_name }}"
-          register: _ses_server_create
-        - name: Show the server data
-          debug:
-            var: _ses_server_create
-        - name: Get server floating IP
-          set_fact:
-            ses_floating_ip: "{{ _ses_server_create['openstack']['accessIPv4'] }}"
-        - name: Extend inventory in workspace with newly created SES node
-          copy:
-            content: "{{ ses_aio_overrides }}"
-            dest: "{{ socok8s_workspace }}/inventory/ses.yml"
-          vars:
-            ses_aio_overrides: |
-              ses_nodes:
-                hosts:
-                  ses-aio:
-                    ansible_host: {{ ses_floating_ip }}
-
-        - meta: refresh_inventory
-
-        - name: Wait for a SSH to be properly started
-          wait_for:
-            host: "{{ ses_floating_ip }}"
-            port: 22
-            search_regex: OpenSSH
-            state: started
-            delay: 10
-            timeout: 180
-
-        - name: Get pubkey, and add it to known hosts
-          command: "ssh-keyscan -H {{ ses_floating_ip | quote }}"
-          register: _sesfloatingkey
-          retries: 10
-          delay: 10
-          until: _sesfloatingkey.stdout and _sesfloatingkey.stdout.strip()
-
-        - name: Insert known host
-          known_hosts:
-            state: present
-            name: "{{ ses_floating_ip }}"
-            key: "{{ _sesfloatingkey.stdout }}"
-
-
-    - name: Handle deletion
-      when:
-        - (ses_node_delete | default('false')) | bool
-      block:
-        - name: Delete server
-          os_server:
-            cloud: "{{ deploy_on_openstack_cloudname }}"
-            delete_fip: yes
-            name: "{{ deploy_on_openstack_sesnode_server_name }}"
-            state: absent
-            timeout: 300
-
-        - name: Delete volume
-          os_volume:
-            cloud: "{{ deploy_on_openstack_cloudname }}"
-            display_name: "{{ deploy_on_openstack_sesnode_volume_name }}"
-            state: "absent"
-
-        # Looping will avoid the need to create a condition if no hosts
-        # exists in the inventory.
-        - name: Remove all hosts from this group known hosts
-          known_hosts:
-            state: absent
-            name: "{{ hostvars[item]['ansible_host'] }}"
-          loop: "{{ groups['ses_nodes'] }}"
-
-        - name: Remove SES inventory hosts
-          file:
-            state: absent
-            path: "{{ socok8s_workspace }}/inventory/ses.yml"
+      include_vars: "{{ item }}"
+      loop:
+        - "{{ playbook_dir }}/../vars/common-vars.yml"
+        - "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+  roles:
+    - role: handle-nodes-on-openstack
+      vars:
+        servername: "{{ deploy_on_openstack_sesnode_server_name }}"
+        flavor: "{{ deploy_on_openstack_sesnode_flavor }}"
+        image: "{{ deploy_on_openstack_sesnode_image }}"
+        network: "{{ deploy_on_openstack_internal_network }}"
+        securitygroups:
+          - "{{ deploy_on_openstack_sesnode_securitygroup }}"
+        groupname_for_inventory: "ses_nodes"
+        delete: "{{ ((ses_node_delete | default('False')) | bool) }}"

--- a/playbooks/openstack-ses_aio_instance.yml
+++ b/playbooks/openstack-ses_aio_instance.yml
@@ -11,7 +11,7 @@
   roles:
     - role: handle-nodes-on-openstack
       vars:
-        servername: "{{ deploy_on_openstack_sesnode_server_name }}"
+        servername_suffix: "ses"
         flavor: "{{ deploy_on_openstack_sesnode_flavor }}"
         image: "{{ deploy_on_openstack_sesnode_image }}"
         network: "{{ deploy_on_openstack_internal_network }}"

--- a/playbooks/roles/handle-nodes-on-openstack/tasks/create_on_openstack.yml
+++ b/playbooks/roles/handle-nodes-on-openstack/tasks/create_on_openstack.yml
@@ -1,0 +1,59 @@
+---
+- name: Create volume
+  os_volume:
+    cloud: "{{ deploy_on_openstack_cloudname }}"
+    display_name: "{{ servername }}-vol"
+    size: 80
+    state: "present"
+
+- name: Create server
+  os_server:
+    cloud: "{{ deploy_on_openstack_cloudname }}"
+    flavor: "{{ flavor }}"
+    image: "{{ image }}"
+    key_name: "{{ deploy_on_openstack_keypairname }}"
+    name: "{{ servername }}"
+    network: "{{ network }}"
+    security_groups: "{{ securitygroups }}"
+    auto_ip: True
+    state: present
+    timeout: 300
+    volumes:
+      - "{{ servername }}-vol"
+    userdata: "{{ userdata | default(omit) }}"
+  register: _server_create
+
+- name: Show the server data
+  debug:
+    var: _server_create
+
+- name: Get server floating IP
+  set_fact:
+    floating_ip: "{{ _server_create['openstack']['accessIPv4'] }}"
+
+- name: Extend inventory in workspace with newly created OSH deployer node
+  copy:
+    content: "{{ soc_aio_overrides }}"
+    dest: "{{ socok8s_workspace }}/inventory/{{ groupname_for_inventory }}.yml"
+  vars:
+    soc_aio_overrides: |
+      {{ groupname_for_inventory }}:
+        hosts:
+          {{ servername }}:
+            ansible_host: {{ floating_ip }}
+
+- meta: refresh_inventory
+
+- name: Get pubkey, and add it to known hosts
+  command: "ssh-keyscan -H {{ floating_ip | quote }}"
+  changed_when: false
+  register: _floatingkey
+  retries: 20
+  delay: 10
+  until: _floatingkey.stdout and _floatingkey.stdout.strip()
+
+- name: Insert known host
+  known_hosts:
+    state: present
+    name: "{{ floating_ip }}"
+    key: "{{ _floatingkey.stdout }}"

--- a/playbooks/roles/handle-nodes-on-openstack/tasks/delete_on_openstack.yml
+++ b/playbooks/roles/handle-nodes-on-openstack/tasks/delete_on_openstack.yml
@@ -1,0 +1,27 @@
+---
+- name: Delete server
+  os_server:
+    cloud: "{{ deploy_on_openstack_cloudname }}"
+    delete_fip: yes
+    name: "{{ servername }}"
+    state: absent
+    timeout: 300
+
+- name: Delete volume
+  os_volume:
+    cloud: "{{ deploy_on_openstack_cloudname }}"
+    display_name: "{{ servername }}-vol"
+    state: "absent"
+
+# Looping will avoid the need to create a condition if no hosts
+# exists in the inventory.
+- name: Remove all hosts from this group known hosts
+  known_hosts:
+    state: absent
+    name: "{{ hostvars[item]['ansible_host'] }}"
+  loop: "{{ groups[groupname_for_inventory] }}"
+
+- name: Delete inventory
+  file:
+    state: absent
+    path: "{{ socok8s_workspace }}/inventory/{{ groupname_for_inventory }}.yml"

--- a/playbooks/roles/handle-nodes-on-openstack/tasks/main.yml
+++ b/playbooks/roles/handle-nodes-on-openstack/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Load vars
+  include_vars: "{{ item }}"
+  loop:
+    - "{{ playbook_dir }}/../vars/common-vars.yml"
+    - "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+
+- name: Create servers on openstack clouds
+  include_tasks: create_on_openstack.yml
+  when:
+    - "not ( (delete | default(False)) | bool )"
+
+- name: Delete servers on openstack clouds
+  include_tasks: delete_on_openstack.yml
+  when:
+    - "( (delete | default(False)) | bool )"

--- a/playbooks/roles/handle-nodes-on-openstack/tasks/main.yml
+++ b/playbooks/roles/handle-nodes-on-openstack/tasks/main.yml
@@ -5,6 +5,10 @@
     - "{{ playbook_dir }}/../vars/common-vars.yml"
     - "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
 
+- name: Define servername based on runtime
+  set_fact:
+    servername: "{{ deploy_on_openstack_prefix }}-{{ servername_suffix }}"
+
 - name: Create servers on openstack clouds
   include_tasks: create_on_openstack.yml
   when:

--- a/playbooks/roles/ses-osh/tasks/main.yml
+++ b/playbooks/roles/ses-osh/tasks/main.yml
@@ -9,7 +9,7 @@
     content: "{{ item.content | b64decode }}"
     mode: 0644
   with_items:
-    - "{{ hostvars[groups['ses_nodes'][0]].ceph_files.results }}"
+    - "{{ hostvars[inventory_hostname].ceph_files.results }}"
 
 - name: Fetch client cinder key for ses-config.yml
   delegate_to: localhost

--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -9,13 +9,18 @@ check_openstack_env_vars_set (){
         echo "No KEYNAME given. You must give an openstack security keypair name to add to your server. Please export KEYNAME='<name of your keypair>'." && exit 1
     fi
 
-    if [ -z ${PREFIX+x} ]; then
-        echo "No PREFIX given. export PREFIX to match your network. It will be used as network and server names" && exit 1
+    if [ -z ${INTERNAL_NETWORK+x} ]; then
+        echo "No INTERNAL_NETWORK given. export INTERNAL_NETWORK to match your network. It will be used as network and server names" && exit 1
     fi
 
     if [ -z ${INTERNAL_SUBNET+x} ];
     then
         echo "INTERNAL_SUBNET name not given. export INTERNAL_SUBNET=..." && exit 1
+    fi
+
+    if [ -z ${EXTERNAL_NETWORK+x} ]; then
+        echo "No EXTERNAL_NETWORK given. Using 'floating'."
+        export EXTERNAL_NETWORK="floating"
     fi
 }
 
@@ -25,7 +30,7 @@ check_openstack_environment_is_ready_for_deploy (){
     which openstack > /dev/null  || (echo "Please install openstack and heat CLI in your PATH"; exit 5)
     openstack stack delete --help > /dev/null || (echo "Please install heat client in your PATH"; exit 6)
     openstack keypair list | grep ${KEYNAME} > /dev/null || (echo "keyname not found. export KEYNAME=" && exit 2)
-    openstack network list | grep "${PREFIX}-net" > /dev/null || (echo "network not found. Make sure a network exist matching ${PREFIX}-net" && exit 3)
+    openstack network list | grep "${INTERNAL_NETWORK}" > /dev/null || (echo "network not found. Make sure a network exist matching ${INTERNAL_NETWORK}" && exit 3)
     openstack subnet list | grep ${INTERNAL_SUBNET} > /dev/null || (echo "subnet not found" && exit 4)
 }
 

--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -9,7 +9,6 @@ deploy_on_openstack_sesnode_server_name: "{{ deploy_on_openstack_prefix }}-ses"
 deploy_on_openstack_sesnode_image: "SLES12-SP3"
 deploy_on_openstack_sesnode_flavor: "m1.large"
 deploy_on_openstack_sesnode_securitygroup: "all-incoming"
-deploy_on_openstack_sesnode_volume_name: "{{ deploy_on_openstack_prefix }}-vol"
 deploy_on_openstack_repos_to_configure:
   SLE12SP3-product: http://provo-clouddata.cloud.suse.de/repos/x86_64/SLES12-SP3-Pool/
   SLE12SP3-update: http://provo-clouddata.cloud.suse.de/repos/x86_64/SLES12-SP3-Updates/
@@ -57,7 +56,6 @@ deploy_on_openstack_oshnode_server_name: "{{ deploy_on_openstack_prefix }}-soc-d
 deploy_on_openstack_oshnode_image: "openSUSE-Leap-15.0"
 deploy_on_openstack_oshnode_flavor: "m1.large"
 deploy_on_openstack_oshnode_securitygroup: "all-incoming"
-deploy_on_openstack_oshnode_volume_name: "{{ deploy_on_openstack_oshnode_server_name }}-vol"
 deploy_on_openstack_oshnode_userdata: |
   {%- raw -%}#cloud-config
   disable_root: false

--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -1,11 +1,13 @@
 ---
 deploy_on_openstack_cloudname: "{{ lookup('env','OS_CLOUD') | default('engcloud-cloud-ci', true) }}"
-deploy_on_openstack_prefix: "{{ lookup('env','PREFIX') }}" #PREFIX is set at all times (ensured in script library)
-deploy_on_openstack_external_network: "floating"
-deploy_on_openstack_internal_network: "{{ deploy_on_openstack_prefix }}-net"
-deploy_on_openstack_internal_subnet: "{{ deploy_on_openstack_prefix }}-subnet"
+# PREFIX must be unique per environment.
+# If you want to deploy two environments on the same network,
+# make sure PREFIX is defined for your environment before running run.sh
+deploy_on_openstack_prefix: "{{ lookup('env','PREFIX') | default('socok8s', true) }}"
+deploy_on_openstack_external_network: "{{ lookup('env', 'EXTERNAL_NETWORK') | default('floating', true) }}"
+deploy_on_openstack_internal_network: "{{ lookup('env','INTERNAL_NETWORK') | default('ccpci-net', true) }}"
+deploy_on_openstack_internal_subnet: "{{ lookup('env', 'INTERNAL_SUBNET') | default('ccpci-subnet', true) }}"
 deploy_on_openstack_keypairname: "{{ lookup('env','KEYNAME') }}"
-deploy_on_openstack_sesnode_server_name: "{{ deploy_on_openstack_prefix }}-ses"
 deploy_on_openstack_sesnode_image: "SLES12-SP3"
 deploy_on_openstack_sesnode_flavor: "m1.large"
 deploy_on_openstack_sesnode_securitygroup: "all-incoming"
@@ -52,7 +54,6 @@ deploy_on_openstack_caasp_image: "caasp-3.0.0-GM-OpenStack-qcow"
 deploy_on_openstack_caasp_workers: 3
 deploy_on_openstack_caasp_securitygroup: "{{ deploy_on_openstack_sesnode_securitygroup }}"
 deploy_on_openstack_caasp_stacknamefile: "{{ socok8s_workspace }}/stackname"
-deploy_on_openstack_oshnode_server_name: "{{ deploy_on_openstack_prefix }}-soc-deployer"
 deploy_on_openstack_oshnode_image: "openSUSE-Leap-15.0"
 deploy_on_openstack_oshnode_flavor: "m1.large"
 deploy_on_openstack_oshnode_securitygroup: "all-incoming"


### PR DESCRIPTION


Currently servernames are non-unique, due to the fact they rely
on PREFIX, which is not unique (only workspace is currently unique).

This is a problem if you are running more than a single environment,
because all the nodes of a same type (for example deployer/ses) will
share the same name if they are on the same network.

This is solved by making sure "PREFIX" becomes a unique variable,
representing each environment.

Because the term "PREFIX" was already used for convenience in terms
of non unique networking, I removed all the reference of derivation
of network from the PREFIX variable.

