### PR TITLE
Added tempest password file and entry in service_accounts.yaml 

### DIFF
--- a/site/soc/secrets/passphrases/osh_tempest_password.yaml
+++ b/site/soc/secrets/passphrases/osh_tempest_password.yaml
@@ -1,0 +1,11 @@
+---
+schema: deckhand/Passphrase/v1
+metadata:
+  schema: metadata/Document/v1
+  name: osh_tempest_password
+  layeringDefinition:
+    abstract: false
+    layer: site
+  storagePolicy: cleartext
+data: {{ lookup('password', secrets_location + '/osh_tempest_password ' + password_opts) }}
+...

--- a/site/soc/software/config/service_accounts.yaml
+++ b/site/soc/software/config/service_accounts.yaml
@@ -372,6 +372,13 @@ data:
           username: barbican-rabbitmq-admin
         barbican:
           username: barbican-rabbitmq-user
+    tempest:
+      tempest:
+        role: admin
+        username: tempest
+        project_name: service
+        user_domain_name: default
+        project_domain_name: default
 ...
 ---
 schema: pegleg/AccountCatalogue/v1


### PR DESCRIPTION
This change is required now that the Tempest global layer chart has merged upstream. The global Tempest chart references both of these files as substitution sources, so even though we are not yet deploying Tempest into the cluster, linting our "soc" site will fail without them.