### PR TITLE
Use a non-security alerting ansible version

### DIFF
--- a/script_library/requirements.txt
+++ b/script_library/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.7.5
+ansible==2.7.10
 netaddr==0.7.19
 jmespath==0.9.3
 requests==2.21.0


### PR DESCRIPTION
Not sure why we need to venv this, but at least we should
use a vesrion that doesn't have CVE-2019-3828