### PR TITLE
Add a Jenkinsfile for testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,55 @@
+pipeline {
+
+    options {
+        timestamps()
+        timeout(time: 45, unit: 'MINUTES', activity: true)
+    }
+
+    agent {
+        node {
+            label "cloud-ccp-ci"
+        }
+    }
+    environment {
+        /* use lowercase SOCOK8S_ENVNAME. CaaSP Velum doesn't like it otherwise */
+        SOCOK8S_ENVNAME = "cloud-socok8s-${env.BRANCH_NAME.toLowerCase()}-${env.BUILD_NUMBER}"
+        OS_CLOUD = "engcloud-cloud-ci"
+        KEYNAME = "engcloud-cloud-ci"
+        DELETE_ANYWAY = "YES"
+        SOCOK8S_DEVELOPER_MODE = "True"
+        DEPLOYMENT_MECHANISM = "openstack"
+        ANSIBLE_STDOUT_CALLBACK = "yaml"
+    }
+
+    stages {
+        stage('Show environment information') {
+            steps {
+                sh 'printenv'
+            }
+        }
+
+        stage('Deploy everything') {
+            steps {
+                sh "./run.sh"
+            }
+        }
+    }
+
+    post {
+        failure {
+            script {
+                if (env.hold_instance_for_debug == 'true') {
+                    echo "You can reach this node by connecting to its floating IP as root user, with the default password of your image."
+                    timeout(time: 3, unit: 'HOURS') {
+                        input(message: "Waiting for input before deleting  env ${SOCOK8S_ENVNAME}.")
+                    }
+                }
+            }
+        }
+        always {
+            script {
+                sh './run.sh teardown'
+            }
+        }
+    }
+}


### PR DESCRIPTION
The Jenkinsfile will be used for PR testing together with the
github-branch-source[1] plugin.
That plugin does periodically scan the SUSE-Cloud organization and
will create new Jenkins jobs whenever a PR (which must be from
somebody with admin or write access and must contain a Jenkinsfile)
against SUSE-Cloud/socok8s is created.

That way we can also test changes to the Jenkinsfile beside changes to
socok8s itself.

[1] https://go.cloudbees.com/docs/plugins/github-branch-source/