### PR TITLE
Fix for upstream repo shuffling

### DIFF
--- a/playbooks/roles/dev-patcher/defaults/main.yml
+++ b/playbooks/roles/dev-patcher/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-dev_patcher_baseurl: "https://review.openstack.org/changes"
+dev_patcher_baseurl: "https://review.opendev.org/changes"
 
 dev_patcher_packages:
   - git

--- a/playbooks/roles/dev-patcher/tasks/main.yml
+++ b/playbooks/roles/dev-patcher/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: Clone upstream repositories for patching
   git:
     repo: "{{ item.value.src }}"
-    dest: "{{ upstream_repos_clone_folder }}/{{ item.key }}"
+    dest: "{{ upstream_repos_clone_folder }}/{{ item.value.dest_subdir }}/{{ item.key }}"
     update: yes
     force: yes
     version: "{{ item.value.version }}"

--- a/playbooks/roles/dev-patcher/tasks/patch-repos.yml
+++ b/playbooks/roles/dev-patcher/tasks/patch-repos.yml
@@ -22,7 +22,7 @@
     chdir: "{{ upstream_repos_clone_folder }}/{{ project }}"
   vars:
     current_revision: "{{ jsoncontent[0]['current_revision'] }}"
-    project: "{{ jsoncontent[0]['project'].replace('openstack/','') }}"
+    project: "{{ jsoncontent[0]['project'] }}"
   when:
     # Do not apply patches if they are already merged
     - "jsoncontent | length > 0"

--- a/vars/manifest.yml
+++ b/vars/manifest.yml
@@ -3,27 +3,36 @@ upstream_repos:
   openstack-helm-infra:
     src: https://git.openstack.org/openstack/openstack-helm-infra
     version: master
+    dest_subdir: openstack
   openstack-helm:
     src: https://git.openstack.org/openstack/openstack-helm
     version: master
+    dest_subdir: openstack
   openstack-helm-images:
     src: https://github.com/openstack/openstack-helm-images
     version: master
+    dest_subdir: openstack
   loci:
     src: https://github.com/openstack/loci
     version: master
-  airship-armada:
-    src: https://github.com/openstack/airship-armada
+    dest_subdir: openstack
+  armada:
+    src: https://opendev.org/airship/armada
     version: master
-  airship-shipyard:
-    src: https://github.com/openstack/airship-shipyard
+    dest_subdir: airship
+  shipyard:
+    src: https://opendev.org/airship/shipyard
     version: master
-  airship-deckhand:
-    src: https://github.com/openstack/airship-deckhand
+    dest_subdir: airship
+  deckhand:
+    src: https://opendev.org/airship/deckhand
     version: master
-  airship-pegleg:
-    src: https://github.com/openstack/airship-pegleg
+    dest_subdir: airship
+  pegleg:
+    src: https://opendev.org/airship/pegleg
     version: master
-  airship-treasuremap:
-    src: https://github.com/openstack/airship-treasuremap
+    dest_subdir: airship
+  treasuremap:
+    src: https://opendev.org/airship/treasuremap
     version: master
+    dest_subdir: airship


### PR DESCRIPTION
Moved cloning of repo to project specific directory (openstack vs
airship).
And now patches are also applied following same structure.