### PR TITLE
Specify a patchset revision for dev-patcher (SOC-9234)

### DIFF
--- a/playbooks/roles/dev-patcher/defaults/main.yml
+++ b/playbooks/roles/dev-patcher/defaults/main.yml
@@ -9,6 +9,8 @@ dev_patcher_packages:
 #conflicting patches will fail (because need resolving)
 dev_patcher_patches:
   # deckhand: Adding opensuse image build for deckhand
-  - 638301
+  - - 638301
+    - 3eee2f196820e0502fcbfb5234cc338f6a6611e6
   # osh-infra: Add support for mulitple VIPS
-  - 640115
+  - - 640115
+    - acdab0cd7f7c4c718d09029e4fb2722f616ecf4b

--- a/playbooks/roles/dev-patcher/tasks/main.yml
+++ b/playbooks/roles/dev-patcher/tasks/main.yml
@@ -50,7 +50,7 @@
   include_tasks: patch-repos.yml
   loop: "{{ (dev_patcher_patches) + (dev_patcher_user_patches | default([])) }}"
   loop_control:
-    loop_var: patchnumber
+    loop_var: patch
 
 - name: Check if there is local code change to cloned repos on deployer
   stat:

--- a/playbooks/roles/dev-patcher/tasks/patch-repos.yml
+++ b/playbooks/roles/dev-patcher/tasks/patch-repos.yml
@@ -1,7 +1,15 @@
 ---
+- name: Fetch patch number
+  set_fact:
+    patchnumber: "{{ patch[0] }}"
+
+- name: Fetch patch revision
+  set_fact:
+    patchrevision: "{{ patch[1] | default('current') }}"
+
 - name: Get patch {{ patchnumber }} details
   uri:
-    url: "{{ dev_patcher_baseurl }}/?q=is:open+{{ patchnumber }}&o=CURRENT_REVISION"
+    url: "{{ dev_patcher_baseurl }}/?q=is:open+{{ patchnumber }}&o=ALL_REVISIONS"
     return_content: yes
     body_format: json
   register: thispatch
@@ -16,12 +24,13 @@
 - name: Apply {{ patchnumber }} - {{ jsoncontent[0]['subject'] }}
   shell: |
     set -o errexit
-    git fetch {{ jsoncontent[0]['revisions'][current_revision]['fetch']['anonymous http']['url'] }} {{ jsoncontent[0]['revisions'][current_revision]['fetch']['anonymous http']['ref'] }}
+    git fetch {{ jsoncontent[0]['revisions'][revision]['fetch']['anonymous http']['url'] }} {{ jsoncontent[0]['revisions'][revision]['fetch']['anonymous http']['ref'] }}
     git cherry-pick FETCH_HEAD
   args:
     chdir: "{{ upstream_repos_clone_folder }}/{{ project }}"
   vars:
-    current_revision: "{{ jsoncontent[0]['current_revision'] }}"
+    # Use latest revision of no revision was specified
+    revision: "{{ (patchrevision != 'current') | ternary(patchrevision, jsoncontent[0]['current_revision']) }}"
     project: "{{ jsoncontent[0]['project'] }}"
   when:
     # Do not apply patches if they are already merged


### PR DESCRIPTION
To make sure product deployment does not change if a patch is adapted
upstream, make sure specific revision is referenced instead of
always using this latest available one.