### PR TITLE
Add new test_plugin for openstack preflight

### DIFF
--- a/playbooks/openstack-osh_instance.yml
+++ b/playbooks/openstack-osh_instance.yml
@@ -8,6 +8,7 @@
       loop:
         - "{{ playbook_dir }}/../vars/common-vars.yml"
         - "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+
   roles:
     - role: handle-nodes-on-openstack
       vars:

--- a/playbooks/openstack-preflight_caasp.yml
+++ b/playbooks/openstack-preflight_caasp.yml
@@ -1,0 +1,21 @@
+---
+- hosts: localhost
+  gather_facts: no
+  connection: local
+  vars:
+    stackname_suffix: "caasp"
+  tasks:
+    - name: Load generic vars
+      include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
+    - name: Load openstack vars
+      include_vars: "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+
+    - name: _openstack_preflight_caasp | Verify Caasp Image exists
+      fail:
+        msg: "Could not find Image '{{deploy_on_openstack_caasp_image}}'"
+      when: not deploy_on_openstack_caasp_image is os_check_image
+
+    - name: _openstack_preflight_caasp | Verify security group exists
+      fail:
+       msg: "Could not find Security Group '{{deploy_on_openstack_caasp_securitygroup}}'"
+      when: not deploy_on_openstack_caasp_securitygroup is os_check_security_group

--- a/playbooks/openstack-preflight_osh.yml
+++ b/playbooks/openstack-preflight_osh.yml
@@ -1,0 +1,37 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Playbook to verify that required resources are in the OpenStack
+# Cloud
+
+---
+- hosts: localhost
+  gather_facts: no
+  connection: local
+  tasks:
+    - name: Load generic vars
+      include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
+    - name: Load openstack vars
+      include_vars: "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+
+    - name: _openstack_preflight_osh | Verify OSH Image exists
+      fail:
+        msg: "Could not find Image '{{deploy_on_openstack_oshnode_image}}'"
+      when: not deploy_on_openstack_oshnode_image is os_check_image
+
+    - name: _openstack_preflight_osh | Verify security group exists
+      fail:
+        msg: "Could not find Security Group '{{deploy_on_openstack_oshnode_securitygroup}}'"
+      when: not deploy_on_openstack_oshnode_securitygroup is os_check_security_group

--- a/playbooks/openstack-preflight_ses.yml
+++ b/playbooks/openstack-preflight_ses.yml
@@ -1,0 +1,37 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Playbook to verify that required resources are in the OpenStack
+# Cloud
+
+---
+- hosts: localhost
+  gather_facts: no
+  connection: local
+  tasks:
+    - name: Load generic vars
+      include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
+    - name: Load openstack vars
+      include_vars: "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+
+    - name: _openstack_preflight_ses | Verify SES Image exists
+      fail:
+        msg: "Could not find Image '{{deploy_on_openstack_sesnode_image}}'"
+      when: not deploy_on_openstack_sesnode_image is os_check_image
+
+    - name: _openstack_preflight_ses | Verify security group exists
+      fail:
+        msg: "Could not find Security Group '{{deploy_on_openstack_sesnode_securitygroup}}'"
+      when: not deploy_on_openstack_sesnode_securitygroup is os_check_security_group

--- a/playbooks/openstack-ses_aio_instance.yml
+++ b/playbooks/openstack-ses_aio_instance.yml
@@ -8,6 +8,7 @@
       loop:
         - "{{ playbook_dir }}/../vars/common-vars.yml"
         - "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+
   roles:
     - role: handle-nodes-on-openstack
       vars:

--- a/playbooks/test_plugins/openstack-preflight.py
+++ b/playbooks/test_plugins/openstack-preflight.py
@@ -1,0 +1,95 @@
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Load a "packages" manifest from a directory; cache these
+# by default.
+
+# Given such a dictionary, locate the latest version of a
+# named package.
+"""
+
+A collection of filters to ensure that certain resources exist
+in an OpenStack deployment.  This is helpful for letting users
+know that images, networks, etc are missing prior to trying to
+deploy vms against those images, networks.
+
+"""
+
+import os
+
+from ansible.utils.display import Display
+import openstack
+from openstack.config import loader
+
+display = Display()
+CLOUD = os.getenv('OS_CLOUD', 'devstack')
+# openstack.enable_logging(True, stream=sys.stdout)
+
+
+def create_connection_from_config():
+    #: Defines the OpenStack Config cloud key in your config file,
+    #: typically in $HOME/.config/openstack/clouds.yaml. That configuration
+    loader.OpenStackConfig()
+    return openstack.connect(cloud=CLOUD)
+
+
+def os_check_image(image_name):
+    cloud = create_connection_from_config()
+    found = False
+    for img in cloud.image.images():
+        if img.name == image_name:
+            found = True
+            break
+    return found
+
+
+def os_check_security_group(group_name):
+    cloud = create_connection_from_config()
+    found = False
+    for sc in cloud.network.security_groups():
+        if sc.name == group_name:
+            found = True
+            break
+
+    return found
+
+
+def os_check_network(net_name):
+    cloud = create_connection_from_config()
+    found = False
+    for net in cloud.network.networks():
+        if net.name == net_name:
+            found = True
+            break
+
+    return found
+
+
+def os_check_subnet(net_name):
+    cloud = create_connection_from_config()
+    found = False
+    for net in cloud.network.subnets():
+        if net.name == net_name:
+            found = True
+            break
+
+    return found
+
+
+class TestModule(object):
+    def tests(self):
+        return {'os_check_image': os_check_image,
+                'os_check_network': os_check_network,
+                'os_check_subnet': os_check_subnet,
+                'os_check_security_group': os_check_security_group}

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -17,12 +17,16 @@ function deploy_network(){
 }
 function deploy_ses(){
     source ${scripts_absolute_dir}/pre-flight-checks.sh check_openstack_environment_is_ready_for_deploy
+    echo "Preflight openstack required resources"
+    run_ansible ${socok8s_absolute_dir}/playbooks/openstack-preflight_ses.yml
     echo "Starting a SES deploy"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-deploy_ses.yml
     echo "ses-ansible deploy is successful"
 }
 function deploy_caasp(){
     source ${scripts_absolute_dir}/pre-flight-checks.sh check_openstack_environment_is_ready_for_deploy
+    echo "Preflight openstack required resources"
+    run_ansible ${socok8s_absolute_dir}/playbooks/openstack-preflight_caasp.yml
     echo "Starting caasp deploy"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-create_caasp.yml
     echo "CaaSP deployed successfully"
@@ -51,6 +55,8 @@ function setup_caasp_workers_for_openstack(){
     run_ansible ${socok8s_absolute_dir}/playbooks/generic-setup_caasp_workers_for_openstack.yml
 }
 function deploy_osh(){
+    echo "Preflight openstack required resources"
+    run_ansible ${socok8s_absolute_dir}/playbooks/openstack-preflight_osh.yml
     echo "Now deploy SUSE version of OSH"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-deploy_osh.yml
 }


### PR DESCRIPTION
    This patch adds a new test_plugins directory
    and a test plugin called openstack-preflight.py
    that adds some test for making sure images, networks
    security groups are available against the configured
    openstack deployment.

    the test plugin adds the following tests
    os_check_image - check to see if an image is available on OpenStack
    os_check_network - check to see if a network is defined on OpenStack
    os_check_subnet - check to see if an subnet is defined on OpenStack
    os_check_security_group - check to see if a security group is defined on OpenStack

    Example usage:

    - name: test to make sure my image is available
      fail:
       msg: "Failed to find {{my_image}} on OpenStack
      when: not my_image is os_check_image

    This also adds ansible native tests for caasp, ses, osh
    deployments to ensure their required images and security groups
    are in place.  The failure messages provide detail about what's
    missing.