### PR TITLE
Add site layer tempest chart and required var defaults in airship_deploy_ucp role

### DIFF
--- a/playbooks/roles/airship-deploy-ucp/defaults/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/defaults/main.yml
@@ -2,3 +2,14 @@
 scale_profile: "{{ lookup('env','scale_profile') | default('minimal', true) }}"
 airship_pegleg_image: "{{ suse_airship_registry_location }}/airshipit/pegleg:{{ suse_airship_components_image_tag }}"
 suse_osh_image_version: "pike"
+
+# Required flags for tempest deployment
+deploy_tempest: false
+tempest_test_flavor_id: null
+tempest_test_image_id: null
+tempest_test_hypervisor_type: null
+tempest_test_public_network_id: null
+tempest_enable_glance_service: true
+tempest_enable_cinder_service: true
+tempest_enable_nova_service: false
+tempest_enable_neutron_service: false

--- a/site/soc/software/charts/osh/openstack-tempest/chart-group.yaml
+++ b/site/soc/software/charts/osh/openstack-tempest/chart-group.yaml
@@ -1,0 +1,18 @@
+---
+schema: armada/ChartGroup/v1
+metadata:
+  schema: metadata/Document/v1
+  name: openstack-tempest-soc
+  layeringDefinition:
+    abstract: false
+    layer: site
+    parentSelector:
+      name: openstack-tempest-chart-group-global
+      component: tempest
+    actions:
+      - method: replace
+        path: .chart_group
+  storagePolicy: cleartext
+data:
+  chart_group:
+    - openstack-tempest-soc

--- a/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
+++ b/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
@@ -1,0 +1,90 @@
+---
+schema: armada/Chart/v1
+metadata:
+  schema: metadata/Document/v1
+  name: openstack-tempest-soc
+  layeringDefinition:
+    abstract: false
+    layer: site
+    parentSelector:
+      name: tempest-global
+      component: tempest
+    actions:
+      - method: merge
+        path: .
+  storagePolicy: cleartext
+data:
+  wait:
+    timeout: 3000
+  test:
+    enabled: true
+    timeout: 3000
+  values:
+    conf:
+      tempest:
+        compute:
+          flavor_ref: "{{ tempest_test_flavor_id }}"
+          image_ref: "{{ tempest_test_image_id }}"
+          image_ref_alt: "{{ tempest_test_image_id }}"
+          hypervisor_type: "{{ tempest_test_hypervisor_type }}"
+        network:
+          default_network: 10.0.0.0/8
+          project_network_cidr: 172.0.4.0/16
+          floating_network_name: "public"
+          public_network_id: "{{ tempest_test_public_network_id }}"
+        validation:
+          image_ssh_user: "cirros"
+          image_ssh_password: "gocubsgo"
+          network_for_ssh: "public"
+          floating_ip_range: 172.24.4.1/24
+        service_available:
+          cinder: "{{ tempest_enable_cinder_service }}"
+          glance: "{{ tempest_enable_glance_service }}"
+          nova: "{{ tempest_enable_nova_service }}"
+          neutron: "{{ tempest_enable_neutron_service }}"
+    endpoints:
+      cluster_domain_suffix: cluster.local
+      local_image_registry:
+        name: docker-registry
+        namespace: docker-registry
+        hosts:
+          default: localhost
+          internal: docker-registry
+          node: localhost
+        host_fqdn_override:
+          default: null
+        port:
+          registry:
+            node: 5000
+      identity:
+        name: keystone
+        auth:
+          admin:
+            region_name: RegionOne
+            username: admin
+            password: {{ lookup('password', secrets_location + '/osh_keystone_admin_password ' + password_opts) }}
+            project_name: admin
+            user_domain_name: default
+            project_domain_name: default
+          tempest:
+            role: admin
+            region_name: RegionOne
+            username: tempest
+            password: {{ lookup('password', secrets_location + '/osh_tempest_password ' + password_opts) }}
+            project_name: service
+            user_domain_name: service
+            project_domain_name: service
+        hosts:
+          default: identity
+          internal: identity-api
+        host_fqdn_override:
+          default: null
+        path:
+          default: /v3
+        scheme:
+          default: http
+        port:
+          api:
+            default: 80
+            internal: 5000
+...

--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -63,6 +63,11 @@ data:
         reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
         subpath: helm-toolkit
         type: git
+      tempest:
+        location: https://opendev.org/openstack/openstack-helm
+        reference: master
+        subpath: tempest
+        type: git
   images:
     calico:
       calico: {}
@@ -201,6 +206,9 @@ data:
       rabbitmq:
         # NOTE: was using {{ suse_osh_image_version }} in upstream
         prometheus_rabbitmq_exporter_helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_osh_image_version }}"
+      tempest:
+        tempest_run_tests: "{{ suse_osh_registry_location }}/openstackhelm/tempest:{{ suse_infra_image_version }}"
+        ks_user: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
     osh_infra:
       elasticsearch:
         # NOTE: was using {{ suse_osh_image_version }} in upstream

--- a/site/soc/software/manifests/full-site.yaml
+++ b/site/soc/software/manifests/full-site.yaml
@@ -26,4 +26,7 @@ data:
     - openstack-compute-kit-soc
     - openstack-heat-soc
     - openstack-horizon-soc
+{% if deploy_tempest %}
+    - openstack-tempest-soc
+{% endif %}
 ...


### PR DESCRIPTION
This change is an experimental WIP and lays the foundation for deploying the tempest helm chart as part of the full soc site.

The current problem is making the Armada chart aware of a handful of values obtained via the openstack cli, such as imageID, flavorID, networkID, etc. In its current form, this chart allows those values to be passed in via the extravars file after they've been obtained externally. These steps will likely get moved to playbook tasks.