### PR TITLE
Only install requirements from PyPI when explicitly set

### DIFF
--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -347,6 +347,12 @@ include a ``baremetal`` and ``kvm``.
 not. This adds a step for patching upstream code, builds images and then
 continues the deployment.
 
+``SOCOK8S_USE_VIRTUALENV`` determines if the script should set up and use a
+virtualenv for python and ansible requirements. Without this it is expected
+that ansible and the requirements are installed via system packages.
+When ``SOCOK8S_DEVELOPER_MODE`` is set to True, this defaults to True, otherwise
+this defaults to False.
+
 ``USE_ARA`` determines if you want to store records in ARA. Set its
 value to 'True' for using ARA.
 

--- a/run.sh
+++ b/run.sh
@@ -30,6 +30,7 @@ done
 
 if [[ "${SOCOK8S_DEVELOPER_MODE:-False}" == "True" ]]; then
     set -x
+    SOCOK8S_USE_VIRTUALENV=${SOCOK8S_USE_VIRTUALENV:-True}
 fi
 
 # USE an env var to setup where to deploy to

--- a/script_library/bootstrap-ansible-if-necessary.sh
+++ b/script_library/bootstrap-ansible-if-necessary.sh
@@ -13,7 +13,6 @@ function install_ansible (){
         source ${socok8s_workspace}/.ansiblevenv/bin/activate
         pip install --upgrade pip
         pip install --upgrade -r $(dirname "$0")/script_library/requirements.txt
-        python -m ara.setup.env > ${socok8s_workspace}/.ansiblevenv/ara.rc
     else
         echo "Found virtualenv at ${socok8s_workspace}/.ansiblevenv . Using that"
         source ${socok8s_workspace}/.ansiblevenv/bin/activate

--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -36,18 +36,38 @@ check_openstack_environment_is_ready_for_deploy (){
     openstack keypair list | grep ${KEYNAME} > /dev/null || (echo "keyname not found. export KEYNAME=" && exit 2)
 }
 
+check_python_requirement (){
+    if ! python -c "import ${1}" > /dev/null 2>&1; then
+        echo "Missing python requirement ${1}."
+        echo "Install from your system packages or set SOCOK8S_USE_VIRTUALENV=True to install requirements into a virtualenv."
+        exit 1
+    fi
+}
+
 check_ansible_requirements (){
+    if [[ "${SOCOK8S_USE_VIRTUALENV:-False}" == "True" ]]; then
+        install_ansible
+    fi
     # Ansible is required
-    which ansible-playbook > /dev/null || install_ansible
+    if ! which ansible-playbook > /dev/null 2>&1; then
+        echo "Ansible is not installed."
+        echo "Install from your system packages or set SOCOK8S_USE_VIRTUALENV=True to install ansible and other requirements into a virtualenv."
+        exit 1
+    fi
     # We need ansible version 2.7 minimum
-    [[ $(ansible --version | awk 'NR==1 { gsub(/[.]/,""); print substr($2,0,2); }' ) -lt "27" ]] && install_ansible
+    if [[ $(ansible --version | awk 'NR==1 { gsub(/[.]/,""); print substr($2,0,2); }' ) -lt "27" ]]; then
+        echo "Insufficent version of ansible: 2.7 or greater is required."
+        echo "Install from your system packages or set SOCOK8S_USE_VIRTUALENV=True to install ansible and other requirements into a virtualenv."
+        exit 1
+    fi
     # In the ansible venv, we should have jmespath and netaddr
-    python -c 'import jmespath' || install_ansible
-    python -c 'import netaddr' || install_ansible
-    python -c 'import openstack' || install_ansible
-    # If ara is required, install it.
+    check_python_requirement 'jmespath'
+    check_python_requirement 'netaddr'
+    check_python_requirement 'openstack'
+    # If ara is requested
     if [[ ${USE_ARA:-False} == "True" ]]; then
-        python -c 'import ara' || install_ansible
+        check_python_requirement 'ara'
+        python -m ara.setup.env > ${socok8s_workspace}/ara.rc
     fi
 }
 

--- a/script_library/requirements.txt
+++ b/script_library/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.7.10
+ansible==2.7.8
 netaddr==0.7.19
 jmespath==0.9.3
 requests==2.21.0

--- a/script_library/run-ansible.sh
+++ b/script_library/run-ansible.sh
@@ -27,7 +27,7 @@ function run_ansible(){
 
     if [[ ${USE_ARA:-False} == "True" ]]; then
         echo "Loading ARA"
-        source ${socok8s_workspace}/.ansiblevenv/ara.rc
+        source ${socok8s_workspace}/ara.rc
     fi
 
     pushd ${socok8s_absolute_dir}


### PR DESCRIPTION
Requirements should come from packages unless in developer mode or the user has explicitly set SOCOK8S_USE_VIRTUALENV.