### PR TITLE
Add horizon chart deploy timeout overides

### DIFF
--- a/site/soc/software/charts/osh/openstack-horizon/horizon.yaml
+++ b/site/soc/software/charts/osh/openstack-horizon/horizon.yaml
@@ -23,6 +23,8 @@ metadata:
       dest:
         path: .values.pod.replicas.api
 data:
+  wait:
+    timeout: {{ openstack_helm_deploy_timeout }}
   values:
     pod:
       replicas:


### PR DESCRIPTION
Add horizon chart deployment timeout. Some baremetal environments take
more than the default 5 minute timeout.