### PR TITLE
Improve subvolume deletion somewhat

### DIFF
--- a/playbooks/roles/airship-configure-worker/templates/caasp_worker_node_set_subvolumes.sh.j2
+++ b/playbooks/roles/airship-configure-worker/templates/caasp_worker_node_set_subvolumes.sh.j2
@@ -41,10 +41,11 @@ restore_and_reboot() {
 delete_subvolume(){
   if [ -d "$1" ]; then
     init
-    devpath=$(grep $1 /proc/mounts | awk '{print $1}')
-    mount $devpath $2 -o subvol="/@"
-    btrfs subvolume delete "$2/$1" || true
-    umount "$2" || true
+    if devpath=$(grep $1 /proc/mounts | awk '{print $1}') ; then
+      mount $devpath $2 -o subvol="/@"
+      btrfs subvolume delete "$2/$1" || true
+      umount "$2" || true
+    fi
   fi
 }
 


### PR DESCRIPTION
If a subvolume is not mounted, then grep will fail while setting
'devpath', causing the script to error out. Turn this into a conditional
so that the non-zero return code from grep does not exit the current
script.