### PR TITLE
Remove upstream defaults for tempest_roles in values.yml

### DIFF
--- a/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
+++ b/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
@@ -25,6 +25,8 @@ data:
     conf:
       script: "tempest run --config-file /etc/tempest/tempest.conf -w {{ tempest_workers }} {{ tempest_test_args[tempest_test_type] }}"
       tempest:
+        auth:
+          tempest_roles: []
         identity-feature-enabled:
           api_v2: false
           domain_specific_drivers: true


### PR DESCRIPTION
Per QE's recommendation, this change removes the default values of 'admin' and 'member' from the tempest_roles key in tempest.conf, since this key is not necessary unless test cases call for additional roles to be assigned for users or projects.