### PR TITLE
Do not require developer mode for applying patches

### DIFF
--- a/playbooks/generic-patch_upstream.yml
+++ b/playbooks/generic-patch_upstream.yml
@@ -2,17 +2,7 @@
 - hosts: soc-deployer
   gather_facts: yes
   any_errors_fatal: true
-  pre_tasks:
-    #http://jinja.pocoo.org/docs/2.10/templates/#default
-    - name: Check if developer mode should be enabled
-      set_fact:
-        developer_mode: "{{ (lookup('env','SOCOK8S_DEVELOPER_MODE') | default('False', true) ) | bool }}"
-      tags:
-        - always
-        - imagebuilder
-        - upstream_patching
   roles:
     - role: dev-patcher
-      when: developer_mode
       tags:
         - upstream_patching


### PR DESCRIPTION
It's possible patching is required even for non-developers. 
~Introduce new variable for that and set it to true by default.~

I think this might be necessary for the case when we need to release while patches are not merged upstream. It does not seem wise to tell users to use "developer mode", hence the ~new variable and~ new default.

Setting as do-not-merge initially as there might be opposition to this approach.