### PR TITLE
Replace Jenkinsfile with Jenkinsfile.integration

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -23,6 +23,22 @@ pipeline {
     }
 
     stages {
+        stage('Git Clone') {
+            steps {
+                checkout([$class: 'GitSCM',
+                          branches: [[name: "*/pr/${CHANGE_ID}"], [name: '*/master']],
+                          doGenerateSubmoduleConfigurations: false,
+                          extensions: [[$class: 'LocalBranch'],
+                                       [$class: 'WipeWorkspace'],
+                                       [$class: 'PreBuildMerge', options: [mergeRemote: 'origin', mergeTarget: 'master']],
+                                       [$class: 'RelativeTargetDirectory', relativeTargetDir: 'socok8s']],
+                          submoduleCfg: [],
+                          userRemoteConfigs: [[refspec: '+refs/pull/*/head:refs/remotes/origin/pr/*',
+                                               credentialsId: 'c2350527-476a-45df-b406-84f028614682',
+                                               url: 'https://github.com/SUSE-Cloud/socok8s']]])
+            }
+        }
+
         stage('Show environment information') {
             steps {
                 sh 'printenv'


### PR DESCRIPTION
Jenkinsfile.integration  is a copy of the Jenkinsfile and adds an
aditional step to clone the git repository.
This is the next step to improve the PR testing and allow multiple
Jenkinsfiles (eg. one for integration, one for docs, one for linting,
...).

Git clone code is copied from
https://github.com/SUSE/caaspctl/blob/master/ci/jenkins/\
  pipelines/prs/caaspctl-integration.Jenkinsfile