### PR TITLE
Updated glance bootstrap values to use cirros image 0.4.0 with public visibility.

### DIFF
--- a/site/soc/software/charts/osh/openstack-glance/glance.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/glance.yaml
@@ -37,6 +37,14 @@ data:
     enabled: {{ run_tests }}
     timeout: {{ test_timeout }}
   values:
+    bootstrap:
+      structured:
+        images:
+          cirros:
+            name: "Cirros 0.4.0 64-bit"
+            source_url: "http://download.cirros-cloud.net/0.4.0/"
+            image_file: "cirros-0.4.0-x86_64-disk.img"
+            private: false
     pod:
       replicas:
         api: 1
@@ -46,6 +54,32 @@ data:
       software:
         rbd:
           rbd_store_pool_app_name: rbd
+      rally_tests:
+        tests:
+          GlanceImages.create_and_delete_image:
+          - args:
+              container_format: bare
+              disk_format: qcow2
+              image_location: http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
+            runner:
+              concurrency: 1
+              times: 1
+              type: constant
+            sla:
+              failure_rate:
+                max: 0
+          GlanceImages.create_and_list_image:
+          - args:
+              container_format: bare
+              disk_format: qcow2
+              image_location: http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
+            runner:
+              concurrency: 1
+              times: 1
+              type: constant
+            sla:
+              failure_rate:
+                max: 0
       ceph:
         enabled: true
         monitors: {{ ','.join(suse_airship_deploy_ceph_mons) }}


### PR DESCRIPTION
This change updates the Cirros test image from 0.3.5 to 0.4.0, which brings it up to date with what's used in Cloud 9. It also sets the visibility to "public", which is required for some of the tempest tests to pass.