### PR TITLE
Kill PREFIX env var and deploy_on_openstack_prefix ansible var

### DIFF
--- a/playbooks/openstack-caasp_instance.yml
+++ b/playbooks/openstack-caasp_instance.yml
@@ -12,7 +12,7 @@
 
     - name: Define stackname to create
       set_fact:
-        stackname: "{{ deploy_on_openstack_prefix }}-{{ stackname_suffix }}"
+        stackname: "{{ socok8s_envname }}-{{ stackname_suffix }}"
 
     - name: Handle creation if not exists
       when:

--- a/playbooks/roles/handle-nodes-on-openstack/tasks/main.yml
+++ b/playbooks/roles/handle-nodes-on-openstack/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Define servername based on runtime
   set_fact:
-    servername: "{{ deploy_on_openstack_prefix }}-{{ servername_suffix }}"
+    servername: "{{ socok8s_envname }}-{{ servername_suffix }}"
 
 - name: Create servers on openstack clouds
   include_tasks: create_on_openstack.yml

--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -1,9 +1,5 @@
 ---
 deploy_on_openstack_cloudname: "{{ lookup('env','OS_CLOUD') | default('engcloud-cloud-ci', true) }}"
-# PREFIX must be unique per environment.
-# If you want to deploy two environments on the same network,
-# make sure PREFIX is defined for your environment before running run.sh
-deploy_on_openstack_prefix: "{{ lookup('env','PREFIX') | default('socok8s', true) }}"
 deploy_on_openstack_external_network: "{{ lookup('env', 'EXTERNAL_NETWORK') | default('floating', true) }}"
 deploy_on_openstack_internal_network: "{{ lookup('env','INTERNAL_NETWORK') | default('ccpci-net', true) }}"
 deploy_on_openstack_internal_subnet: "{{ lookup('env', 'INTERNAL_SUBNET') | default('ccpci-subnet', true) }}"


### PR DESCRIPTION
Commit ba3a49b456 already started to remove the 'PREFIX'
variable. This commit now removes the last reference and also drops
the ansible variable 'deploy_on_openstack_prefix'.
For creating resource names, the ansible variable 'socok8s_envname' is
now used as prefix.