### PR TITLE
Add missing requirement

### DIFF
--- a/doc/source/suse-ecp/ose-localhost.rst
+++ b/doc/source/suse-ecp/ose-localhost.rst
@@ -57,6 +57,7 @@ Base software
 Install the following software on your `localhost`:
 
   * jq
+  * which
   * ipcalc
   * git
   * python-virtualenv


### PR DESCRIPTION
Which isn't installed by default on minimal openSUSE installs such as
the container images.