### PR TITLE
Adding note for SES 2 disk requirement for AIO setup.

### DIFF
--- a/doc/source/deployment/requirements.rst
+++ b/doc/source/deployment/requirements.rst
@@ -52,7 +52,7 @@ Minimum Node Specification
   the target workloads on the compute node.
 
 :term:`SES` All-In-One (AIO) node (Experimental only)
-++++++++++++++++++++++++++++++++++++++++++++++++++++
++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 * (v)CPU: 6
 *  Memory: 16GB

--- a/doc/source/deployment/requirements.rst
+++ b/doc/source/deployment/requirements.rst
@@ -51,12 +51,16 @@ Minimum Node Specification
   If the work node is used as Compute node, sizing shall be determined by
   the target workloads on the compute node.
 
-:term:`SES` AIO node (Experimental only)
-++++++++++++++++++++++++++++++++++++++++
+:term:`SES` All-In-One (AIO) node (Experimental only)
+++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 * (v)CPU: 6
 *  Memory: 16GB
 *  Storage: 80GB
+
+  .. note::
+     When SES is deployed as AIO, then make sure that 2 additional 60GB storage
+     disks are added to node for OSD.
 
 Cluster size
 ------------


### PR DESCRIPTION
This doc change is added as per SOC-9323 comments in case user
end up using SES in AIO setup. Generally user is supposed to
follow SES own instruction and guidelines referenced in docs.
But still we have seen re-occurrence of this issue in testing as
its more like a tribal knowledge. So clarifying this via this
doc snippet.