### PR TITLE
Add Nova metadata shared secret manifest

### DIFF
--- a/site/soc/secrets/passphrases/osh_nova_metadata_proxy_shared_secret.yaml
+++ b/site/soc/secrets/passphrases/osh_nova_metadata_proxy_shared_secret.yaml
@@ -1,0 +1,11 @@
+---
+schema: deckhand/Passphrase/v1
+metadata:
+  schema: metadata/Document/v1
+  name: osh_nova_metadata_proxy_shared_secret
+  layeringDefinition:
+    abstract: false
+    layer: site
+  storagePolicy: cleartext
+data: {{ lookup('password', secrets_location + '/osh_nova_metadata_proxy_shared_secret ' + password_opts) }}
+...


### PR DESCRIPTION
Added soc site  Nova metadata shared secret manifest as it is now required by Nova global chart
