### PR TITLE
Fix Nova scheduler rabbitmq error during Airship deployment

### DIFF
--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -55,7 +55,7 @@ data:
         type: git
       nova:
         location: https://opendev.org/openstack/openstack-helm
-        reference: 6d7a90944725a398064ac19c9137e228cc0c6e98
+        reference: baf5356a4fb61590a95f64a63c0dcabfebb3baaa
         subpath: nova
         type: git
       nova-htk:


### PR DESCRIPTION
Move up the Nova chart version to include the patch
https://review.opendev.org/#/c/651140/ taht fixes the Nova scheduler pod
rabbitmq socker failure.