### PR TITLE
Fix the novncproxy url in host rules

### DIFF
--- a/playbooks/roles/airship-setup-deployer/tasks/main.yml
+++ b/playbooks/roles/airship-setup-deployer/tasks/main.yml
@@ -100,7 +100,7 @@
       {{ socok8s_ext_vip }} compute.openstack.svc.cluster.local
       {{ socok8s_ext_vip }} network.openstack.svc.cluster.local
       {{ socok8s_ext_vip }} dashboard.openstack.svc.cluster.local
-      {{ socok8s_ext_vip }} novncproxy.openstack.svc.cluster.local
+      {{ socok8s_ext_vip }} nova-novncproxy.openstack.svc.cluster.local
       {{ socok8s_ext_vip }} orchestration.openstack.svc.cluster.local
 
 - name: Creates /etc/openstack directory

--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -89,7 +89,7 @@
       {{ socok8s_ext_vip }} neutron-server.openstack.svc.cluster.local neutron-server
       {{ socok8s_ext_vip }} horizon.openstack.svc.cluster.local horizon
       {{ socok8s_ext_vip }} heat.openstack.svc.cluster.local heat
-      {{ socok8s_ext_vip }} novncproxy.openstack.svc.cluster.local novncproxy
+      {{ socok8s_ext_vip }} nova-novncproxy.openstack.svc.cluster.local nova-novncproxy
       {{ socok8s_ext_vip }} barbican.openstack.svc.cluster.local barbican
 
 # Developers have patched code, and don't need fetching product sources

--- a/site/soc/software/config/endpoints.yaml
+++ b/site/soc/software/config/endpoints.yaml
@@ -960,7 +960,7 @@ data:
       name: nova
       hosts:
         default: nova-novncproxy
-        public: novncproxy
+        public: nova-novncproxy
       host_fqdn_override:
         default: null
         public:


### PR DESCRIPTION
The novncprox host rule in the /etc/hosts was missing "nova-" prefix.