### PR TITLE
Use the new location of the OpenStack infra hosted repositories

### DIFF
--- a/playbooks/roles/deploy-osh/defaults/main.yml
+++ b/playbooks/roles/deploy-osh/defaults/main.yml
@@ -31,10 +31,10 @@ helm_download_url: "https://raw.githubusercontent.com/kubernetes/helm/master/scr
 # OpenStack-Helm repos, frozen on 9th November 2018
 osh_repos:
   openstack-helm-infra:
-    src: https://git.openstack.org/openstack/openstack-helm-infra.git
+    src: https://opendev.org/openstack/openstack-helm-infra.git
     version: b55e9b10a72ce5531ae22f15f953b2eb71e6f623
   openstack-helm:
-    src: https://git.openstack.org/openstack/openstack-helm.git
+    src: https://opendev.org/openstack/openstack-helm.git
     version: 4f94593e870ac879b2d01300cb02485ace58b3ac
 
 suse_osh_deploy_require_ha: True

--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -9,47 +9,47 @@ data:
         subpath: ingress
     osh:
       cinder-htk:
-        location: https://git.openstack.org/openstack/openstack-helm-infra
+        location: https://opendev.org/openstack/openstack-helm-infra
         reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
         subpath: helm-toolkit
         type: git
       glance-htk:
-        location: https://git.openstack.org/openstack/openstack-helm-infra
+        location: https://opendev.org/openstack/openstack-helm-infra
         reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
         subpath: helm-toolkit
         type: git
       heat-htk:
-        location: https://git.openstack.org/openstack/openstack-helm-infra
+        location: https://opendev.org/openstack/openstack-helm-infra
         reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
         subpath: helm-toolkit
         type: git
       horizon:
-        location: https://git.openstack.org/openstack/openstack-helm
+        location: https://opendev.org/openstack/openstack-helm
         reference: f22f53030335121a6019a603910deef0a759b1de
         subpath: horizon
         type: git
       horizon-htk:
-        location: https://git.openstack.org/openstack/openstack-helm-infra
+        location: https://opendev.org/openstack/openstack-helm-infra
         reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e 
         subpath: helm-toolkit
         type: git
       keystone:
-        location: https://git.openstack.org/openstack/openstack-helm
+        location: https://opendev.org/openstack/openstack-helm
         reference: f22f53030335121a6019a603910deef0a759b1de
         subpath: keystone
         type: git
       keystone-htk:
-        location: https://git.openstack.org/openstack/openstack-helm-infra
+        location: https://opendev.org/openstack/openstack-helm-infra
         reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
         subpath: helm-toolkit
         type: git
       ingress-htk:
-        location: https://git.openstack.org/openstack/openstack-helm-infra
+        location: https://opendev.org/openstack/openstack-helm-infra
         reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
         subpath: helm-toolkit
         type: git
       neutron-htk:
-        location: https://git.openstack.org/openstack/openstack-helm-infra
+        location: https://opendev.org/openstack/openstack-helm-infra
         reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
         subpath: helm-toolkit
         type: git

--- a/vars/manifest.yml
+++ b/vars/manifest.yml
@@ -1,19 +1,19 @@
 ---
 upstream_repos:
   openstack-helm-infra:
-    src: https://git.openstack.org/openstack/openstack-helm-infra
+    src: https://opendev.org/openstack/openstack-helm-infra
     version: master
     dest_subdir: openstack
   openstack-helm:
-    src: https://git.openstack.org/openstack/openstack-helm
+    src: https://opendev.org/openstack/openstack-helm
     version: master
     dest_subdir: openstack
   openstack-helm-images:
-    src: https://github.com/openstack/openstack-helm-images
+    src: https://opendev.org/openstack/openstack-helm-images
     version: master
     dest_subdir: openstack
   loci:
-    src: https://github.com/openstack/loci
+    src: https://opendev.org/openstack/loci
     version: master
     dest_subdir: openstack
   armada:


### PR DESCRIPTION
OpenStack Infra has renamed itself to opendev, see

http://lists.openstack.org/pipermail/openstack-discuss/2019-March/003603.html
http://lists.openstack.org/pipermail/openstack-discuss/2019-April/004920.html

for details.