### PR TITLE
CI: only run lint when playbook files have changed

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -1,3 +1,11 @@
+#!groovy
+
+// Global vars so they can be used in different steps
+DocsChanged = false
+PlaybooksChanged = false
+ToxChanged = false
+
+
 pipeline {
 
     options {
@@ -37,8 +45,33 @@ pipeline {
                 sh 'printenv'
             }
         }
+        stage('Check for updated files') {
+            when { expression { env.BRANCH_NAME != 'master' } }
+            steps {
+                script {
+                    /* Need to fetch master to check against it for the proper diff */
+                    sh "git config --add remote.origin.fetch +refs/heads/master:refs/remotes/origin/master"
+                    sh "git fetch --no-tags"
+                    List<String> sourceChanged = sh(returnStdout: true, script: "git diff --name-only origin/master..origin/${env.BRANCH_NAME}").split()
+                    echo "Files changed for this PR:\n${sourceChanged.join('\n')}"
+                    for (int i = 0; i < sourceChanged.size(); i++) {
+                        if (sourceChanged[i].contains("playbooks/")) {
+                            PlaybooksChanged = true
+                        }
+                        if (sourceChanged[i].contains("doc/")) {
+                            DocsChanged = true
+                        }
+                        if (sourceChanged[i].contains("tox.ini")) {
+                            ToxChanged = true
+                        }
+                    }
+                }
+            }
+        }
 
         stage('Lint Ansible playbooks') {
+            when { expression { return PlaybooksChanged } }
+
             options {
                 timeout(time: 5, unit: 'MINUTES', activity: true)
             }


### PR DESCRIPTION
Provides 3 different vars to know when tox, playbooks or docs
have been modified so we can trigger the following steps according
to those.