### PR TITLE
Remove dev patch for scale profile schema

### DIFF
--- a/playbooks/roles/dev-patcher/defaults/main.yml
+++ b/playbooks/roles/dev-patcher/defaults/main.yml
@@ -10,7 +10,5 @@ dev_patcher_packages:
 dev_patcher_patches:
   # deckhand: Adding opensuse image build for deckhand
   - 638301
-  # treasuremap: Add a preliminary draft of schema for the pod scale policy/profile in Airship.
-  - 639861
   # osh-infra: Add support for mulitple VIPS
   - 640115

--- a/site/soc/software/config/endpoints.yaml
+++ b/site/soc/software/config/endpoints.yaml
@@ -653,8 +653,6 @@ data:
         default: null
         public:
           host: image.DOMAIN
-        admin: 
-          host: image-api.DOMAIN
       path:
         default: null
       scheme:


### PR DESCRIPTION
Remove dev patch for scale profile schema. Uptream prefers to keep
additional profiles downstream.`