### PR TITLE
Add playbook and role for deploying tempest helm chart using airship shipyard workflow

### DIFF
--- a/doc/source/deployment/verify.rst
+++ b/doc/source/deployment/verify.rst
@@ -17,3 +17,143 @@ services are functioning as expected by running the following commands:
    export OS_CLOUD='openstack'
    openstack endpoint list
    openstack server list
+
+OpenStack Tempest Testing
+=========================
+
+After the deployment of SUSE Containerized OpenStack has completed, it is possible to run
+OpenStack Tempest tests against the core services in the deployment using the `run.sh` script.
+Before running Tempest tests, it will be necessary to manually configure OpenStack network
+resources and provide a few configuration parameters in the ${WORKDIR}/env/extravars file.
+
+Setting Up An External Network And Subnet in OpenStack
+------------------------------------------------------
+
+To set up an external network and subnet in OpenStack, the following commands can be run from a
+shell on the `Deployer` node.
+
+.. code-block:: console
+
+   export OS_CLOUD=openstack
+   openstack network create --provider-network-type flat --provider-physical-network public \ 
+     --external public
+   openstack subnet create --network public --subnet-range 192.168.100.0/24 --allocation-pool \
+     start=192.168.100.10,end=192.168.100.200 --gateway 192.168.100.1 --no-dhcp public-subnet
+
+.. note::
+
+   The external public network is expected to be able to reach the internet. The above values 
+   will vary based on your network environment. 
+
+Once the public network and subnet have been created in OpenStack, their names will need to be
+made known to Tempest by adding the following keys in the ${WORKDIR}/env/extravars file:
+
+.. code-block:: yaml
+
+   openstack_external_network_name: "public"
+   openstack_external_subnet_name: "public-subnet"
+
+Tempest will also need to know the CIDR block from which to allocate project IPv4 subnets. This
+value should be specified with the following key in the extravars file:
+
+.. code-block:: yaml
+
+   openstack_project_network_cidr: "192.0.4.0/24"
+
+Configuring Tempest Test Parameters
+-----------------------------------
+
+By default, the implementation of Tempest in SUSE Containerized OpenStack will run smoke tests
+for all deployed services including compute, identity, image, network, and volume, using 4
+workers. 
+
+To modify the number of workers, add the following key with a value of your choosing to the
+extravars file:
+
+.. code-block:: yaml
+
+   tempest_workers: 6
+
+To disable tests for specific OpenStack components, any or all of the following keys can be
+added to the extravars file:
+
+.. code-block:: yaml
+
+   tempest_enable_cinder_service: false
+   tempest_enable_glance_service: false
+   tempest_enable_nova_service: false
+   tempest_enable_neutron_service: false
+
+To run all Tempest tests instead of just smoke tests, add the following key to the extravars
+file:
+
+.. code-block:: yaml
+
+   tempest_test_type: "all"
+
+Running Tempest Tests
+---------------------
+
+Once all of the OpenStack network resources have been created and all configuration parameters have
+been provided in ${WORKDIR}/env/extravars, Tempest testing can be started by running the following
+command from the root of the socok8s directory:
+
+.. code-block:: console
+
+   ./run.sh test
+
+Once the Tempest pods have been deployed, testing will begin immediately. You can check the progress
+of the test pod at any time by running
+
+.. code-block:: console
+
+   kubectl get pods -n openstack | grep tempest-run
+
+Example output:
+
+.. code-block:: console
+
+   airship-tempest-run-tests-hq6jg                          1/1     Running       0          33m
+
+A status of 'Running' indicates that testing is still in progress. Once testing is complete, the status
+of the airship-tempest-run-tests pod will change to 'Complete', indicating that all tests passed, or
+'Error', indicating that at least one test has failed.
+
+Tempest Test Results
+--------------------
+
+All test results can be viewed by retrieving the logs from the airship-tempest-run-tests pod by running
+the following command:
+
+.. code-block:: console
+
+   kubectl logs -n openstack airship-tempest-run-tests-hq6jg
+
+.. note::
+
+   The logs can be viewed at any time, even while a current test batch is still running. 
+
+Once testing is complete, the logs will conclude with a summary of all passed, skipped, and failed tests
+similar to the following:
+
+.. code-block:: console
+
+   ======
+   Totals
+   ======
+   Ran: 78 tests in 104.0000 sec.
+    - Passed: 62
+    - Skipped: 16
+    - Expected Fail: 0
+    - Unexpected Success: 0
+    - Failed: 0
+   Sum of execute time for each test: 56.3147 sec.
+
+   ==============
+   Worker Balance
+   ==============
+    - Worker 0 (19 tests) => 0:01:44.140828
+    - Worker 1 (20 tests) => 0:01:02.484599
+    - Worker 2 (18 tests) => 0:00:29.100245
+    - Worker 3 (21 tests) => 0:01:28.449495
+   

--- a/playbooks/deploy_tempest.yml
+++ b/playbooks/deploy_tempest.yml
@@ -1,0 +1,6 @@
+---
+- hosts: soc-deployer
+  gather_facts: yes
+  any_errors_fatal: true
+  roles:
+    - role: airship-deploy-tempest

--- a/playbooks/roles/airship-deploy-tempest/defaults/main.yml
+++ b/playbooks/roles/airship-deploy-tempest/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+deploy_tempest: true
+tempest_test_type: "smoke"
+tempest_test_args:
+  smoke:  "--smoke"
+  all: "--regex '.*'"
+tempest_workers: 4
+tempest_enable_cinder_service: true
+tempest_enable_glance_service: true
+tempest_enable_nova_service: true
+tempest_enable_neutron_service: true
+openstack_external_network_name: "public"
+openstack_external_subnet_name: "public-subnet"
+openstack_project_network_cidr: "172.0.4.0/24"

--- a/playbooks/roles/airship-deploy-tempest/files/tempest_get_image_id.sh
+++ b/playbooks/roles/airship-deploy-tempest/files/tempest_get_image_id.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -xe
+
+export OS_CLOUD=openstack
+
+IMAGE_NAME=$(openstack image show -f value -c name \
+  $(openstack image list -f csv | awk -F ',' '{ print $2 "," $1 }' | \
+  grep "^\"Cirros" | head -1 | awk -F ',' '{ print $2 }' | tr -d '"'))
+openstack image show "${IMAGE_NAME}" -f value -c id

--- a/playbooks/roles/airship-deploy-tempest/files/tempest_setup_subnet.sh
+++ b/playbooks/roles/airship-deploy-tempest/files/tempest_setup_subnet.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -xe
+
+export OS_CLOUD=openstack
+
+export OSH_PRIVATE_SUBNET_POOL="10.0.0.0/8"
+export OSH_PRIVATE_SUBNET_POOL_NAME="shared-default-subnetpool"
+export OSH_PRIVATE_SUBNET_POOL_DEF_PREFIX="24"
+openstack stack create --wait \
+  --parameter subnet_pool_name=${OSH_PRIVATE_SUBNET_POOL_NAME} \
+  --parameter subnet_pool_prefixes=${OSH_PRIVATE_SUBNET_POOL} \
+  --parameter subnet_pool_default_prefix_length=${OSH_PRIVATE_SUBNET_POOL_DEF_PREFIX} \
+  -t ./tools/gate/files/heat-subnet-pool-deployment.yaml \
+  heat-subnet-pool-deployment

--- a/playbooks/roles/airship-deploy-tempest/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-tempest/tasks/main.yml
@@ -1,0 +1,122 @@
+---
+# tasks file for airship-deploy-tempest
+- name: Load standard variables
+  include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
+  tags:
+    - always
+
+- name: Set site path
+  set_fact:
+    site_path: "{{ upstream_repos_clone_folder }}/airship/treasuremap/site/{{ socok8s_site_name }}"
+  tags:
+    - always
+
+- name: Ensure site directory for {{ socok8s_site_name }} exists
+  become: yes
+  file:
+    path: "{{ site_path }}"
+    state: directory
+
+- name: Ensure tempest chart directory exists
+  become: yes
+  file:
+    path: "{{ site_path }}/software/charts/osh/openstack-tempest"
+    state: directory
+
+- name: Get external network ID
+  shell: "openstack network show {{ openstack_external_network_name }} -f value -c id"
+  environment:
+    OS_CLOUD: openstack
+  register: tempest_test_public_network_id
+  tags:
+    - skip_ansible_lint
+
+- name: Get external subnet CIDR
+  shell: "openstack subnet show {{ openstack_external_subnet_name }} -f value -c cidr"
+  environment:
+    OS_CLOUD: openstack
+  register: openstack_external_subnet_cidr
+  tags:
+    - skip_ansible_lint
+
+- name: Check if subnet pool stack exists
+  shell: "openstack stack show heat-subnet-pool-deployment"
+  environment:
+    OS_CLOUD: openstack
+  register: subnet_pool_result
+  failed_when:
+    - subnet_pool_result.rc != 0
+    - "'not found' not in subnet_pool_result.stderr"
+  changed_when: false
+  tags:
+    - skip_ansible_lint
+
+- name: Copy setup subnet pool script
+  copy:
+    src: "{{ role_path }}/files/tempest_setup_subnet.sh"
+    dest: /tmp/tempest_setup_subnet.sh
+    mode: 0755
+
+- name: Setup subnet pool
+  shell: /tmp/tempest_setup_subnet.sh
+  args:
+    chdir: "{{ upstream_repos_clone_folder }}/openstack/openstack-helm"
+  when: subnet_pool_result.stderr is search('not found')
+  tags:
+    - skip_ansible_lint
+
+- name: Get m1.tiny flavor ID
+  shell: "openstack flavor show m1.tiny -f value -c id"
+  environment:
+    OS_CLOUD: openstack
+  register: tempest_test_flavor_id
+  tags:
+    - skip_ansible_lint
+
+- name: Copy get Cirros image ID script
+  copy:
+    src: "{{ role_path }}/files/tempest_get_image_id.sh"
+    dest: /tmp/tempest_get_image_id.sh
+    mode: 0755
+
+- name: Get Cirros image ID
+  shell: /tmp/tempest_get_image_id.sh
+  register: tempest_test_image_id
+  tags:
+    - skip_ansible_lint
+
+- name: Render tempest.yaml and move to openstack-tempest directory
+  become: yes
+  template:
+    src: "{{ playbook_dir }}/../site/soc/software/charts/osh/openstack-tempest/tempest.yaml"
+    dest: "{{ site_path }}/software/charts/osh/openstack-tempest/tempest.yaml"
+
+- name: Move chart-group.yaml to openstack-tempest directory
+  become: yes
+  copy:
+    src: "{{ playbook_dir }}/../site/soc/software/charts/osh/openstack-tempest/chart-group.yaml"
+    dest: "{{ site_path }}/software/charts/osh/openstack-tempest/chart-group.yaml"
+
+- name: Reprocess site manifest template for tempest deployment
+  become: yes
+  template:
+    src: "{{ playbook_dir }}/../site/soc/software/manifests/full-site.yaml"
+    dest: "{{ site_path }}/software/manifests/full-site.yaml"
+  when: deploy_tempest|default(false)|bool
+
+- name: Delete previous tempest test pods if present
+  shell: "helm delete --purge airship-tempest"
+  register: helm_result
+  failed_when:
+    - helm_result.rc != 0
+    - "'not found' not in helm_result.stderr"
+  changed_when: helm_result.stdout is search('deleted')
+  tags:
+    - skip_ansible_lint
+
+- name: Update site software via Shipyard
+  include_role:
+    name: airship-deploy-osh
+    apply:
+      tags:
+        - update_airship_osh_site

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,7 @@ set -o errexit
 usage() {
     echo "deploy                                         -- Deploy SUSE Containerized OpenStack."
     echo "update_openstack                               -- Update OpenStack deployment."
+    echo "test                                           -- Deploy and run OpenStack Tempest tests."
     echo "add_openstack_compute                          -- Add OpenStack compute node. Add compute node host(s) in inventory file."
     echo "remove_openstack_compute <compute-node-name>   -- Remove OpenStack compute node. Provide compute node host name with option."
     echo "remove_deployment                              -- Delete all resources related with deployment including images."
@@ -154,6 +155,9 @@ case "$deployment_action" in
         ;;
     "gather_logs")
         gather_logs
+        ;;
+    "test")
+        deploy_tempest
         ;;
     *)
         echo "Invalid option, Check --help for valid options"

--- a/script_library/deployment-actions-kvm.sh
+++ b/script_library/deployment-actions-kvm.sh
@@ -63,6 +63,10 @@ function remove_compute(){
     echo "Now Remove compute"
     run_ansible ${socok8s_absolute_dir}/playbooks/remove_compute.yml -e compute_node_name=$1
 }
+function deploy_tempest(){
+    echo "Deploying Tempest"
+    run_ansible ${socok8s_absolute_dir}/playbooks/deploy_tempest.yml
+}
 function clean_k8s(){
     echo "DANGER ZONE. Set the env var 'DELETE_ANYWAY' to 'YES' to delete everything in your userspace."
     if [[ ${DELETE_ANYWAY:-"NO"} == "YES" ]]; then

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -65,6 +65,10 @@ function deploy_airship(){
     fi
     run_ansible ${socok8s_absolute_dir}/playbooks/generic-deploy_airship.yml ${tagged_info}
 }
+function deploy_tempest(){
+    echo "Deploying Tempest"
+    run_ansible ${socok8s_absolute_dir}/playbooks/deploy_tempest.yml
+}
 function clean_airship(){
     clean_action=''
     action_desc='everything'

--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -91,7 +91,7 @@ validate_cli_options (){
        exit 1
    fi
 
-   OPTIONS=(deploy update_openstack add_openstack_compute remove_openstack_compute remove_deployment deploy_network deploy_ses deploy_caasp deploy_ccp_deployer enroll_caasp_workers patch_upstream build_images deploy_osh setup_caasp_workers_for_openstack setup_hosts setup_openstack setup_airship setup_everything teardown clean_k8s clean_airship_not_images gather_logs)
+   OPTIONS=(deploy test update_openstack add_openstack_compute remove_openstack_compute remove_deployment deploy_network deploy_ses deploy_caasp deploy_ccp_deployer enroll_caasp_workers patch_upstream build_images deploy_osh setup_caasp_workers_for_openstack setup_hosts setup_openstack setup_airship setup_everything teardown clean_k8s clean_airship_not_images gather_logs)
 
    action=$1
    isvalid=false

--- a/site/soc/software/charts/osh/openstack-tempest/chart-group.yaml
+++ b/site/soc/software/charts/osh/openstack-tempest/chart-group.yaml
@@ -1,0 +1,18 @@
+---
+schema: armada/ChartGroup/v1
+metadata:
+  schema: metadata/Document/v1
+  name: openstack-tempest-soc
+  layeringDefinition:
+    abstract: false
+    layer: site
+    parentSelector:
+      name: openstack-tempest-chart-group-global
+      component: tempest
+    actions:
+      - method: replace
+        path: .chart_group
+  storagePolicy: cleartext
+data:
+  chart_group:
+    - openstack-tempest-soc

--- a/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
+++ b/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
@@ -1,0 +1,52 @@
+---
+schema: armada/Chart/v1
+metadata:
+  schema: metadata/Document/v1
+  name: openstack-tempest-soc
+  layeringDefinition:
+    abstract: false
+    layer: site
+    parentSelector:
+      name: tempest-global
+      component: tempest
+    actions:
+      - method: merge
+        path: .
+  storagePolicy: cleartext
+data:
+  wait:
+    timeout: 6000
+{% if deploy_tempest is defined and deploy_tempest is sameas true %}
+  values:
+    jobs:
+      run_tests:
+        backoffLimit: 0
+        restartPolicy: Never
+    conf:
+      script: "tempest run --config-file /etc/tempest/tempest.conf -w {{ tempest_workers }} {{ tempest_test_args[tempest_test_type] }}"
+      tempest:
+        identity-feature-enabled:
+          api_v2: false
+          domain_specific_drivers: true
+        compute:
+          flavor_ref: "{{ tempest_test_flavor_id.stdout }}"
+          image_ref: "{{ tempest_test_image_id.stdout }}"
+          image_ref_alt: "{{ tempest_test_image_id.stdout }}"
+          hypervisor_type: "{{ tempest_test_hypervisor_type | default('qemu') }}"
+        network:
+          default_network: "10.0.0.0/8"
+          project_network_cidr: "{{ openstack_project_network_cidr }}"
+          floating_network_name: "{{ openstack_external_network_name }}"
+          public_network_id: "{{ tempest_test_public_network_id.stdout }}"
+        validation:
+          image_ssh_user: "cirros"
+          image_ssh_password: "gocubsgo"
+          network_for_ssh: "{{ openstack_external_network_name }}"
+          floating_ip_range: "{{ openstack_external_subnet_cidr.stdout }}"
+        service_available:
+          cinder: "{{ tempest_enable_cinder_service }}"
+          glance: "{{ tempest_enable_glance_service }}"
+          nova: "{{ tempest_enable_nova_service }}"
+          neutron: "{{ tempest_enable_neutron_service }}"
+{% endif %}  
+...

--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -73,6 +73,11 @@ data:
         reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
         subpath: helm-toolkit
         type: git
+      tempest:
+        location: https://opendev.org/openstack/openstack-helm
+        reference: 3811eedefe92f1df6c1d31a366773b9a6dce0b7b
+        subpath: tempest
+        type: git
   images:
     calico:
       calico: {}
@@ -208,6 +213,9 @@ data:
         openvswitch_vswitchd: "{{ suse_osh_registry_location }}/openstackhelm/openvswitch:{{ suse_infra_image_version }}"
       rabbitmq:
         prometheus_rabbitmq_exporter_helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+      tempest:
+        tempest_run_tests: "{{ suse_osh_registry_location }}/openstackhelm/tempest:{{ suse_infra_image_version }}"
+        ks_user: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
     osh_infra:
       elasticsearch:
         memory_init: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"

--- a/site/soc/software/manifests/full-site.yaml
+++ b/site/soc/software/manifests/full-site.yaml
@@ -26,4 +26,7 @@ data:
     - openstack-compute-kit-soc
     - openstack-heat-soc
     - openstack-horizon-soc
+{% if deploy_tempest is defined and deploy_tempest is sameas true %}
+    - openstack-tempest-soc
+{% endif %}
 ...


### PR DESCRIPTION
This change is necessary to accommodate the setup tasks required by the tempest helm chart that setup networks and obtain image, flavor and network IDs to pass in as value overrides. 

After rendering the templates, an openstack-tempest directory is created in {clone_folder}/airship/treasuremap/site/soc/software/charts/osh and all appropriate files are moved there. A new task was also added to reprocess the software/manifests/full-site.yaml template so that tempest can be added to the deployment manifest. Once all files are in place, the airship-deploy-osh role is called with the update_airship_osh_site tag and the update_software workflow is run to deploy tempest into the cluster.