### PR TITLE
caasp: Switch to IBS mirror in Provo for CaaSP repos

### DIFF
--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -22,10 +22,10 @@ deploy_on_openstack_repos_to_configure:
   OpenStack-Cloud8-product: http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-OpenStack-Cloud-8-Pool/
   SES5-product: http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-Enterprise-Storage-5-Pool/
   SES5-update: http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-Enterprise-Storage-5-Updates/
-  SLE12Containers: http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/12/x86_64/update/
+  SLE12Containers: http://ibs-mirror.prv.suse.net/dist/ibs/SUSE/Updates/SLE-Module-Containers/12/x86_64/update/
   Leap15develtools: https://download.opensuse.org/repositories/devel:/tools/openSUSE_Leap_15.0/
-  CAASP30-update: http://dist.nue.suse.com/ibs/SUSE/Updates/SUSE-CAASP/3.0/x86_64/update/
-  CAASP30-pool: http://dist.nue.suse.com/ibs/SUSE/Products/SUSE-CAASP/3.0/x86_64/product/
+  CAASP30-update: http://ibs-mirror.prv.suse.net/dist/ibs/SUSE/Updates/SUSE-CAASP/3.0/x86_64/update/
+  CAASP30-pool: http://ibs-mirror.prv.suse.net/dist/ibs/SUSE/Products/SUSE-CAASP/3.0/x86_64/product/
 deploy_on_openstack_ses_repos_per_imagename:
   SLES12-SP3:
     - SLE12SP3-product


### PR DESCRIPTION
This should speed up the the transcational update of the CaaSP nodes a
bit as we don't need to transfer everything over the slow link accross
the ocean when running in ECP.