### PR TITLE
Fix cpu mode for qemu virt type

### DIFF
--- a/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
@@ -109,6 +109,7 @@ data:
       nova:
         libvirt:
           virt_type: qemu
+          cpu_mode: host-model
     pod:
       replicas:
         api_metadata: 1 


### PR DESCRIPTION
Set cpu mode to host-model when the virt type is set to qemu. This is to
match Cloud 9 settings.