### PR TITLE
Upgrade pip before installing required dependencies

### DIFF
--- a/script_library/bootstrap-ansible-if-necessary.sh
+++ b/script_library/bootstrap-ansible-if-necessary.sh
@@ -11,6 +11,7 @@ function install_ansible (){
     if [[ ! -d ${socok8s_workspace}/.ansiblevenv/ ]]; then
         virtualenv ${socok8s_workspace}/.ansiblevenv/
         source ${socok8s_workspace}/.ansiblevenv/bin/activate
+        pip install --upgrade pip
         pip install --upgrade -r $(dirname "$0")/script_library/requirements.txt
         python -m ara.setup.env > ${socok8s_workspace}/.ansiblevenv/ara.rc
     else


### PR DESCRIPTION
Without this, the first creation of virtualenv fails (because of old pip) and on next run (after manual upgrade), pip will not be executed (because venv already exists)