### PR TITLE
Use a current leap image rather than GM

### DIFF
--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -18,10 +18,7 @@ deploy_on_openstack_sesnode_userdata: |
 deploy_on_openstack_repos_to_configure:
   SLE12SP3-product: http://provo-clouddata.cloud.suse.de/repos/x86_64/SLES12-SP3-Pool/
   SLE12SP3-update: http://provo-clouddata.cloud.suse.de/repos/x86_64/SLES12-SP3-Updates/
-  SLE12SP3SDK-product: http://provo-clouddata.cloud.suse.de/repos/x86_64/SLE12-SP3-SDK-Pool/
-  SLE12SP3SDK-update: http://provo-clouddata.cloud.suse.de/repos/x86_64/SLE12-SP3-SDK-Updates/
   SUSE-CA: http://download.suse.de/ibs/SUSE:/CA/SLE_12_SP3/
-  OpenStack-Cloud8-product: http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-OpenStack-Cloud-8-Pool/
   SES5-product: http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-Enterprise-Storage-5-Pool/
   SES5-update: http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-Enterprise-Storage-5-Updates/
   SLE12Containers: http://ibs-mirror.prv.suse.net/dist/ibs/SUSE/Updates/SLE-Module-Containers/12/x86_64/update/
@@ -40,16 +37,8 @@ deploy_on_openstack_ses_repos_per_imagename:
     - SES5-update
     - SLE12Containers
 deploy_on_openstack_osh_repos_per_imagename:
-  openSUSE-Leap-15.0:
+  openSUSE-Leap-15.0-JeOS.x86_64-15.0.1-OpenStack-Cloud:
     - Leap15develtools
-  SLES12-SP3:
-    - SLE12SP3-product
-    - SLE12SP3-update
-    - SLE12SP3SDK-product
-    - SLE12SP3SDK-update
-    - SUSE-CA
-    - OpenStack-Cloud8-product
-    - SLE12Containers
 deploy_on_openstack_caasp_repos_per_imagename:
   caasp-3.0.0-GM-OpenStack-qcow:
     - CAASP30-update
@@ -58,7 +47,7 @@ deploy_on_openstack_caasp_image: "caasp-3.0.0-GM-OpenStack-qcow"
 deploy_on_openstack_caasp_workers: 3
 deploy_on_openstack_caasp_securitygroup: "{{ deploy_on_openstack_sesnode_securitygroup }}"
 deploy_on_openstack_caasp_stacknamefile: "{{ socok8s_workspace }}/stackname"
-deploy_on_openstack_oshnode_image: "openSUSE-Leap-15.0"
+deploy_on_openstack_oshnode_image: "openSUSE-Leap-15.0-JeOS.x86_64-15.0.1-OpenStack-Cloud"
 deploy_on_openstack_oshnode_flavor: "m1.large"
 deploy_on_openstack_oshnode_securitygroup: "all-incoming"
 deploy_on_openstack_oshnode_userdata: |


### PR DESCRIPTION
The openSUSE Leap team provides a daily updated Leap 15.0 image,
so we don't need to run against a GM image. By using an updated
image, we don't need to spend 10 minutes on downloading and installing
8 months of maintenance patches.

Also cleanup repo list a bit.