### PR TITLE
Add tempest deployment to deploy_osh

### DIFF
--- a/playbooks/roles/deploy-osh/defaults/main.yml
+++ b/playbooks/roles/deploy-osh/defaults/main.yml
@@ -104,3 +104,7 @@ suse_osh_deploy_nova_yaml_overrides: {}
 suse_osh_deploy_ovs_yaml_overrides: {}
 suse_osh_deploy_rabbitmq_yaml_overrides: {}
 suse_osh_deploy_neutron_yaml_overrides: {}
+suse_osh_deploy_tempest_yaml_overrides: {}
+
+# override in your extravars to deploy and run tempest
+deploy_tempest: False

--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -428,3 +428,20 @@
   tags:
     - barbican
     - run
+
+- name: Deploy Tempest
+  import_tasks: component-install.yml
+  vars:
+    _component_runcommand: "./tools/deployment/multinode/900-tempest.sh"
+    _component_run_env:
+      OSH_EXTRA_HELM_ARGS_TEMPEST: >
+        --values=/tmp/socok8s-susedefaults-tempest.yaml
+        --values=/tmp/socok8s-useroverrides-tempest.yaml
+        {{ lookup('env', 'OSH_EXTRA_HELM_ARGS_TEMPEST') | default('', True) }}
+    _component_overrides:
+      - suse_file: tempest.yaml
+        user_overrides: "{{ suse_osh_deploy_tempest_yaml_overrides }}"
+  tags:
+    - tempest
+    - run
+  when: deploy_tempest

--- a/playbooks/roles/deploy-osh/templates/tempest.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/tempest.yaml.j2
@@ -1,0 +1,4 @@
+images:
+  tags:
+    tempest_run_tests: "{{ suse_osh_registry_location }}/openstackhelm/tempest:{{ suse_infra_image_version }}"
+    ks_user: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"


### PR DESCRIPTION
Deploys tempest as part of the deploy_osh playbook to run tempest
tests in the deployment

Uses the var `deploy_tempest` to enable or disable the deployment of tempest

requires:
- [x] Add tempest suse image and zuul job  -> https://review.openstack.org/#/c/650933/
- [x] Fix configmap-etc values for tempest -> https://review.openstack.org/#/c/650948/
- [x] Fix tempest test script -> https://review.openstack.org/#/c/652700/
- [x] Fix some tempest values -> https://review.openstack.org/653425
- [x] Overrides in our side for the image once its available upstream - Not needed
- [x] Overrides in our side for the tempest script for rocky (tempest init && tempest run --smoke) - Not needed
- [x] Overrides in our side for `conf -> tempest -> identity -> admin_domain_scope: false` (Seems like our admin user has no domain scope?)*
- [x] EXTRA: Add logging.conf to tempest -> https://review.openstack.org/#/c/652963/ - not needed but useful for log clarity

*This may come as a side effect of using the ubuntu xenial image for testing, it may be a tempest version issue, will retest once we have the suse images up. May be also needed upstream