### PR TITLE
python3-virtualenv instead of python2-virtualenv

### DIFF
--- a/doc/source/deployment/setup-deployer.rst
+++ b/doc/source/deployment/setup-deployer.rst
@@ -47,7 +47,7 @@ The following software must be installed on your `Deployer`:
   * git
   * jq
   * python3-netaddr
-  * python-virtualenv
+  * python3-virtualenv
 
 Create SUSE Containerized OpenStack Workspace
 ---------------------------------------------


### PR DESCRIPTION
While zypper knows how to install python-virtualenv, it defaults to the
python2 version.