### PR TITLE
Added missing test keys to ucp/mariadb.yaml chart

### DIFF
--- a/site/soc/software/charts/ucp/core/mariadb.yaml
+++ b/site/soc/software/charts/ucp/core/mariadb.yaml
@@ -22,6 +22,9 @@ metadata:
 data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
+  test:
+    enabled: {{ run_tests | default('true') }}
+    timeout: {{ test_timeout | default(300) }}
   values:
     pod:
       replicas:


### PR DESCRIPTION
This change is needed so that setting run_tests: false and test_timeout to a custom value will be recognized by the ucp/mariadb chart. Somehow this chart got overlooked when this feature was implemented with an earlier change.