### PR TITLE
Adding workaround for missing volume path directory

### DIFF
--- a/playbooks/roles/airship-configure-worker/templates/caasp_worker_node_set_subvolumes.sh.j2
+++ b/playbooks/roles/airship-configure-worker/templates/caasp_worker_node_set_subvolumes.sh.j2
@@ -22,8 +22,10 @@ init(){
 
 create_subvolume(){
   if [ ! -d "$1" ]; then
-    init 
+    init
     mksubvolume "$1"
+    # make sure that directory related to volume is already created
+    mkdir -p "$1"
   fi
 }
 


### PR DESCRIPTION
During create subvolume command, sometimes volume directory path
is not created and caasp node goes into emergency mode after reboot
and makes it unreachable from deployer.