### PR TITLE
Increase test_timeout value and move default values into role defaults

### DIFF
--- a/playbooks/roles/airship-deploy-ucp/defaults/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 scale_profile: "{{ lookup('env','scale_profile') | default('minimal', true) }}"
 airship_pegleg_image: "{{ suse_airship_registry_location }}/airshipit/pegleg:{{ suse_airship_components_image_tag['pegleg'] }}"
+run_tests: true
+test_timeout: 2700

--- a/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
@@ -21,8 +21,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     bootstrap:
       enabled: false

--- a/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
@@ -19,8 +19,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/neutron-rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/neutron-rabbitmq.yaml
@@ -26,8 +26,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/neutron.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/neutron.yaml
@@ -34,8 +34,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/nova-rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova-rabbitmq.yaml
@@ -26,8 +26,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
@@ -66,8 +66,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     labels:
       agent:

--- a/site/soc/software/charts/osh/openstack-glance/glance.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/glance.yaml
@@ -34,8 +34,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     bootstrap:
       enabled: false

--- a/site/soc/software/charts/osh/openstack-glance/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/rabbitmq.yaml
@@ -26,8 +26,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-heat/heat.yaml
+++ b/site/soc/software/charts/osh/openstack-heat/heat.yaml
@@ -42,8 +42,8 @@ metadata:
         path: .values.pod.replicas.engine
 data:
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-heat/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-heat/rabbitmq.yaml
@@ -24,8 +24,8 @@ metadata:
         path: .values.pod.replicas.server
 data:
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
@@ -24,8 +24,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-keystone/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/rabbitmq.yaml
@@ -26,8 +26,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/osh/openstack-mariadb/mariadb.yaml
+++ b/site/soc/software/charts/osh/openstack-mariadb/mariadb.yaml
@@ -26,8 +26,8 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/armada/armada.yaml
+++ b/site/soc/software/charts/ucp/armada/armada.yaml
@@ -23,8 +23,8 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/core/mariadb.yaml
+++ b/site/soc/software/charts/ucp/core/mariadb.yaml
@@ -23,8 +23,8 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/core/rabbitmq.yaml
+++ b/site/soc/software/charts/ucp/core/rabbitmq.yaml
@@ -25,8 +25,8 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/deckhand/barbican.yaml
+++ b/site/soc/software/charts/ucp/deckhand/barbican.yaml
@@ -23,8 +23,8 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/deckhand/deckhand.yaml
+++ b/site/soc/software/charts/ucp/deckhand/deckhand.yaml
@@ -23,8 +23,8 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/keystone/keystone.yaml
+++ b/site/soc/software/charts/ucp/keystone/keystone.yaml
@@ -24,8 +24,8 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:

--- a/site/soc/software/charts/ucp/shipyard/shipyard.yaml
+++ b/site/soc/software/charts/ucp/shipyard/shipyard.yaml
@@ -35,8 +35,8 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   test:
-    enabled: {{ run_tests | default('true') }}
-    timeout: {{ test_timeout | default(300) }}
+    enabled: {{ run_tests }}
+    timeout: {{ test_timeout }}
   values:
     pod:
       replicas:


### PR DESCRIPTION
This change increases the default tiller test_timeout value from 300s to 1800s, and it moves the default values for both test_timeout and run_tests into the role's defaults (which is where they probably should have been in the first place). The default value of 300s didn't seem to be enough for anyone's environment, so rather than make the user increase the value in extravars before deploying for the first time, it's better to increase the default.

