### PR TITLE
 remove sphinx option not available on leap versions

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -80,7 +80,6 @@ html_theme_options = {
     'github_banner': True,
     'page_width': '1280px',
     'sidebar_width': '340px',
-    'show_relbars': 'true',
 }
 
 html_logo = 'suse_logo_w-tag_color.png'


### PR DESCRIPTION
leap alabaster theme version is a bit old (0.7.10) and it does not
support the show_relbars config as that appears on 0.7.11

Instead of silently ignore unkown parameters, alabaster will instead
die, which is pretty bad.

So we need to drop that option to be able to package docs for leap
15.0/15.1