### PR TITLE
Add a connection timeout to the OSH node reboot

### DIFF
--- a/playbooks/openstack-osh_hostconfig.yml
+++ b/playbooks/openstack-osh_hostconfig.yml
@@ -58,6 +58,7 @@
     - name: Reboot host
       reboot:
         reboot_timeout: 900
+        connect_timeout: 90
 
     - name: Store facts
       setup:


### PR DESCRIPTION
Similar to 996668b0bc370894499bf40864cda2ea191a3d28 occasionally the
playbooks would timeout rebooting the OSH node. Refreshing the
connection allows ansible to pick up when the host has rebooted.