### PR TITLE
Using upstream images for airship components

### DIFF
--- a/examples/workdir/env/extravars
+++ b/examples/workdir/env/extravars
@@ -17,7 +17,7 @@ redeploy_osh_only: false
 # varibles which can be overriden if needed.
 
 #suse_osh_registry_location: "docker.io"
-#suse_osh_image_version: "pike"
+#suse_openstack_image_version: "rocky-opensuse_15"
 
 # List of extra patches for the dev-patcher
 # instead of waiting for patch numbers to be added on the main repo

--- a/playbooks/roles/airship-deploy-osh/defaults/main.yml
+++ b/playbooks/roles/airship-deploy-osh/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-shipyard_image: "{{ suse_airship_registry_location }}/airshipit/shipyard:{{suse_airship_components_image_tag}}"
-airship_pegleg_image: "{{ suse_airship_registry_location }}/airshipit/pegleg:{{suse_airship_components_image_tag}}"
+shipyard_image: "{{ suse_airship_registry_location }}/airshipit/shipyard:{{suse_airship_components_image_tag['shipyard']}}"
+airship_pegleg_image: "{{ suse_airship_registry_location }}/airshipit/pegleg:{{suse_airship_components_image_tag['pegleg']}}"

--- a/playbooks/roles/airship-deploy-ucp/defaults/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 scale_profile: "{{ lookup('env','scale_profile') | default('minimal', true) }}"
-airship_pegleg_image: "{{ suse_airship_registry_location }}/airshipit/pegleg:{{ suse_airship_components_image_tag }}"
-suse_osh_image_version: "pike"
+airship_pegleg_image: "{{ suse_airship_registry_location }}/airshipit/pegleg:{{ suse_airship_components_image_tag['pegleg'] }}"

--- a/playbooks/roles/airship-deploy-ucp/templates/armada.yaml.j2
+++ b/playbooks/roles/airship-deploy-ucp/templates/armada.yaml.j2
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: armada
       containers:
       - name: armada
-        image: '{{ suse_airship_registry_location }}/airshipit/armada:{{ suse_airship_components_image_tag }}'
+        image: "{{ suse_airship_registry_location }}/airshipit/armada:{{ suse_airship_components_image_tag['armada'] }}"
         ports:
         - containerPort: 8000
       nodeSelector:

--- a/playbooks/roles/dev-patcher/defaults/main.yml
+++ b/playbooks/roles/dev-patcher/defaults/main.yml
@@ -8,14 +8,8 @@ dev_patcher_packages:
 #unrelated patches will fail (because not cloned)
 #conflicting patches will fail (because need resolving)
 dev_patcher_patches:
-  # Adding opensuse support in image building of airflow and shipyard
-  - 636229
-  # armada: Support armada to run on opensuse image leap15
-  - 637327
   # deckhand: Adding opensuse image build for deckhand
   - 638301
-  # pegleg: Support pegleg to run on opensuse leap15 image
-  - 639495
   # treasuremap: Add a preliminary draft of schema for the pod scale policy/profile in Airship.
   - 639861
   # osh-infra: Add support for mulitple VIPS

--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -30,7 +30,7 @@ data:
         type: git
       horizon-htk:
         location: https://opendev.org/openstack/openstack-helm-infra
-        reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e 
+        reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
         subpath: helm-toolkit
         type: git
       keystone:
@@ -152,10 +152,8 @@ data:
         keystone_domain_manage: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
       libvirt:
         libvirt: "{{ suse_osh_registry_location }}/openstackhelm/libvirt:{{ suse_libvirt_image_version }}"
-      #TODO JG add suse image support
       mariadb:
-        # NOTE: was using {{ suse_osh_image_version }} in upstream
-        prometheus_mysql_exporter_helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
+        prometheus_mysql_exporter_helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       memcached: {}
       neutron:
         bootstrap: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
@@ -199,45 +197,37 @@ data:
         openvswitch_db_server: "{{ suse_osh_registry_location }}/openstackhelm/openvswitch:{{ suse_infra_image_version }}"
         openvswitch_vswitchd: "{{ suse_osh_registry_location }}/openstackhelm/openvswitch:{{ suse_infra_image_version }}"
       rabbitmq:
-        # NOTE: was using {{ suse_osh_image_version }} in upstream
-        prometheus_rabbitmq_exporter_helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
+        prometheus_rabbitmq_exporter_helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
     osh_infra:
       elasticsearch:
-        # NOTE: was using {{ suse_osh_image_version }} in upstream
-        memory_init: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
-        helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
-        snapshot_repository: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
+        memory_init: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        snapshot_repository: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       fluent_logging:
-        # NOTE: was using {{ suse_osh_image_version }} in upstream
-        helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
-        elasticsearch_template: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
+        helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        elasticsearch_template: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       grafana:
-        # NOTE: was using {{ suse_osh_image_version }} in upstream
-        db_init: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
-        grafana_db_session_sync: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
-        helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
+        db_init: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        grafana_db_session_sync: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       kibana:
-        # NOTE: was using {{ suse_osh_image_version }} in upstream
-        register_kibana_indexes: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
+        register_kibana_indexes: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       nagios: {}
       prometheus:
-        # NOTE: was using {{ suse_osh_image_version }} in upstream
-        helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
+        helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       prometheus_alertmanager: {}
       prometheus_kube_state_metrics: {}
       prometheus_node_exporter: {}
-      # NOTE JG the image is in att namespace
       prometheus_openstack_exporter:
-        # NOTE: was using {{ suse_osh_image_version }} in upstream
-        ks_user: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
+        ks_user: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       prometheus_process_exporter: {}
     # the ucp section is not used in socok8s deployment.
     ucp:
       armada:
-        api: "{{ suse_airship_registry_location }}/airshipit/armada:{{ suse_airship_components_image_tag }}"
-        ks_user: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
-        ks_service: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
-        ks_endpoints: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
+        api: "{{ suse_airship_registry_location }}/airshipit/armada:{{ suse_airship_components_image_tag['armada'] }}"
+        ks_user: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        ks_service: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        ks_endpoints: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       barbican:
         bootstrap: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
         scripted_test: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
@@ -249,11 +239,11 @@ data:
         ks_endpoints: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
         barbican_api: "{{ suse_osh_registry_location }}/openstackhelm/barbican:{{ suse_openstack_image_version }}"
       deckhand:
-        deckhand: "{{ suse_airship_registry_location }}/airshipit/deckhand:{{ suse_airship_components_image_tag }}"
-        db_sync: "{{ suse_airship_registry_location }}/airshipit/deckhand:{{ suse_airship_components_image_tag }}"
-        ks_user: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
-        ks_service: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
-        ks_endpoints: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
+        deckhand: "{{ suse_airship_registry_location }}/airshipit/deckhand:{{ suse_airship_components_image_tag['deckhand'] }}"
+        db_sync: "{{ suse_airship_registry_location }}/airshipit/deckhand:{{ suse_airship_components_image_tag['deckhand'] }}"
+        ks_user: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        ks_service: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        ks_endpoints: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       divingbell: {}
       drydock: {}
       ingress:
@@ -278,13 +268,13 @@ data:
       promenade: {}
       rabbitmq: {}
       shipyard:
-        shipyard: "{{ suse_airship_registry_location }}/airshipit/shipyard:{{ suse_airship_components_image_tag }}"
-        shipyard_db_sync: "{{ suse_airship_registry_location }}/airshipit/shipyard:{{ suse_airship_components_image_tag }}"
-        airflow: "{{ suse_airship_registry_location }}/airshipit/airflow:{{ suse_airship_components_image_tag }}"
-        airflow_db_sync: "{{ suse_airship_registry_location }}/airshipit/airflow:{{ suse_airship_components_image_tag }}"
-        ks_user: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
-        ks_service: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
-        ks_endpoints: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
+        shipyard: "{{ suse_airship_registry_location }}/airshipit/shipyard:{{ suse_airship_components_image_tag['shipyard'] }}"
+        shipyard_db_sync: "{{ suse_airship_registry_location }}/airshipit/shipyard:{{ suse_airship_components_image_tag['shipyard'] }}"
+        airflow: "{{ suse_airship_registry_location }}/airshipit/airflow:{{ suse_airship_components_image_tag['airflow'] }}"
+        airflow_db_sync: "{{ suse_airship_registry_location }}/airshipit/airflow:{{ suse_airship_components_image_tag['airflow'] }}"
+        ks_user: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        ks_service: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        ks_endpoints: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       tiller: {}
     kubernetes:
       ingress:

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -55,12 +55,27 @@ suse_airship_registry_location: "{%- if suse_airship_build_local_images or suse_
 suse_airship_components_image_build_tag: "master"
 
 # Complete distro specific published image tag
-# Interim solution till we don't publish suse images on quay.io
-suse_airship_components_image_tag: "{%- if suse_airship_build_local_images or suse_airship_use_local_images -%}
-                                     {{suse_airship_components_image_build_tag}}-{{suse_distro_identifier}}
-                                    {%- else -%}
-                                      master
-                                    {%- endif -%}"
+suse_airship_components_image_tag: |
+                                   {% if suse_airship_build_local_images or suse_airship_use_local_images %}
+                                   {% set _img_tag = {
+                                     'armada': "{{suse_airship_components_image_build_tag}}-{{suse_distro_identifier}}",
+                                     'shipyard': "{{suse_airship_components_image_build_tag}}-{{suse_distro_identifier}}",
+                                     'airflow' : "{{suse_airship_components_image_build_tag}}-{{suse_distro_identifier}}",
+                                     'deckhand': "{{suse_airship_components_image_build_tag}}-{{suse_distro_identifier}}",
+                                     'pegleg': "{{suse_airship_components_image_build_tag}}-{{suse_distro_identifier}}"
+                                    }
+                                   %}
+                                   {% else %}
+                                   {% set _img_tag = {
+                                     'armada': '1110c23cd192ea5eff77629d10924b290140d6e2-opensuse_15',
+                                     'shipyard': 'cd6f154da56079ba408b922ed748a80b622c3592-opensuse_15',
+                                     'airflow': 'cd6f154da56079ba408b922ed748a80b622c3592-opensuse_15',
+                                     'deckhand': 'master',
+                                     'pegleg': '652c3abefd0f647cfc45096aa76cb76bfaf8a805-opensuse_15'
+                                   }
+                                   %}
+                                   {% endif %}
+                                   {{ _img_tag }}
 
 socok8s_site_name: "soc"
 


### PR DESCRIPTION
Now either DO NOT set environment variable AIRSHIP_BUILD_LOCAL_IMAGES
and AIRSHIP_USE_LOCAL_IMAGES or set it to False to consume upstream
images.

Deckhand is currently using master image as related upstream review
(https://review.opendev.org/#/c/638301/) has not merged because of
a unrelated gate jobs failure. Once its resolved and merged, we need
to update it to use suse image commit-id version.

Also updating heat image reference to rocky version as it was referring
to pike in some of chart image refs.