### PR TITLE
Jenkinsfile: don't run the final deploys in "parallel"

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -68,29 +68,25 @@ pipeline {
             }
         }
 
-        stage('Deploy') {
-            parallel {
-		stage('Deploy OpenStack Helm') {
-		    when {
-			expression { params.deployment == "osh" }
-		    }
-		    steps {
-			sh "./run.sh patch_upstream"
-			sh "./run.sh build_images"
-			sh "./run.sh deploy_osh"
-		    }
-		}
+	stage('Deploy OpenStack Helm') {
+	    when {
+		expression { params.deployment == "osh" }
+	    }
+	    steps {
+		sh "./run.sh patch_upstream"
+		sh "./run.sh build_images"
+		sh "./run.sh deploy_osh"
+	    }
+	}
 
-		stage('Deploy Airship') {
-		    when {
-			expression { params.deployment == "airship" }
-		    }
-		    steps {
-			sh "./run.sh setup_airship"
-		    }
-		}
-            }
-        }
+	stage('Deploy Airship') {
+	    when {
+		expression { params.deployment == "airship" }
+	    }
+	    steps {
+		sh "./run.sh setup_airship"
+	    }
+	}
     }
 
     post {


### PR DESCRIPTION
Apparently skipping a parallel stage in jenkins as a good way to confuse
the Blue Ocean UI: https://issues.jenkins-ci.org/browse/JENKINS-48879