### PR TITLE
Install helm-serve unit file directly if ansible is not running as root

### DIFF
--- a/playbooks/roles/common-deployer/tasks/helm-run.yml
+++ b/playbooks/roles/common-deployer/tasks/helm-run.yml
@@ -1,4 +1,12 @@
 ---
+- name: Copy systemd unit into place for helm server if running as non-root
+  become: yes
+  template:
+    src: helm-serve.service.j2
+    dest: /etc/systemd/system/helm-serve.service
+    mode: 0640
+  when: ansible_user != "root"
+
 - name: Ensure helm serve service is running
   become: yes
   systemd:

--- a/playbooks/roles/common-deployer/templates/helm-serve.service.j2
+++ b/playbooks/roles/common-deployer/templates/helm-serve.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Helm Server
+After=network.target
+
+[Service]
+User={{ ansible_user }}
+Restart=always
+ExecStart=/usr/bin/helm serve
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
And set User=ansible user so that the service can run as current user

By default the service file is provided with the `helm` package, but that one assumes helm-serve is run by root.