### PR TITLE
Change to use suse ceph config helper image

### DIFF
--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -64,6 +64,8 @@ data:
         cinder_volume: "{{ suse_osh_registry_location }}/openstackhelm/cinder:{{ suse_openstack_image_version }}"
         cinder_volume_usage_audit: "{{ suse_osh_registry_location }}/openstackhelm/cinder:{{ suse_openstack_image_version }}"
         cinder_backup: "{{ suse_osh_registry_location }}/openstackhelm/cinder:{{ suse_openstack_image_version }}"
+        cinder_storage_init: "{{ suse_osh_registry_location }}/openstackhelm/ceph-config-helper:{{ suse_infra_image_version }}"
+        cinder_backup_storage_init: "{{ suse_osh_registry_location }}/openstackhelm/ceph-config-helper:{{ suse_infra_image_version }}"
       glance:
         glance_db_sync: "{{ suse_osh_registry_location }}/openstackhelm/glance:{{ suse_openstack_image_version }}"
         db_init: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
@@ -75,6 +77,7 @@ data:
         glance_registry: "{{ suse_osh_registry_location }}/openstackhelm/glance:{{ suse_openstack_image_version }}"
         # Bootstrap image requires curl
         bootstrap: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        glance_storage_init: "{{ suse_osh_registry_location }}/openstackhelm/ceph-config-helper:{{ suse_infra_image_version }}"
       heat:
         bootstrap: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
         db_init: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
@@ -156,6 +159,7 @@ data:
         # as it has both oscli and jq.
         nova_spiceproxy: "{{ suse_osh_registry_location }}/openstackhelm/nova:{{ suse_osh_image_version }}"
         nova_spiceproxy_assets: "{{ suse_osh_registry_location }}/kolla/ubuntu-source-nova-spicehtml5proxy:{{ suse_osh_image_version }}"
+        nova_service_cleaner: "{{ suse_osh_registry_location }}/openstackhelm/ceph-config-helper:{{ suse_infra_image_version }}"
       openvswitch:
         openvswitch_db_server: "{{ suse_osh_registry_location }}/openstackhelm/openvswitch:{{ suse_ovs_image_version }}"
         openvswitch_vswitchd: "{{ suse_osh_registry_location }}/openstackhelm/openvswitch:{{ suse_ovs_image_version }}"


### PR DESCRIPTION
Changed to use suse ceph config helper image in Cinder, Glance and Nova