### PR TITLE
ci: add linting for playbooks in the pipeline

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -38,6 +38,15 @@ pipeline {
             }
         }
 
+        stage('Lint Ansible playbooks') {
+            options {
+                timeout(time: 5, unit: 'MINUTES', activity: true)
+            }
+            steps {
+                sh "tox -e lint"
+            }
+        }
+
         stage('Create network') {
             options {
                 timeout(time: 10, unit: 'MINUTES', activity: true)


### PR DESCRIPTION
Will trigger an ansible-lint run if we detect changes under the
playbooks dir