### PR TITLE
Use local storage for SES and deployer nodes

### DIFF
--- a/playbooks/openstack-ses_aio_instance.yml
+++ b/playbooks/openstack-ses_aio_instance.yml
@@ -17,5 +17,6 @@
         network: "{{ deploy_on_openstack_internal_network }}"
         securitygroups:
           - "{{ deploy_on_openstack_sesnode_securitygroup }}"
+        userdata: "{{ deploy_on_openstack_sesnode_userdata }}"
         groupname_for_inventory: "ses_nodes"
         delete: "{{ ((ses_node_delete | default('False')) | bool) }}"

--- a/playbooks/roles/handle-nodes-on-openstack/tasks/create_on_openstack.yml
+++ b/playbooks/roles/handle-nodes-on-openstack/tasks/create_on_openstack.yml
@@ -1,11 +1,4 @@
 ---
-- name: Create volume
-  os_volume:
-    cloud: "{{ deploy_on_openstack_cloudname }}"
-    display_name: "{{ servername }}-vol"
-    size: 80
-    state: "present"
-
 - name: Create server
   os_server:
     cloud: "{{ deploy_on_openstack_cloudname }}"
@@ -18,8 +11,6 @@
     auto_ip: True
     state: present
     timeout: 300
-    volumes:
-      - "{{ servername }}-vol"
     userdata: "{{ userdata | default(omit) }}"
   register: _server_create
 

--- a/playbooks/roles/handle-nodes-on-openstack/tasks/delete_on_openstack.yml
+++ b/playbooks/roles/handle-nodes-on-openstack/tasks/delete_on_openstack.yml
@@ -7,12 +7,6 @@
     state: absent
     timeout: 300
 
-- name: Delete volume
-  os_volume:
-    cloud: "{{ deploy_on_openstack_cloudname }}"
-    display_name: "{{ servername }}-vol"
-    state: "absent"
-
 # Looping will avoid the need to create a condition if no hosts
 # exists in the inventory.
 - name: Remove all hosts from this group known hosts

--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -9,8 +9,14 @@ deploy_on_openstack_internal_network: "{{ lookup('env','INTERNAL_NETWORK') | def
 deploy_on_openstack_internal_subnet: "{{ lookup('env', 'INTERNAL_SUBNET') | default('ccpci-subnet', true) }}"
 deploy_on_openstack_keypairname: "{{ lookup('env','KEYNAME') }}"
 deploy_on_openstack_sesnode_image: "SLES12-SP3"
-deploy_on_openstack_sesnode_flavor: "m1.large"
+deploy_on_openstack_sesnode_flavor: "d4.xlarge"
 deploy_on_openstack_sesnode_securitygroup: "all-incoming"
+# Userdata to prevent the ephemeral disk being mounted by cloud-init
+deploy_on_openstack_sesnode_userdata: |
+  {%- raw -%}#cloud-config
+  mounts:
+    - [ ephemeral0, null ]
+  {% endraw %}
 deploy_on_openstack_repos_to_configure:
   SLE12SP3-product: http://provo-clouddata.cloud.suse.de/repos/x86_64/SLES12-SP3-Pool/
   SLE12SP3-update: http://provo-clouddata.cloud.suse.de/repos/x86_64/SLES12-SP3-Updates/


### PR DESCRIPTION
Up to now the SES and the soc-deployer instances were creating cinder
volumes for their addtional disk. This commit switches them to use local
storage. Which should avoid some overhead that running ceph-osds on top
of ceph-volumes introduced. Additionally it makes the
"handle-nodes-on-openstack" role a little simpler, as we don't need to
worry about volumes anymore.

For the SES node we're switching to a flavor that provides an ephemeral
disk and inject user-data that avoids mounting that disk so it can be
used by the SES deployment scripts later on.

For the soc-deployer this isn't much of a change since it wasn't using
the cinder volume anyways.