### PR TITLE
Fix Nova missing genisoimage error

### DIFF
--- a/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
@@ -110,6 +110,8 @@ data:
         libvirt:
           virt_type: qemu
           cpu_mode: host-model
+        DEFAULT:
+          mkisofs_cmd: mkisofs
     pod:
       replicas:
         api_metadata: 1 


### PR DESCRIPTION
SUSE Nova image doesn't have genisoimage installed. Added overrides in
Nova chart to use mkisofs as replacement.