### PR TITLE
Addressing host variables lookup based on group and index

### DIFF
--- a/playbooks/roles/ses-osh/tasks/main.yml
+++ b/playbooks/roles/ses-osh/tasks/main.yml
@@ -9,7 +9,7 @@
     content: "{{ item.content | b64decode }}"
     mode: 0644
   with_items:
-    - "{{ hostvars['ses-aio'].ceph_files.results }}"
+    - "{{ hostvars[groups['ses_nodes'][0]].ceph_files.results }}"
 
 - name: Fetch client cinder key for ses-config.yml
   delegate_to: localhost


### PR DESCRIPTION
Existing ses-osh role logic looks for variables generated in ses role
based on ses node name. This will work in environment where inventory
file is generated. But in case of existing SES node, node name can be
different from 'ses-aio' as its supposed to be hostname of ses node.

So changing logic to look for group name and then use first host (aio
case) variable to read values. Host group names is something we can
expect user to match but not specific host name.