### PR TITLE
Freeze helm repositories to the same version that is used by airship (do not merge)

### DIFF
--- a/vars/manifest.yml
+++ b/vars/manifest.yml
@@ -2,11 +2,11 @@
 upstream_repos:
   openstack-helm-infra:
     src: https://opendev.org/openstack/openstack-helm-infra
-    version: master
+    version: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
     dest_subdir: openstack
   openstack-helm:
     src: https://opendev.org/openstack/openstack-helm
-    version: master
+    version: f22f53030335121a6019a603910deef0a759b1de
     dest_subdir: openstack
   openstack-helm-images:
     src: https://opendev.org/openstack/openstack-helm-images


### PR DESCRIPTION
Updating helm repo's references to the ones present in 

https://github.com/SUSE-Cloud/socok8s/blob/master/site/soc/software/config/versions.yaml