### PR TITLE
overiding volume size for all rabbitmq in openstack and postgresql in ucp

### DIFF
--- a/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
@@ -28,4 +28,6 @@ data:
     monitoring:
       prometheus:
         enabled: false
+    volume:
+      size: {{ rabbitmq_volume_size }}
 ...

--- a/site/soc/software/charts/osh/openstack-compute-kit/neutron-rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/neutron-rabbitmq.yaml
@@ -35,4 +35,6 @@ data:
     monitoring:
       prometheus:
         enabled: false
+    volume:
+      size: {{ rabbitmq_volume_size }}
 ...

--- a/site/soc/software/charts/osh/openstack-compute-kit/nova-rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova-rabbitmq.yaml
@@ -35,4 +35,6 @@ data:
     monitoring:
       prometheus:
         enabled: false
+    volume:
+      size: {{ rabbitmq_volume_size }}
 ...

--- a/site/soc/software/charts/osh/openstack-glance/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/rabbitmq.yaml
@@ -35,4 +35,6 @@ data:
     monitoring:
       prometheus:
         enabled: false
+    volume:
+      size: {{ rabbitmq_volume_size }}
 ...

--- a/site/soc/software/charts/osh/openstack-heat/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-heat/rabbitmq.yaml
@@ -33,4 +33,6 @@ data:
     monitoring:
       prometheus:
         enabled: false
+    volume:
+      size: {{ rabbitmq_volume_size }}
 ...

--- a/site/soc/software/charts/osh/openstack-keystone/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/rabbitmq.yaml
@@ -35,4 +35,6 @@ data:
     monitoring:
       prometheus:
         enabled: false
+    volume:
+      size: {{ rabbitmq_volume_size }}
 ...

--- a/site/soc/software/charts/osh/openstack-mariadb/mariadb.yaml
+++ b/site/soc/software/charts/osh/openstack-mariadb/mariadb.yaml
@@ -32,4 +32,8 @@ data:
     pod:
       replicas:
         server: 1
+    volume:
+      size: {{ db_volume_size }}
+      backup:
+        size: {{ db_volume_size }}
 ...

--- a/site/soc/software/charts/ucp/core/postgresql.yaml
+++ b/site/soc/software/charts/ucp/core/postgresql.yaml
@@ -31,7 +31,7 @@ data:
   values:
     storage:
       pvc:
-        size: 2Gi
+        size: {{ db_volume_size }}
     pod:
       replicas:
         server: 1

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -93,3 +93,7 @@ ucp_deploy_timeout: 1800
 
 #Set timeout for osh deployment
 openstack_helm_deploy_timeout: 3000
+
+#Set volume size for all rabbitmq in openstack deployment and postgresql in ucp deployment.
+rabbitmq_volume_size: 5Gi
+db_volume_size: 5Gi


### PR DESCRIPTION

Volume size is configurable and default is 5Gi

QE ran into issue after creating vms.
rabbitmq and postgresql pods were in CrashLoopBackOff state.