### PR TITLE
Create separate tmp directory outside workspace

### DIFF
--- a/playbooks/openstack-enroll_caasp_workers.yml
+++ b/playbooks/openstack-enroll_caasp_workers.yml
@@ -39,6 +39,7 @@
           - phantomjs
           - libxml2-devel
           - libxslt-devel
+          - which
 
     - name: Copying velum automation
       unarchive:

--- a/playbooks/openstack-osh_hostconfig.yml
+++ b/playbooks/openstack-osh_hostconfig.yml
@@ -27,6 +27,9 @@
         option: download.use_deltarpm
         value: "false"
 
+    - name: Workaround stupid JeOS image bugs (bsc#1138727)
+      shell: "netconfig update -f"
+
     - name: Configure host repositories
       zypper_repository:
         name: "{{ item }}"


### PR DESCRIPTION
The workspace is currently fiddled with temporary files like
the virtualenv (which is only created if not the right packages
are installed upfront) and the persistent config files.
    
Separate the venv which is scratch (cache) data from the config
dir so that the $HOME directory is not fulled up with that for
those who have quota on $HOME (like I have). use SOCOK8S_TMP_BASEDIR
for that.
