### PR TITLE
openstack client: pass through OS_AUTH_TYPE

### DIFF
--- a/playbooks/openstack-caasp_instance.yml
+++ b/playbooks/openstack-caasp_instance.yml
@@ -21,6 +21,7 @@
             state: "present"
             name: "{{ stackname }}"
             template: "{{ playbook_dir }}/../files/caasp-stack.yaml"
+            auth_type: "{{ os_auth_type }}"
             parameters:
               image: "{{ deploy_on_openstack_caasp_image }}"
               external_net: "{{ deploy_on_openstack_external_network }}"

--- a/playbooks/openstack-create_network.yml
+++ b/playbooks/openstack-create_network.yml
@@ -16,6 +16,7 @@
             state: "present"
             name: "{{ deploy_on_openstack_network_stackname }}"
             template: "{{ playbook_dir }}/../heat-templates/openstack-network.yml"
+            auth_type: "{{ os_auth_type }}"
             parameters:
               prefix: "{{ socok8s_envname }}"
               network_external: "{{ deploy_on_openstack_external_network }}"

--- a/playbooks/openstack-delete_caasp.yml
+++ b/playbooks/openstack-delete_caasp.yml
@@ -20,6 +20,7 @@
           os_stack:
             name: "{{ stackname }}"
             state: absent
+            auth_type: "{{ os_auth_type }}"
 
         - name: Remove host from known hosts
           known_hosts:

--- a/playbooks/openstack-delete_network.yml
+++ b/playbooks/openstack-delete_network.yml
@@ -14,4 +14,5 @@
           os_stack:
             state: "absent"
             name: "{{ deploy_on_openstack_network_stackname }}"
+            auth_type: "{{ os_auth_type }}"
 

--- a/playbooks/roles/handle-nodes-on-openstack/tasks/create_on_openstack.yml
+++ b/playbooks/roles/handle-nodes-on-openstack/tasks/create_on_openstack.yml
@@ -16,6 +16,7 @@
     state: present
     timeout: 300
     userdata: "{{ userdata | default(omit) }}"
+    auth_type: "{{ os_auth_type }}"
   register: _server_create
 
 - name: Show the server data

--- a/playbooks/roles/handle-nodes-on-openstack/tasks/delete_on_openstack.yml
+++ b/playbooks/roles/handle-nodes-on-openstack/tasks/delete_on_openstack.yml
@@ -5,6 +5,7 @@
     name: "{{ servername }}"
     state: absent
     timeout: 300
+    auth_type: "{{ os_auth_type }}"
 
 # Looping will avoid the need to create a condition if no hosts
 # exists in the inventory.

--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -1,4 +1,5 @@
 ---
+os_auth_type: "{{ lookup('env', 'OS_AUTH_TYPE') | default('password', true) }}"
 deploy_on_openstack_external_network: "{{ lookup('env', 'EXTERNAL_NETWORK') | default('floating', true) }}"
 deploy_on_openstack_internal_network: "{{ socok8s_envname }}-net"
 deploy_on_openstack_internal_subnet: "{{ socok8s_envname }}-subnet"


### PR DESCRIPTION
Because of https://storyboard.openstack.org/#!/story/2005821 to use
token based auth one needs to pass through OS_AUTH_TYPE to any openstack
client call.

Token based authentication allows a deployer that doesn't know the
openstack password.