### PR TITLE
Fix glance admin enpoint url

### DIFF
--- a/site/soc/software/config/endpoints.yaml
+++ b/site/soc/software/config/endpoints.yaml
@@ -653,8 +653,6 @@ data:
         default: null
         public:
           host: image.DOMAIN
-        admin: 
-          host: image-api.DOMAIN
       path:
         default: null
       scheme:


### PR DESCRIPTION
The glance admin ednpoint had pattern DOMAIN that wasn't defined in
substituion. Changed to use the default value, that is the same as
internal endpoint.