### PR TITLE
Add Ansible requirements in the deploy guide


### DIFF
--- a/doc/source/deploy-guide/prepare-localhost.rst
+++ b/doc/source/deploy-guide/prepare-localhost.rst
@@ -60,6 +60,7 @@ Optionally, `localhost` can be preinstalled with the following software:
 
   * ansible>=2.7.0
   * python-openstackclient
+  * python-heatclient
   * python-requests
   * python-jmespath
   * python-openstacksdk
@@ -71,6 +72,14 @@ Python 3, so install the "python3-" variant of the packages)
 
 If those optional software aren't installed, they will be installed in a
 venv in |socok8s_workspace_default|\ `/.ansiblevenv` .
+
+.. note ::
+
+   Here are the requirements that will be installed in that workspace:
+
+   .. include :: requirements.txt
+      :code:
+
 
 Cloning this repository
 -----------------------

--- a/doc/source/deploy-guide/requirements.txt
+++ b/doc/source/deploy-guide/requirements.txt
@@ -1,0 +1,1 @@
+../../../script_library/requirements.txt


### PR DESCRIPTION


This clarifies what will be installed in the Ansible venv, which
is installed if the deployer doesn't provide its own ansible
environment.

Showing the versions basically states what this tooling has been
tested with.

