### PR TITLE
jenkins: retry SES step

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -50,7 +50,9 @@ pipeline {
                 }
                 stage('Setup SES') {
                     steps {
-                        sh "./run.sh deploy_ses"
+                        retry(3) {
+                            sh "./run.sh deploy_ses"
+                        }
                     }
                 }
                 stage('Setup Deployer') {


### PR DESCRIPTION
Seems that sometimes we are hitting an issue when deploying ses which
is fixed by retrying.

As the ses deployment is done by the ses team playbooks and we dont
have any control over those, we cannot directly try to indroduce the
retry on the playbook tasks. Instead we can just retry the jenkins
step, which should be idempotent, to check if its fixed.