### PR TITLE
Fix copy path for pegleg output

### DIFF
--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -72,7 +72,8 @@
 
 - name: Copy site to Shipyard
   become: yes
-  copy:
+  delegate_to: '{{ inventory_hostname }}'
+  synchronize:
     src: '{{ treasuremap_dir }}/{{ pegleg_output }}'
     dest: '{{ upstream_repos_clone_folder }}/airship-shipyard'
   tags:


### PR DESCRIPTION
The pegleg output is generated on the remote host and should be copied
locally to the host.

The current code works when ansible is run locally on the deployer
node; but if soc-deployer is a remote host, then the pegleg output
generated in the previous task will not be availbe for the copy task.