### PR TITLE
Make sure USER is set in jenkins

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -26,6 +26,7 @@ pipeline {
         SOCOK8S_DEVELOPER_MODE = "True"
         DEPLOYMENT_MECHANISM = "openstack"
         ANSIBLE_STDOUT_CALLBACK = "yaml"
+        USER = "jenkins" /* Why isn't this set in the jenkins environment? */
     }
 
     stages {


### PR DESCRIPTION
For some unknown reason, there is no USER variable in the test
environment spawned by jenkins. Manually set the USER variable to the
appropriate value in the jenkins job. This is needed by the
airship-setup-deployer role.