### PR TITLE
Jenkinsfile: Run steps in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,9 +28,53 @@ pipeline {
             }
         }
 
-        stage('Deploy everything') {
+        stage('Setup network') {
             steps {
-                sh "./run.sh"
+                sh "./run.sh deploy_network"
+            }
+        }
+        stage('Setup hosts') {
+            parallel {
+                stage('Setup CaaSP') {
+                    steps {
+                        sh "./run.sh deploy_caasp"
+                    }
+                }
+                stage('Setup SES') {
+                    steps {
+                        sh "./run.sh deploy_ses"
+                    }
+                }
+                stage('Setup Deployer') {
+                    steps {
+                        sh "./run.sh deploy_ccp_deployer"
+                    }
+                }
+            }
+        }
+        stage('Enroll CaaSP workers') {
+            steps {
+                sh "./run.sh enroll_caasp_workers"
+            }
+        }
+        stage('Setup CaaSP workers and apply upstream patches') {
+            parallel {
+                stage('Setup CaaSP workes for OpenStack Helm') {
+                    steps {
+                        sh "./run.sh setup_caasp_workers_for_openstack"
+                    }
+                }
+                stage('Apply upstream patches') {
+                    steps {
+                        sh "./run.sh patch_upstream"
+                    }
+                }
+            }
+        }
+        stage('Deploy OpenStack Helm') {
+            steps {
+                sh "./run.sh build_images"
+                sh "./run.sh deploy_osh"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ pipeline {
     options {
         timestamps()
         timeout(time: 45, unit: 'MINUTES', activity: true)
+        parallelsAlwaysFailFast()
     }
 
     agent {

--- a/playbooks/generic-enroll_caasp_workers.yml
+++ b/playbooks/generic-enroll_caasp_workers.yml
@@ -1,3 +1,2 @@
 ---
-- import_playbook: openstack-update_and_reboot_caasp.yml
 - import_playbook: openstack-enroll_caasp_workers.yml

--- a/playbooks/openstack-create_caasp.yml
+++ b/playbooks/openstack-create_caasp.yml
@@ -16,3 +16,4 @@
 
 ---
 - import_playbook: openstack-caasp_instance.yml
+- import_playbook: openstack-update_and_reboot_caasp.yml

--- a/playbooks/openstack-update_and_reboot_caasp.yml
+++ b/playbooks/openstack-update_and_reboot_caasp.yml
@@ -49,12 +49,12 @@
         reboot_timeout: 900
         connect_timeout: 90
 
-- hosts: soc-deployer
+- hosts: localhost
   gather_facts: no
   tasks:
     - name: "wait for Velum to come back again"
       uri:
-        url: "https://{{ groups['caasp-admin'][0] }}/"
+        url: "https://{{ hostvars[groups['caasp-admin'][0]]['ansible_host'] }}/"
         method: GET
         status: 200
         validate_certs: no

--- a/playbooks/roles/handle-nodes-on-openstack/tasks/create_on_openstack.yml
+++ b/playbooks/roles/handle-nodes-on-openstack/tasks/create_on_openstack.yml
@@ -9,6 +9,11 @@
     network: "{{ network }}"
     security_groups: "{{ securitygroups }}"
     auto_ip: True
+    # This is needed as we want to run deployments in parallel
+    # reuse_ips: True is racy according to:
+    # https://docs.ansible.com/ansible/latest/modules/os_server_module.html
+    reuse_ips: False
+    delete_fip: True
     state: present
     timeout: 300
     userdata: "{{ userdata | default(omit) }}"


### PR DESCRIPTION
Instead of deploying SES, then CaaSP, then ..., do steps in parallel
where possible.
This should speedup the CI runs a lot.