### PR TITLE
Update tempest config params to increase smoke test success rate

### DIFF
--- a/doc/source/deployment/verify.rst
+++ b/doc/source/deployment/verify.rst
@@ -35,7 +35,7 @@ shell on the `Deployer` node.
 .. code-block:: console
 
    export OS_CLOUD=openstack
-   openstack network create --provider-network-type flat --provider-physical-network public \ 
+   openstack network create --provider-network-type flat --provider-physical-network external \ 
      --external public
    openstack subnet create --network public --subnet-range 192.168.100.0/24 --allocation-pool \
      start=192.168.100.10,end=192.168.100.200 --gateway 192.168.100.1 --no-dhcp public-subnet

--- a/playbooks/roles/airship-deploy-tempest/defaults/main.yml
+++ b/playbooks/roles/airship-deploy-tempest/defaults/main.yml
@@ -12,3 +12,4 @@ tempest_enable_neutron_service: true
 openstack_external_network_name: "public"
 openstack_external_subnet_name: "public-subnet"
 openstack_project_network_cidr: "172.0.4.0/24"
+cirros_test_image_url: "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"

--- a/playbooks/roles/airship-deploy-tempest/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-tempest/tasks/main.yml
@@ -23,11 +23,11 @@
     path: "{{ site_path }}/software/charts/osh/openstack-tempest"
     state: directory
 
-- name: Get external network ID
-  shell: "openstack network show {{ openstack_external_network_name }} -f value -c id"
+- name: Get external network details
+  shell: "openstack network show {{ openstack_external_network_name }} -f value -c id -c shared"
   environment:
     OS_CLOUD: openstack
-  register: tempest_test_public_network_id
+  register: tempest_public_network_details
   tags:
     - skip_ansible_lint
 

--- a/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
+++ b/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
@@ -15,7 +15,7 @@ metadata:
   storagePolicy: cleartext
 data:
   wait:
-    timeout: 6000
+    timeout: 12000
 {% if deploy_tempest is defined and deploy_tempest is sameas true %}
   values:
     jobs:
@@ -27,9 +27,15 @@ data:
       tempest:
         auth:
           tempest_roles: []
+          admin_domain_name: "Default"
+        identity:
+          admin_domain_scope: true
+          default_domain_id: "default"
         identity-feature-enabled:
           api_v2: false
           domain_specific_drivers: true
+        image:
+          http_image: "{{ cirros_test_image_url }}"
         compute:
           flavor_ref: "{{ tempest_test_flavor_id.stdout }}"
           image_ref: "{{ tempest_test_image_id.stdout }}"
@@ -39,7 +45,8 @@ data:
           default_network: "10.0.0.0/8"
           project_network_cidr: "{{ openstack_project_network_cidr }}"
           floating_network_name: "{{ openstack_external_network_name }}"
-          public_network_id: "{{ tempest_test_public_network_id.stdout }}"
+          public_network_id: "{{ tempest_public_network_details.stdout_lines[0] }}"
+          shared_physical_network: "{{ tempest_public_network_details.stdout_lines[1] }}"
         validation:
           image_ssh_user: "cirros"
           image_ssh_password: "gocubsgo"


### PR DESCRIPTION
This change incorporates tempest.conf changes recommended by QE to increase passing rate in tempest smoke tests.

This change also updates the network setup example in verify.rst to correct the name of the --provider-physical-network value from 'public' to 'external'.