### PR TITLE
Add deployment timeout to Heat chart

### DIFF
--- a/site/soc/software/charts/osh/openstack-heat/heat.yaml
+++ b/site/soc/software/charts/osh/openstack-heat/heat.yaml
@@ -41,6 +41,8 @@ metadata:
       dest:
         path: .values.pod.replicas.engine
 data:
+  wait:
+    timeout: {{ openstack_helm_deploy_timeout }}
   test:
     enabled: {{ run_tests }}
     timeout: {{ test_timeout }}


### PR DESCRIPTION
Add deployment timeout to Heat chart so Airship doesnot timeout
prematurely.