### PR TITLE
Changing use virtual env default to True if not set

### DIFF
--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -321,9 +321,8 @@ continues the deployment.
 
 ``SOCOK8S_USE_VIRTUALENV`` determines if the script should set up and use a
 virtualenv for python and ansible requirements. Without this it is expected
-that ansible and the requirements are installed via system packages.
-When ``SOCOK8S_DEVELOPER_MODE`` is set to True, this defaults to True, otherwise
-this defaults to False.
+that ansible and the requirements are installed via system packages. This
+by default is set to True.
 
 ``USE_ARA`` determines if you want to store records in ARA. Set its
 value to 'True' for using ARA.

--- a/run.sh
+++ b/run.sh
@@ -31,9 +31,10 @@ done
 
 if [[ "${SOCOK8S_DEVELOPER_MODE:-False}" == "True" ]]; then
     set -x
-    SOCOK8S_USE_VIRTUALENV=${SOCOK8S_USE_VIRTUALENV:-True}
 fi
 
+# By default use virtualenv during deployment if not set otherwise use environment variable
+SOCOK8S_USE_VIRTUALENV=${SOCOK8S_USE_VIRTUALENV:-True}
 # USE an env var to setup where to deploy to
 # by default, ccp will deploy on openstack for inception style fun (and CI).
 DEPLOYMENT_MECHANISM=${DEPLOYMENT_MECHANISM:-"kvm"}


### PR DESCRIPTION
Currently it seems that virtual env setup is *always* needed otherwise
we see errors during deployment at various stages.
So changing default as does not ask user to set it to True if its
always needed.