### PR TITLE
airship keystone: override bootstrap script (SOC-9409)

### DIFF
--- a/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
@@ -58,4 +58,22 @@ data:
             Allow from all
           </IfModule>
         </Directory>
+    bootstrap:
+      # We override this due to SOC-9409: admin role not assigned to admin user on the default domain
+      # upstream patch: https://review.opendev.org/662993
+      # TODO(itxaka): remove once upstream patch is merged and airship git sha for openstack-helm updated
+      script: |
+        #NOTE(gagehugo): As of Rocky, keystone creates a member role by default
+        openstack role create --or-show member
+        openstack role add \
+              --user="${OS_USERNAME}" \
+              --user-domain="${OS_USER_DOMAIN_NAME}" \
+              --project-domain="${OS_PROJECT_DOMAIN_NAME}" \
+              --project="${OS_PROJECT_NAME}" \
+              "member"
+        # admin needs the admin role for the default domain
+        openstack role add \
+              --user="${OS_USERNAME}" \
+              --domain="default" \
+              "admin"
 ...


### PR DESCRIPTION
As SOC-9409 mentions we cannot create admin scoped tokens
because the admin role is not assigned to admin user on the
default domain.

This patch fixed that by adding the admin role to the admin user
for the default domain on the boostrap.

This is only a temp patch, as mentioned in the override file
this has been sent upstream, but until that its merged we can
carry this.