### PR TITLE
Add explicit shipyard image download task

### DIFF
--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -86,6 +86,21 @@
     - install
     - always
 
+# The first time you run shipyard, it will download its docker image
+- name: Download Shipyard image
+  command: '{{ shipyard }} help'
+  args:
+    chdir: '{{ upstream_repos_clone_folder }}/airship/shipyard'
+  environment:
+    SHIPYARD_IMAGE: "{{ shipyard_image }}"
+    OS_PASSWORD: "{{ lookup('password', secrets_location + '/ucp_shipyard_keystone_password ' + password_opts) }}"
+# The download may fail on the first attempt
+  retries: 3
+  tags:
+    - install
+    - skip_ansible_lint
+    - update_airship_osh_site
+
 # TODO(aagate): Add a changed_when: to help idempotency
 - name: Create config docs in Shipyard
   command: '{{ shipyard }} create configdocs {{ socok8s_site_name }}-design --replace --directory=/target/{{ pegleg_output }}'


### PR DESCRIPTION
The first time you run shipyard, it will download its docker image.
Use a help command to download the image, and retry 3 times to work
around network instability.