### PR TITLE
Change default mechanism for run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,7 @@ socok8s_absolute_dir="$( cd "$(dirname "$0")" ; pwd -P )"
 
 # USE an env var to setup where to deploy to
 # by default, ccp will deploy on openstack for inception style fun (and CI).
-DEPLOYMENT_MECHANISM=${DEPLOYMENT_MECHANISM:-"KVM"}
+DEPLOYMENT_MECHANISM=${DEPLOYMENT_MECHANISM:-"kvm"}
 
 # The base directory where workspace(s) are created in
 SOCOK8S_WORKSPACE_BASEDIR=${SOCOK8S_WORKSPACE_BASEDIR:-~}

--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,7 @@ socok8s_absolute_dir="$( cd "$(dirname "$0")" ; pwd -P )"
 
 # USE an env var to setup where to deploy to
 # by default, ccp will deploy on openstack for inception style fun (and CI).
-DEPLOYMENT_MECHANISM=${DEPLOYMENT_MECHANISM:-"openstack"}
+DEPLOYMENT_MECHANISM=${DEPLOYMENT_MECHANISM:-"KVM"}
 
 # The base directory where workspace(s) are created in
 SOCOK8S_WORKSPACE_BASEDIR=${SOCOK8S_WORKSPACE_BASEDIR:-~}


### PR DESCRIPTION
In preparation of CCP tech preview. we would like to change the default DEPLOYMENT_MECHANISM to be KVM. The default for tech preview is supposed to be bring your own CAASP and SES. This will set the deployment mechanism to skip openstack environment creation.