### PR TITLE
Remove compute node is part of remove deployment.

### DIFF
--- a/playbooks/generic-clean_airship.yml
+++ b/playbooks/generic-clean_airship.yml
@@ -14,6 +14,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
+- hosts: airship-openstack-compute-workers
+  gather_facts: no
+  any_errors_fatal: true
+  roles:
+    - { role: openstack-remove-compute, compute_node_name: "{{ inventory_hostname }}" }
+
 - hosts: soc-deployer
   gather_facts: no
   pre_tasks:

--- a/playbooks/roles/openstack-remove-compute/tasks/main.yml
+++ b/playbooks/roles/openstack-remove-compute/tasks/main.yml
@@ -8,11 +8,24 @@
   failed_when: false
   changed_when: false
 
-- name: Validate the compute node id.
+- name: Validate compute node id.
   debug:
     msg: "Compute node {{ compute_node_name }} does not exists in openstack."
   delegate_to: localhost
   when: compute_id.stdout | length | int == 0
+
+- name: Get VM list from compute node.
+  command: "openstack server list --host {{ compute_node_name }}"
+  register: vm_exist
+  delegate_to: localhost
+  failed_when: false
+  changed_when: false
+
+- name: Validate VM(s) exists on compute node.
+  fail:
+    msg: "VM(s) exists on compute node {{ compute_node_name }}."
+  delegate_to: localhost
+  when: vm_exist.stdout | length | int != 0
 
 - name: Check for control-plane label.
   shell: |

--- a/run.sh
+++ b/run.sh
@@ -91,7 +91,12 @@ case "$deployment_action" in
             echo "Please enter compute node host name"
             exit 1
         fi
-        remove_compute $2
+        read -r -p "WARNING: Please remove all VM(s) from the compute host. Are you sure to continue? [y/n] " user_input
+        if [[ $user_input == "y" ]]; then
+            remove_compute $2
+        else
+            exit 0
+        fi
         ;;
     "setup_caasp_workers_for_openstack")
         setup_caasp_workers_for_openstack
@@ -140,7 +145,12 @@ case "$deployment_action" in
         clean_airship clean_openstack_clean_ucp_clean_rest
         ;;
     "remove_deployment")
-        clean_airship
+        read -r -p "WARNING: Please remove all VM(s) from all compute host(s). Are you sure to continue? [y/n] " user_input
+        if [[ $user_input == "y" ]]; then
+            clean_airship
+        else
+            exit 0
+        fi
         ;;
     "gather_logs")
         gather_logs


### PR DESCRIPTION
Issue:
QA noticed nova instances going to ERROR in the new deployment.
"libvirt.libvirtError: operation failed: domain 'instance-00000001' already exists"
This was because nova instances still exists from previous deploy.