### PR TITLE
Fix openstack-helm-infra repo version in manifest for dev patcher

### DIFF
--- a/vars/manifest.yml
+++ b/vars/manifest.yml
@@ -2,7 +2,7 @@
 upstream_repos:
   openstack-helm-infra:
     src: https://opendev.org/openstack/openstack-helm-infra
-    version: master
+    version: 3ba03ed8eacdc30098ecb09324b61db0f8e102ac
     dest_subdir: openstack
   openstack-helm:
     src: https://opendev.org/openstack/openstack-helm


### PR DESCRIPTION
Fixed openstack-helm-infra repo version in manifest for dev patcher for
tech preview release.