### PR TITLE
Assign floating IPs to caasp workers via the heat stack

### DIFF
--- a/files/caasp-stack-worker.yaml
+++ b/files/caasp-stack-worker.yaml
@@ -16,6 +16,11 @@ parameters:
     description: >
       Name or ID of private network for which the worker will be attached
     default: floating
+  external_net:
+    type: string
+    description: >
+      Name or ID of public network for which floating IP addresses will be allocated
+    default: floating
   secgroup_base:
     type: string
     description: >
@@ -60,10 +65,7 @@ resources:
       key_name: { get_param: keypair }
       flavor: { get_param: flavor }
       networks:
-        - network: { get_param: internal_net }
-      security_groups:
-        - { get_param: secgroup_base }
-        - { get_param: secgroup_worker }
+        - port: { get_resource: worker_port }
       user_data_format: RAW
       user_data:
         str_replace:
@@ -95,3 +97,22 @@ resources:
         properties:
           instance_id: { get_resource: worker }
           volume_size: { get_param: volume_size }
+
+  worker_port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_param: internal_net }
+      security_groups:
+        - { get_param: secgroup_base }
+        - { get_param: secgroup_worker }
+
+  worker_floating_ip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: { get_param: external_net }
+
+  worker_floating_ip_association:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      floatingip_id: { get_resource: worker_floating_ip }
+      port_id: { get_resource: worker_port }

--- a/files/caasp-stack.yaml
+++ b/files/caasp-stack.yaml
@@ -202,6 +202,7 @@ resources:
           name: {list_join: ['-', [{get_param: 'OS::stack_name'}, 'worker', '%index%']]}
           image: { get_param: image }
           internal_net: { get_param: internal_network }
+          external_net: { get_param: external_net }
           secgroup_base: { get_resource: secgroup_base }
           secgroup_worker: { get_param: security_group }
           flavor: { get_param: worker_flavor }

--- a/playbooks/openstack-caasp_instance.yml
+++ b/playbooks/openstack-caasp_instance.yml
@@ -31,21 +31,6 @@
               keypair: "{{ deploy_on_openstack_keypairname }}"
               worker_count: "{{ deploy_on_openstack_caasp_workers }}"
 
-        # TODO(evrardjp) Remove this when all the nodes have floating IPs in the template
-        - name: Get all the node with no floating ips
-          command: openstack server list --name {{ stackname | quote }}-worker -c ID -f json --noindent
-          changed_when: false
-          register: _workernodeswithnofloating
-        # Do not reuse to prevent ssh issues or race conditions when running
-        # multiple of those jobs at the same time.
-        - name: Get a floating ip for the workers
-          loop: "{{ _workernodeswithnofloating.stdout | from_json }}"
-          os_floating_ip:
-            cloud: "{{ deploy_on_openstack_cloudname }}"
-            server: "{{ item.ID }}"
-            reuse: no
-            network: "{{ deploy_on_openstack_external_network }}"
-
         # TODO(evrardjp): Replace this with stack output
         - name: Get workers details
           command: openstack server list --name {{ stackname }}-worker -c ID -c Name -c Networks -f json --noindent


### PR DESCRIPTION
Instead of using ansible to assign floating IPs to the CaaSP worker
nodes, use the CaaSP heat stack to do that.
That has the advantage that the cleanup of the resources is a lot
easier because you don't have to manually unassign floating IPs when
calling "./run.sh teardown".
Note that we currently don't do the mentioned cleanup so the teardown
function is broken.