### PR TITLE
Fix conflciting endpoint definition in endpoints.yml for novncproxy

### DIFF
--- a/site/soc/software/config/endpoints.yaml
+++ b/site/soc/software/config/endpoints.yaml
@@ -960,7 +960,6 @@ data:
       name: nova
       hosts:
         default: nova-novncproxy
-        public: nova-novncproxy
       host_fqdn_override:
         default: null
         public:
@@ -974,7 +973,7 @@ data:
       port:
         novnc_proxy:
           default: 6080
-          public: 80
+          public: 6080
           #public: 443
     compute_spice_proxy:
       name: nova


### PR DESCRIPTION
Fixed a conflicting endpoint definition for public and default for novncproxy
in endpoints.yaml. Both public an ddefault had the same value nova-novncproxy that Airship didnt like,