### PR TITLE
Use global separate openstack helm toolkit definitions for openstack services

### DIFF
--- a/playbooks/roles/dev-patcher/defaults/main.yml
+++ b/playbooks/roles/dev-patcher/defaults/main.yml
@@ -20,6 +20,4 @@ dev_patcher_patches:
   - 639861
   # osh-infra: Add support for mulitple VIPS
   - 640115
-  # Enable service specific version of helm toolkit used in OSH services
-  - 657638
 

--- a/playbooks/roles/dev-patcher/defaults/main.yml
+++ b/playbooks/roles/dev-patcher/defaults/main.yml
@@ -20,4 +20,3 @@ dev_patcher_patches:
   - 639861
   # osh-infra: Add support for mulitple VIPS
   - 640115
-

--- a/playbooks/roles/dev-patcher/defaults/main.yml
+++ b/playbooks/roles/dev-patcher/defaults/main.yml
@@ -20,3 +20,6 @@ dev_patcher_patches:
   - 639861
   # osh-infra: Add support for mulitple VIPS
   - 640115
+  # Enable service specific version of helm toolkit used in OSH services
+  - 657638
+

--- a/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
@@ -50,29 +50,4 @@ data:
           rbd_user: {{ ses_cluster_configuration['cinder']['rbd_store_user'] }}
           rbd_pool: {{ ses_cluster_configuration['cinder']['rbd_store_pool'] }}
           rbd_secret_uuid: {{ libvirt_ceph_cinder_secret_uuid }}
-  dependencies:
-    - cinder-htk
-...
----
-schema: armada/Chart/v1
-metadata:
-  schema: metadata/Document/v1
-  name:  cinder-htk
-  layeringDefinition:
-    abstract: false
-    layer: site
-  storagePolicy: cleartext
-  substitutions:
-    - src:
-        schema: pegleg/SoftwareVersions/v1
-        name: software-versions
-        path: .charts.osh.cinder-htk
-      dest:
-        path: .source
-data:
-  chart_name: cinder-htk
-  release: cinder-htk
-  namespace: cinder-htk
-  values: {}
-  dependencies: []
 ...

--- a/site/soc/software/charts/osh/openstack-compute-kit/neutron.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/neutron.yaml
@@ -70,29 +70,4 @@ data:
       paste:
         app:neutronversions:
           paste.app_factory: neutron.pecan_wsgi.app:versions_factory
-  dependencies:
-    - neutron-htk
-...
----
-schema: armada/Chart/v1
-metadata:
-  schema: metadata/Document/v1
-  name:  neutron-htk
-  layeringDefinition:
-    abstract: false
-    layer: site
-  storagePolicy: cleartext
-  substitutions:
-    - src:
-        schema: pegleg/SoftwareVersions/v1
-        name: software-versions
-        path: .charts.osh.neutron-htk
-      dest:
-        path: .source
-data:
-  chart_name: neutron-htk
-  release: neutron-htk
-  namespace: neutron-htk
-  values: {}
-  dependencies: []
 ...

--- a/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
@@ -118,29 +118,4 @@ data:
         consoleauth: 1
         scheduler: 1
         novncproxy: 1
-  dependencies:
-    - nova-htk
-...
----
-schema: armada/Chart/v1
-metadata:
-  schema: metadata/Document/v1
-  name:  nova-htk
-  layeringDefinition:
-    abstract: false
-    layer: site
-  storagePolicy: cleartext
-  substitutions:
-    - src:
-        schema: pegleg/SoftwareVersions/v1
-        name: software-versions
-        path: .charts.osh.nova-htk
-      dest:
-        path: .source
-data:
-  chart_name: nova-htk
-  release: nova-htk
-  namespace: nova-htk
-  values: {}
-  dependencies: []
 ...

--- a/site/soc/software/charts/osh/openstack-glance/glance.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/glance.yaml
@@ -53,29 +53,4 @@ data:
         glance_store:
           rbd_store_user: {{ ses_cluster_configuration.glance.rbd_store_user }}
           rbd_store_pool: {{ ses_cluster_configuration.glance.rbd_store_pool }}
-  dependencies:
-    - glance-htk
-...
----
-schema: armada/Chart/v1
-metadata:
-  schema: metadata/Document/v1
-  name:  glance-htk
-  layeringDefinition:
-    abstract: false
-    layer: site
-  storagePolicy: cleartext
-  substitutions:
-    - src:
-        schema: pegleg/SoftwareVersions/v1
-        name: software-versions
-        path: .charts.osh.glance-htk
-      dest:
-        path: .source
-data:
-  chart_name: glance-htk
-  release: glance-htk
-  namespace: glance-htk
-  values: {}
-  dependencies: []
 ...

--- a/site/soc/software/charts/osh/openstack-heat/heat.yaml
+++ b/site/soc/software/charts/osh/openstack-heat/heat.yaml
@@ -51,29 +51,4 @@ data:
         cfn: 1
         cloudwatch: 1
         engine: 1
-  dependencies:
-    - heat-htk
-...
----
-schema: armada/Chart/v1
-metadata:
-  schema: metadata/Document/v1
-  name:  heat-htk
-  layeringDefinition:
-    abstract: false
-    layer: site
-  storagePolicy: cleartext
-  substitutions:
-    - src:
-        schema: pegleg/SoftwareVersions/v1
-        name: software-versions
-        path: .charts.osh.heat-htk
-      dest:
-        path: .source
-data:
-  chart_name: heat-htk
-  release: heat-htk
-  namespace: heat-htk
-  values: {}
-  dependencies: []
 ...

--- a/site/soc/software/charts/osh/openstack-horizon/horizon.yaml
+++ b/site/soc/software/charts/osh/openstack-horizon/horizon.yaml
@@ -50,28 +50,3 @@ data:
             Allow from all
           </IfModule>
           </Directory>
-  dependencies:
-    - horizon-htk
----
-schema: armada/Chart/v1
-metadata:
-  schema: metadata/Document/v1
-  name:  horizon-htk
-  layeringDefinition:
-    abstract: false
-    layer: site
-  storagePolicy: cleartext
-  substitutions:
-    - src:
-        schema: pegleg/SoftwareVersions/v1
-        name: software-versions
-        path: .charts.osh.horizon-htk
-      dest:
-        path: .source
-data:
-  chart_name: horizon-htk
-  release: horizon-htk
-  namespace: horizon-htk
-  values: {}
-  dependencies: []
-...

--- a/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
@@ -58,29 +58,4 @@ data:
             Allow from all
           </IfModule>
         </Directory>
-  dependencies:
-    - keystone-htk
-...
----
-schema: armada/Chart/v1
-metadata:
-  schema: metadata/Document/v1
-  name:  keystone-htk
-  layeringDefinition:
-    abstract: false
-    layer: site
-  storagePolicy: cleartext
-  substitutions:
-    - src:
-        schema: pegleg/SoftwareVersions/v1
-        name: software-versions
-        path: .charts.osh.keystone-htk
-      dest:
-        path: .source
-data:
-  chart_name: keystone-htk
-  release: keystone-htk
-  namespace: keystone-htk
-  values: {}
-  dependencies: []
 ...


### PR DESCRIPTION
Replace local chart definition for separate osh toolkit in favor of
upstream global chart definitions that is now availble.