### PR TITLE
Jenkinsfile: Abort previous builds

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -38,6 +38,14 @@ pipeline {
             }
         }
 
+        stage('Abort previous builds') {
+            steps {
+                script {
+                    abortPreviousRunningBuilds()
+                }
+            }
+        }
+
         stage('Create network') {
             options {
                 timeout(time: 10, unit: 'MINUTES', activity: true)
@@ -126,6 +134,28 @@ pipeline {
             script {
                     sh './run.sh teardown'
                 }
+        }
+    }
+}
+
+
+def abortPreviousRunningBuilds() {
+    def hi = Hudson.instance
+    def pname = env.JOB_NAME.split('/')[0]
+
+    hi.getItem(pname).getItem(env.JOB_BASE_NAME).getBuilds().each{ build ->
+        def exec = build.getExecutor()
+
+        if (build.number != currentBuild.number && exec != null) {
+            exec.interrupt(
+                Result.ABORTED,
+                new CauseOfInterruption.UserInterruption(
+                    "Aborted by #${currentBuild.number}"
+                )
+            )
+            println("Aborted previous running build #${build.number}")
+        } else {
+            println("Build is not running or is current build, not aborting - #${build.number}")
         }
     }
 }


### PR DESCRIPTION
If a new build starts, abort already running builds to save
resources.