### PR TITLE
Override Armada deployment timeout configuration

### DIFF
--- a/site/soc/deployment/deployment-configuration.yaml
+++ b/site/soc/deployment/deployment-configuration.yaml
@@ -10,4 +10,8 @@ metadata:
 data:
   armada:
     manifest: full-site
+    get_releases_timeout: 300
+    get_status_timeout: 300
+    post_apply_timeout: 7200
+    validate_design_timeout: 600
 ...


### PR DESCRIPTION
QE baremetal environment is slow and can't finish post apply deployment in
the default timeout. Overrided the default configuration with larger
enough timeout.