### PR TITLE
Stop ignoring errors

### DIFF
--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -180,7 +180,6 @@
   until: shipyard_desc_action.stdout.find('Processing') < 0 and shipyard_desc_action.stdout.find('running') < 0
   retries: 240
   delay: 15
-  ignore_errors: yes
   tags:
     - skip_ansible_lint
     - update_airship_osh_site

--- a/playbooks/roles/airship-deploy-ucp/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/tasks/main.yml
@@ -192,7 +192,6 @@
   until: armada_results.stdout.find('armada-') == 0
   retries: 60
   delay: 10
-  ignore_errors: yes
   tags:
     - skip_ansible_lint
 
@@ -208,7 +207,6 @@
   until: armada_pod_status.stdout == "true"
   retries: 30
   delay: 10
-  ignore_errors: yes
   tags:
     - skip_ansible_lint
 
@@ -260,7 +258,6 @@
   until: armada_results.stdout.find('armada-api-') == 0
   retries: 180
   delay: 10
-  ignore_errors: yes
   tags:
     - skip_ansible_lint
 
@@ -277,6 +274,5 @@
   until: armada_api_pod_status.stdout == "true"
   retries: 60
   delay: 10
-  ignore_errors: yes
   tags:
     - skip_ansible_lint


### PR DESCRIPTION
We have a few tasks that poll-wait with a status loop. Some of these
loops ignore errors. Stop ignoring errors so that the tasks will fail if
they reach the end of the loop.