### PR TITLE
Add env var SOCOK8S_ENVNAME as unique name

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -100,3 +100,11 @@ htmlhelp_basename = '%sdoc' % project
 
 # Example configuration for intersphinx: refer to the Python standard library.
 #intersphinx_mapping = {'http://docs.python.org/': None}
+
+
+# A string of reStructuredText that will be included at the beginning of
+# every source file that is read.
+rst_prolog = """
+.. |socok8s_envname_default| replace:: socok8s
+.. |socok8s_workspace_default| replace:: ~/|socok8s_envname_default|-workspace
+"""

--- a/doc/source/deploy-guide/configure-environment.rst
+++ b/doc/source/deploy-guide/configure-environment.rst
@@ -46,8 +46,9 @@ Configure the deployment
      }
    }
 
-All the files for the deployment are in a **workspace**, whose default location
-is `~/suse-osh-deploy` on `localhost`.
+All the files for the deployment are in a :term:`workspace`, whose default location
+is |socok8s_workspace_default| on `localhost`.
+The default name can be changed via the environment variable `SOCOK8S_ENVNAME`
 
 This workspace is structured like an `ansible-runner` directory.
 

--- a/doc/source/deploy-guide/prepare-localhost.rst
+++ b/doc/source/deploy-guide/prepare-localhost.rst
@@ -70,7 +70,7 @@ release that ansible is using. (e.g. on openSUSE Tumbleweed, Ansible is using
 Python 3, so install the "python3-" variant of the packages)
 
 If those optional software aren't installed, they will be installed in a
-venv in `~/suse-socok8s-deploy/.ansiblevenv`.
+venv in |socok8s_workspace_default|\ `/.ansiblevenv` .
 
 Cloning this repository
 -----------------------
@@ -116,16 +116,17 @@ Enable mitogen (optional)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To improve deployment speed, enable mitogen strategy and connection plugin.
-First install mitogen in your venv (e.g. `~/suse-socok8s-deploy/.ansiblevenv/` or your local
-ansible environment), then enable it using environment variables.
+First install mitogen in your venv (e.g. |socok8s_workspace_default|\ `/.ansiblevenv` 
+or your local ansible environment), then enable it using environment variables.
 
 Alternatively, enable it for all your ansible calls by adding it to your
 ansible configuration:
 
-.. code-block:: console
+.. we need parsed-literal instead of code-block here. Otherwise the variable substitute does not work
+.. parsed-literal::
 
    cat < EOF >> ~/.ansible.cfg
-   strategy_plugins=${HOME}/suse-socok8s-deploy/.ansiblevenv/lib/python3.6/site-packages/ansible_mitogen/plugins/strategy
+   strategy_plugins=${HOME}\ |socok8s_workspace_default|\ /.ansiblevenv/lib/python3.6/site-packages/ansible_mitogen/plugins/strategy
    strategy = mitogen_linear
    EOF
 
@@ -145,6 +146,20 @@ You might want to improve SSH connections by enabling pipelining:
    EOF
 
 .. _deploymechanism:
+
+Defining a workspace
+--------------------
+
+`socok8s` might create a :term:`workspace`, install things (eg. ansible in a virtualenv) 
+or create resources (eg. OpenStack Heat stacks if the deployment mechanism is `openstack`).
+For all of theses operations, a environment variable called `SOCOK8S_ENVNAME`
+needs to be set. This variable must be unique if multiple environments are
+installed in parallel.
+
+.. code-block:: console
+
+   export SOCOK8S_ENVNAME='foctodoodle'
+
 
 Set a deployment mechanism
 --------------------------

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -8,3 +8,9 @@ Glossary
 
    SES
      SUSE Enterprise Storage
+
+   workspace
+     A directory (by default |socok8s_workspace_default| ) that is structured like an `ansible-runner`
+     directory.
+     The default workspace directory can be changed by setting the environment
+     variable `SOCOK8S_ENVNAME`. The workspace directory name is always `${SOCOK8S_ENVNAME}-workspace`.

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -48,7 +48,7 @@ Design considerations
 
 In order to not pollute the developer/CI machine (called `localhost`),
 all the data relevant for a deployment (like any eventual override) is stored
-in a user-space `ANSIBLE_RUNNER_DIR` folder, with unprivileged access.
+in a user-space |socok8s_workspace_default| folder, with unprivileged access.
 
 This also helps the story of running behind
 a corporate firewall: the `localhost` can be (connecting to)

--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,10 @@ socok8s_absolute_dir="$( cd "$(dirname "$0")" ; pwd -P )"
 # by default, ccp will deploy on openstack for inception style fun (and CI).
 DEPLOYMENT_MECHANISM=${DEPLOYMENT_MECHANISM:-"openstack"}
 
+# The base directory where workspace(s) are created in
+SOCOK8S_WORKSPACE_BASEDIR=${SOCOK8S_WORKSPACE_BASEDIR:-~}
+
+source ${scripts_absolute_dir}/pre-flight-checks.sh check_common_env_vars_set
 source ${scripts_absolute_dir}/bootstrap-ansible-if-necessary.sh
 source ${scripts_absolute_dir}/pre-flight-checks.sh check_jq_present
 source ${scripts_absolute_dir}/pre-flight-checks.sh check_ansible_requirements

--- a/script_library/bootstrap-ansible-if-necessary.sh
+++ b/script_library/bootstrap-ansible-if-necessary.sh
@@ -6,13 +6,12 @@ set -e
 # is packaged for all the distributions.
 
 function install_ansible (){
-    if [[ -z ${ANSIBLE_RUNNER_DIR:-} ]]; then
-        ANSIBLE_RUNNER_DIR=~/suse-socok8s-deploy
+    # NOTE(toabctl): ${SOCOK8S_WORKSPACE_BASEDIR} and ${SOCOK8S_ENVNAME} are always set
+    local socok8s_workspace=${SOCOK8S_WORKSPACE_BASEDIR}/${SOCOK8S_ENVNAME}-workspace
+    if [[ ! -d ${socok8s_workspace}/.ansiblevenv/ ]]; then
+        virtualenv ${socok8s_workspace}/.ansiblevenv/
     fi
-    if [[ ! -d ${ANSIBLE_RUNNER_DIR}/.ansiblevenv/ ]]; then
-        virtualenv ${ANSIBLE_RUNNER_DIR}/.ansiblevenv/
-    fi
-    source ${ANSIBLE_RUNNER_DIR}/.ansiblevenv/bin/activate
+    source ${socok8s_workspace}/.ansiblevenv/bin/activate
     pip install --upgrade -r $(dirname "$0")/script_library/requirements.txt
-    python -m ara.setup.env > ${ANSIBLE_RUNNER_DIR}/.ansiblevenv/ara.rc
+    python -m ara.setup.env > ${socok8s_workspace}/.ansiblevenv/ara.rc
 }

--- a/script_library/clean-airship.sh
+++ b/script_library/clean-airship.sh
@@ -108,7 +108,7 @@ fi
 
 if [[ ${clean_action} == *"clean_ucp"* ]]; then
     sudo rm -rf /opt/airship
-    sudo rm -rf ${ANSIBLE_RUNNER_DIR}/secrets
+    sudo rm -rf ${SOCOK8S_WORKSPACE_BASEDIR}/${SOCOK8S_ENVNAME}-workspace/secrets
 fi
 
 if [[ ${clean_action} == *"clean_openstack"* ]]; then

--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+check_common_env_vars_set (){
+    # basic checks that are needed for everything else!
+    if [ -z ${SOCOK8S_ENVNAME+x} ]; then
+        echo "No SOCOK8S_ENVNAME given. export SOCOK8S_ENVNAME=... for setting a env name" && exit 1
+    fi
+    # NOTE(toabctl): SOCOK8S_WORKSPACE_BASEDIR is always set in run.sh
+    if [ -z ${SOCOK8S_WORKSPACE_BASEDIR+x} ]; then
+        echo "No SOCOK8S_WORKSPACE_BASEDIR given. export SOCOK8S_WORKSPACE_BASEDIR=... for setting a directory" && exit 1
+    fi
+
+    echo "Using ${SOCOK8S_WORKSPACE_BASEDIR}/${SOCOK8S_ENVNAME}-workspace as workspace directory"
+}
+
 check_openstack_env_vars_set (){
     if [ -z ${OS_CLOUD+x} ]; then
         echo "No OS_CLOUD given. export OS_CLOUD=... corresponding to your clouds.yaml" && exit 1

--- a/script_library/run-ansible.sh
+++ b/script_library/run-ansible.sh
@@ -4,19 +4,17 @@
 
 function run_ansible(){
     set -x
-    # ansible-runner default locations
-    if [[ -z ${ANSIBLE_RUNNER_DIR+x} ]]; then
-        echo "ANSIBLE_RUNNER_DIR env var is not set, defaulting to '~/suse-socok8s-deploy'"
-        export ANSIBLE_RUNNER_DIR="${HOME}/suse-socok8s-deploy"
-    fi
 
-    extravarsfile=${ANSIBLE_RUNNER_DIR}/env/extravars
-    inventorydir=${ANSIBLE_RUNNER_DIR}/inventory/
+    # NOTE(toabctl): ${SOCOK8S_WORKSPACE_BASEDIR} and ${SOCOK8S_ENVNAME} are always set
+    local socok8s_workspace=${SOCOK8S_WORKSPACE_BASEDIR}/${SOCOK8S_ENVNAME}-workspace
+
+    extravarsfile=${socok8s_workspace}/env/extravars
+    inventorydir=${socok8s_workspace}/inventory/
 
     # This creates a structure that's similar to ansible-runner tool
-    [[ ! -d ${ANSIBLE_RUNNER_DIR}/env ]] && mkdir -p ${ANSIBLE_RUNNER_DIR}/env
-    if [[ ! -d ${ANSIBLE_RUNNER_DIR}/inventory ]]; then
-        mkdir -p ${ANSIBLE_RUNNER_DIR}/inventory
+    [[ ! -d ${socok8s_workspace}/env ]] && mkdir -p ${socok8s_workspace}/env
+    if [[ ! -d ${socok8s_workspace}/inventory ]]; then
+        mkdir -p ${socok8s_workspace}/inventory
         # Ensure default groupnames exist. It also DRY so that we automatically connect on hosts as root.
         # However don't force this by default if people already have an inventory.
         cp ${socok8s_absolute_dir}/examples/workdir/inventory/hosts.yml ${inventorydir}/default-inventory.yml
@@ -29,7 +27,7 @@ function run_ansible(){
 
     if [[ ${USE_ARA:-False} == "True" ]]; then
         echo "Loading ARA"
-        source ${ANSIBLE_RUNNER_DIR}/.ansiblevenv/ara.rc
+        source ${socok8s_workspace}/.ansiblevenv/ara.rc
     fi
 
     pushd ${socok8s_absolute_dir}

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -1,7 +1,12 @@
 ---
+# socok8s_envname is the "unique" variable that is used to create resource names
+socok8s_envname: "{{ lookup('env','SOCOK8S_ENVNAME') | default('socok8s', true) }}"
 upstream_repos_clone_folder: "/opt"
 developer_mode: "{{ (lookup('env','SOCOK8S_DEVELOPER_MODE') | default('False', true) ) | bool }}"
-socok8s_workspace: "{{ lookup('env','ANSIBLE_RUNNER_DIR') | default('~/suse-socok8s-deploy', true) }}"
+# configure the workspace base directory (where workspace(s) are created in)
+socok8s_workspace_basedir: "{{ lookup('env','SOCOK8S_WORKSPACE_BASEDIR') | default('~', true) }}"
+# configure the full path to the current workspace
+socok8s_workspace: "{{ socok8s_workspace_basedir }}/{{ socok8s_envname }}-workspace"
 socok8s_extravars: "{{ socok8s_workspace }}/env/extravars"
 socok8s_ses_pools_details: "{{ socok8s_workspace }}/ses_config.yml"
 socok8s_registry_cert: "{{ socok8s_workspace }}/certs/domain.crt"


### PR DESCRIPTION
For beeing able to deploy multiple environments in parallel, introduce
the unique environment variable SOCOK8S_ENVNAME.
This variable will be used for deriving other resource names like:

- the workspace name (previously ANSIBLE_RUNNER_DIR) where the state
  will be stored
- OpenStack resources (networks/stacks/servers/volumes/...)

Adding this variable makes it easier to collect resources which belong
to a given deployment or workspace.

This commit is just the first step which adds the variable and uses it
for defining the workspace name.

Note: Every deployment must now set SOCOK8S_ENVNAME before running any
steps from run.sh

Note: ANSIBLE_RUNNER_DIR has no longer any effect. The workspace
directory is now constructed via ${SOCOK8S_ENVNAME}-workspace .