### PR TITLE
SOC-9435: Run commands from the correct host

### DIFF
--- a/playbooks/roles/openstack-remove-compute/tasks/main.yml
+++ b/playbooks/roles/openstack-remove-compute/tasks/main.yml
@@ -4,27 +4,25 @@
      set -o pipefail
      openstack compute service list | grep {{ compute_node_name }} | awk '{print $2}'
   register: compute_id
-  delegate_to: localhost
+  delegate_to: "{{ groups['soc-deployer'][0] }}"
   failed_when: false
   changed_when: false
 
 - name: Validate compute node id.
   debug:
     msg: "Compute node {{ compute_node_name }} does not exists in openstack."
-  delegate_to: localhost
   when: compute_id.stdout | length | int == 0
 
 - name: Get VM list from compute node.
   command: "openstack server list --host {{ compute_node_name }}"
   register: vm_exist
-  delegate_to: localhost
+  delegate_to: "{{ groups['soc-deployer'][0] }}"
   failed_when: false
   changed_when: false
 
 - name: Validate VM(s) exists on compute node.
   fail:
     msg: "VM(s) exists on compute node {{ compute_node_name }}."
-  delegate_to: localhost
   when: vm_exist.stdout | length | int != 0
 
 - name: Check for control-plane label.
@@ -32,18 +30,18 @@
      set -o pipefail
      kubectl get node {{ compute_node_name }} --show-labels | grep openstack-control-plane=enabled
   register: node_label_result
-  delegate_to: localhost
+  delegate_to: "{{ groups['soc-deployer'][0] }}"
   failed_when: false
   changed_when: false
 
 - name: Remove openstack-compute-node label from compute node
   command: "kubectl label node {{ compute_node_name }} openstack-compute-node-"
-  delegate_to: localhost
+  delegate_to: "{{ groups['soc-deployer'][0] }}"
   changed_when: false
 
 - name: Remove openvswitch label from compute node.
   command: "kubectl label node {{ compute_node_name }} openvswitch-"
-  delegate_to: localhost
+  delegate_to: "{{ groups['soc-deployer'][0] }}"
   when: node_label_result.stdout | length | int == 0
 
 - name: Wait for compute pods to terminate
@@ -54,13 +52,13 @@
   until: nova_pod_name.stdout | length | int == 0
   retries: 30
   delay: 10
-  delegate_to: localhost
+  delegate_to: "{{ groups['soc-deployer'][0] }}"
   failed_when: false
   changed_when: false
 
 - name: Delete openstack compute service.
   command: "openstack compute service delete {{ compute_id.stdout }}"
-  delegate_to: localhost
+  delegate_to: "{{ groups['soc-deployer'][0] }}"
   when: compute_id.stdout | length | int != 0
   failed_when: false
 


### PR DESCRIPTION
Run 'openstack' and 'kubectl' commands from the deployer, not from
localhost. In ECP environments localhost does not have kubectl
installed, and openstack commands go to the ECP endpoints by default.

Delegate these commands to the first soc-deployer host, which will give
the expected output in any environment.