### PR TITLE
Remove rocky specific changes to neutron from our side

### DIFF
--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -388,6 +388,7 @@
         --values=/tmp/socok8s-susedefaults-neutron.yaml
         --values=/tmp/socok8s-useroverrides-neutron.yaml
         {{ lookup('env', 'OSH_EXTRA_HELM_ARGS_NEUTRON') | default('', True) }}
+      OSH_OPENSTACK_RELEASE: "rocky"
       OSH_EXTRA_HELM_ARGS_NOVA: >
         --values=/tmp/socok8s-susedefaults-nova.yaml
         --values=/tmp/socok8s-useroverrides-nova.yaml

--- a/playbooks/roles/deploy-osh/templates/neutron.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/neutron.yaml.j2
@@ -1,10 +1,3 @@
-{% if developer_mode %}
-conf:
-  # api-paste entrypoint neutron.api.versions:Versions.factory was deprecated in Queens
-  # We must replace it for Rocky deployments
-  paste:
-    app:neutronversions:
-      paste.app_factory: neutron.pecan_wsgi.app:versions_factory
 images:
   tags:
     bootstrap: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
@@ -20,4 +13,3 @@ images:
     neutron_metadata: "{{ suse_osh_registry_location }}/openstackhelm/neutron:{{ suse_openstack_image_version }}"
     neutron_openvswitch_agent: "{{ suse_osh_registry_location }}/openstackhelm/neutron:{{ suse_openstack_image_version }}"
     neutron_server: "{{ suse_osh_registry_location }}/openstackhelm/neutron:{{ suse_openstack_image_version }}"
-{%  endif %}


### PR DESCRIPTION
With https://review.openstack.org/#/c/651250/ they are available
upstream, we only need to pass openstack release version to the
helm deploy script.