### PR TITLE
Updating SES pool configuration setup docs

### DIFF
--- a/doc/source/deployment/configure.rst
+++ b/doc/source/deployment/configure.rst
@@ -106,11 +106,32 @@ See also
 Configure for SES Integration
 -----------------------------
 
-The file `ses_config.yml` is the output from :ref:`ses_integration`, and must
-be present in the workspace.
+SES integration configuration file `ses_config.yml` is created as part of
+deployment. And needed Ceph admin keyring and user keyring are added in the
+file `env/extravars` in your workspace.  In initial deployment steps, all
+necessary Ceph pools are created and configuration is made available in your
+workspace. Make sure that `env/extravars` file is already present in your
+workspace before deployment step is executed.
 
-The Ceph admin keyring and user keyring, in **base64**, must be present in the
-file `env/extravars` in your workspace.
+If there is a need to differentiate storage resources (pools, users) associated
+with the deployment, then a variable can be set in extravars to add a prefix
+to those resources. Otherwise default with no specific prefix is used.
+
+.. code-block:: yaml
+
+  airship_ses_pools_prefix: "mycloud-"
+
+
+If usage of SES salt runner script is preferred, then you can review next
+sub-section, otherwise skip it.
+
+
+With SES Salt runner usage (Optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In case `ses_config.yml` is created as output from :ref:`ses_integration`, then
+it can be copied to workspace. The Ceph admin keyring and user keyring, in
+**base64**, must be present in the file `env/extravars` in your workspace.
 
 The Ceph admin keyring can be obtained by running the following on ceph host.
 

--- a/doc/source/deployment/ses-integration.rst
+++ b/doc/source/deployment/ses-integration.rst
@@ -44,6 +44,13 @@ The integration runner creates separate users for Cinder, Cinder backup, and
 Glance. Both the Cinder and Nova services will have the same user, as Cinder
 needs access to create objects that Nova uses.
 
+.. note ::
+
+   This is an optional step in case preference is to use storage pools created
+   with Salt runner. Otherwise, deployment steps will create the necessary pool
+   and configuration files in your workspace. So this whole section can be
+   skipped.
+
 Log in as root to run the SES 5.5 Salt runner on the salt admin host.
 
 .. code-block:: bash

--- a/doc/source/deployment/setup-deployer.rst
+++ b/doc/source/deployment/setup-deployer.rst
@@ -65,7 +65,7 @@ Deployer. Set up your workspace with the following steps:
 
   mkdir ~/socok8s-workspace
   export SOCOK8S_ENVNAME=socok8s
-  export SOCOK8S_WORKSPACE_BASEDIR=~/socok8s-workspace
+  export SOCOK8S_WORKSPACE_BASEDIR=~
 
 
 Cloning the repository


### PR DESCRIPTION
Now we are creating needed ceph pools as part of deployment
and also ses_config is also created and made available in
workspace. Changes needed in extravars is also taken care
in playbook execution. So now we are kind of deprecating salt runner
instructions as an optional setup.