### PR TITLE
Fix extravars file creation when only deploying CaaSP

### DIFF
--- a/playbooks/openstack-caasp_instance.yml
+++ b/playbooks/openstack-caasp_instance.yml
@@ -88,17 +88,6 @@
             chdir: "{{ playbook_dir }}/../files/"
             executable: /bin/bash
 
-        - name: Get the VIP from the network stack
-          command: openstack stack output show {{ deploy_on_openstack_network_stackname }} vip -c output_value -f value
-          changed_when: false
-          register: _network_stack_vip_output
-
-        - name: Add vip with cidr in extravars
-          lineinfile:
-            path: "{{ socok8s_extravars }}"
-            regexp: "^socok8s_ext_vip.*"
-            line: "socok8s_ext_vip: {{ _network_stack_vip_output.stdout }}"
-
         - name: Extend inventory in workspace with newly created caasp nodes
           copy:
             content: "{{ caasp_overrides }}"

--- a/playbooks/openstack-create_network.yml
+++ b/playbooks/openstack-create_network.yml
@@ -24,3 +24,17 @@
         - name: show network stack output
           debug:
             var: network_stack_create_output
+
+    - name: Get the VIP from the network stack
+      command: openstack stack output show {{ deploy_on_openstack_network_stackname }} vip -c output_value -f value
+      changed_when: false
+      register: _network_stack_vip_output
+
+    - name: Add vip with cidr in extravars
+      delegate_to: localhost
+      blockinfile:
+        path: "{{ socok8s_extravars }}"
+        create: yes
+        marker: "# {mark} ANSIBLE MANAGED BLOCK FOR VIP"
+        block: |
+          socok8s_ext_vip: {{ _network_stack_vip_output.stdout }}


### PR DESCRIPTION
When deploying CaaSP before SES, the env/extravars file was not
created and the "lineinfile" ansible statement failed because the file
was not there.
That is now fixed because using "blockinfile" creates the
file. "blockinfile" is also used in
playbooks/roles/ses-osh/tasks/main.yml which was responsible for
creating env/extravars . Now it doesn't matter which (SES or CaasP) is
deployed first.

Also move the code to write the VIP to env/extravars to the networking
stack creation. The VIP is created there so it makes sense to also set
the VIP from there.