### PR TITLE
Remove override that was disabling bootstrap jobs for cinder and glance charts

### DIFF
--- a/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
@@ -24,8 +24,6 @@ data:
     enabled: {{ run_tests }}
     timeout: {{ test_timeout }}
   values:
-    bootstrap:
-      enabled: false
     pod:
       replicas:
         api: 1

--- a/site/soc/software/charts/osh/openstack-glance/glance.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/glance.yaml
@@ -37,8 +37,6 @@ data:
     enabled: {{ run_tests }}
     timeout: {{ test_timeout }}
   values:
-    bootstrap:
-      enabled: false
     pod:
       replicas:
         api: 1


### PR DESCRIPTION
This change removes value overrides from the cinder and glance Armada charts that were preventing necessary bootstrap jobs from running. 