### PR TITLE
Make it possible for the final task to fail

### DIFF
--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -189,6 +189,7 @@
 - name: Print Shipyard update software action status
   debug:
     msg: "{{ shipyard_desc_action.stdout_lines }}"
+  failed_when: "'failed' in shipyard_desc_action.stdout"
   tags:
     - update_airship_osh_site
     - add_compute_node


### PR DESCRIPTION
The final task is a debug task, which normally displays OK (in green if
color is enabled). This will mark the debug task as failed (in red) if
the message contains the word 'failed'.