### PR TITLE
Preparating for caaspv4 and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ doc/build
 
 # log artifacts
 logs/
+
+# NOTE(toabctl): Remove when skuba is a public repo and we can use submodules
+# for now, submodules/skuba needs to be a local symlink to the SUSE/skuba checkout
+submodules/skuba

--- a/playbooks/openstack-create_network.yml
+++ b/playbooks/openstack-create_network.yml
@@ -36,3 +36,33 @@
           socok8s_{{ item.output_key }}: {{ item.output_value }}
       with_items: "{{ network_stack_create_output.stack.outputs }}"
       when: ( item.output_key == 'dcm_vip') or ( item.output_key == 'ext_vip' )
+
+    - name: Add internal network ID to group_vars
+      blockinfile:
+        path: "{{ socok8s_workspace }}/inventory/group_vars/all/openstack-network.yml"
+        create: yes
+        marker: "# {mark} ANSIBLE MANAGED BLOCK FOR deploy_on_openstack_internal_network_id"
+        block: |
+          deploy_on_openstack_internal_network_id: {{ item.output_value }}
+      with_items: "{{ network_stack_create_output.stack.outputs }}"
+      when: ( item.output_key == 'network_id')
+
+    - name: Add internal subnet ID to group_vars
+      blockinfile:
+        path: "{{ socok8s_workspace }}/inventory/group_vars/all/openstack-network.yml"
+        create: yes
+        marker: "# {mark} ANSIBLE MANAGED BLOCK FOR deploy_on_openstack_internal_subnet_id"
+        block: |
+          deploy_on_openstack_internal_subnet_id: {{ item.output_value }}
+      with_items: "{{ network_stack_create_output.stack.outputs }}"
+      when: ( item.output_key == 'subnet_id')
+
+    - name: Add router ID to group_vars
+      blockinfile:
+        path: "{{ socok8s_workspace }}/inventory/group_vars/all/openstack-network.yml"
+        create: yes
+        marker: "# {mark} ANSIBLE MANAGED BLOCK FOR deploy_on_openstack_router_id"
+        block: |
+          deploy_on_openstack_router_id: {{ item.output_value }}
+      with_items: "{{ network_stack_create_output.stack.outputs }}"
+      when: ( item.output_key == 'router_id')

--- a/playbooks/openstack-create_network.yml
+++ b/playbooks/openstack-create_network.yml
@@ -66,3 +66,20 @@
           deploy_on_openstack_router_id: {{ item.output_value }}
       with_items: "{{ network_stack_create_output.stack.outputs }}"
       when: ( item.output_key == 'router_id')
+
+    - name: Reload group_vars openstack-network to have the router ID available
+      include_vars:
+        file: "{{ socok8s_workspace }}/inventory/group_vars/all/openstack-network.yml"
+
+    - name: Get router interface port ID
+      command: "openstack port list --router {{ deploy_on_openstack_router_id }} -f value -c ID"
+      register: _router_interface_port_id
+      changed_when: False
+
+    - name: Add router interface port ID to group_vars
+      blockinfile:
+        path: "{{ socok8s_workspace }}/inventory/group_vars/all/openstack-network.yml"
+        create: yes
+        marker: "# {mark} ANSIBLE MANAGED BLOCK FOR deploy_on_openstack_router_interface_id"
+        block: |
+          deploy_on_openstack_router_interface_id: {{ _router_interface_port_id.stdout }}

--- a/playbooks/openstack-delete_caasp.yml
+++ b/playbooks/openstack-delete_caasp.yml
@@ -25,7 +25,7 @@
         - name: Remove host from known hosts
           known_hosts:
             state: absent
-            name: "{{ hostvars[item]['ansible_host'] }}"
+            name: "{{ hostvars[item]['ansible_host'] | default('') }}"
           loop: "{{ groups['caasp-admin'] + groups['caasp-masters'] + groups['caasp-workers'] }}"
 
         - name: Remove caasp files

--- a/playbooks/openstack-delete_caasp4.yml
+++ b/playbooks/openstack-delete_caasp4.yml
@@ -1,0 +1,29 @@
+---
+#
+# (c) Copyright 2019 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+- hosts: localhost
+  gather_facts: yes
+  any_errors_fatal: true
+  vars_files:
+    - "{{ playbook_dir }}/../vars/common-vars.yml"
+    - "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+  tasks:
+    - import_role:
+        name: caasp4
+        tasks_from: cleanup_nodes
+      vars:
+        skuba_ci_terraform_workspace: "{{ socok8s_workspace }}/skuba-terraform/"

--- a/playbooks/openstack-deploy_caasp4.yml
+++ b/playbooks/openstack-deploy_caasp4.yml
@@ -1,0 +1,30 @@
+---
+#
+# (c) Copyright 2019 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+- hosts: localhost
+  gather_facts: yes
+  any_errors_fatal: true
+  vars_files:
+    - "{{ playbook_dir }}/../vars/common-vars.yml"
+    - "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+  tasks:
+    - import_role:
+        name: caasp4
+        tasks_from: setup_nodes
+      vars:
+        skuba_ci_terraform_worker_count: "{{ deploy_on_openstack_caasp_workers }}"
+        skuba_ci_terraform_workspace: "{{ socok8s_workspace }}/skuba-terraform/"

--- a/playbooks/openstack-deploy_caasp4.yml
+++ b/playbooks/openstack-deploy_caasp4.yml
@@ -28,3 +28,9 @@
       vars:
         skuba_ci_terraform_worker_count: "{{ deploy_on_openstack_caasp_workers }}"
         skuba_ci_terraform_workspace: "{{ socok8s_workspace }}/skuba-terraform/"
+
+    - import_role:
+        name: caasp4
+        tasks_from: setup_k8s
+      vars:
+        skuba_cluster_basedir: "{{ socok8s_workspace }}"

--- a/playbooks/roles/caasp4/defaults/main.yml
+++ b/playbooks/roles/caasp4/defaults/main.yml
@@ -1,0 +1,24 @@
+# A image that is available in the OpenStack cloud. That image is used to deploy
+# CaaSP 4 with the skuba ci terraforms
+skuba_ci_terraform_image_name: "SLE-15-SP1-JeOS-GM"
+# the username to log into the image
+skuba_ci_terraform_image_username: "sles"
+# the password to log into the image
+skuba_ci_terraform_image_password: "linux"
+
+# number of master nodes
+skuba_ci_terraform_master_count: 1
+# number of worker nodes
+skuba_ci_terraform_worker_count: 2
+# the flavor name used for master nodes
+skuba_ci_terraform_master_flavor: "m1.medium"
+# the flavor name used for worker nodes
+skuba_ci_terraform_worker_flavor: "m1.medium"
+
+# A public key file that is used by terraform when setting up nodes
+# Login to the CaaSP 4 nodes is possible with this priv/pub key combination
+skuba_ci_terraform_autorized_keys_files:
+  - "{{ lookup('file', '{{ ansible_env.HOME }}/.ssh/id_rsa.pub', errors='ignore') }}"
+
+# The directory where the skuba CI terraform data will be copied to
+skuba_ci_terraform_workspace: "skuba-terraform-workspace"

--- a/playbooks/roles/caasp4/defaults/main.yml
+++ b/playbooks/roles/caasp4/defaults/main.yml
@@ -22,3 +22,9 @@ skuba_ci_terraform_autorized_keys_files:
 
 # The directory where the skuba CI terraform data will be copied to
 skuba_ci_terraform_workspace: "skuba-terraform-workspace"
+
+
+# The directory where skuba creates the cluster in
+skuba_cluster_basedir: "."
+# The name that is used for the CaaSP 4 cluster
+skuba_cluster_name: "caasp4-cluster"

--- a/playbooks/roles/caasp4/tasks/_cleanup_nodes_terraform_remove_resources.yml
+++ b/playbooks/roles/caasp4/tasks/_cleanup_nodes_terraform_remove_resources.yml
@@ -1,0 +1,47 @@
+---
+#
+# (c) Copyright 2019 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+- name: Get current state from terraform
+  command: terraform state list
+  args:
+    chdir: "{{ socok8s_workspace }}/skuba-terraform/"
+  register: _terraform_state_list
+  changed_when: False
+
+- name: Remove internal network resource from terraform state
+  command: terraform state rm openstack_networking_network_v2.network
+  args:
+    chdir: "{{ socok8s_workspace }}/skuba-terraform/"
+  when: '"openstack_networking_network_v2.network" in _terraform_state_list.stdout_lines'
+
+- name: Remove internal subnet resource from terraform state
+  command: terraform state rm openstack_networking_subnet_v2.subnet
+  args:
+    chdir: "{{ socok8s_workspace }}/skuba-terraform/"
+  when: '"openstack_networking_subnet_v2.subnet" in _terraform_state_list.stdout_lines'
+
+- name: Remove router interrface resource from terraform state
+  command: terraform state rm openstack_networking_router_interface_v2.router_interface
+  args:
+    chdir: "{{ socok8s_workspace }}/skuba-terraform/"
+  when: '"openstack_networking_router_interface_v2.router_interface" in _terraform_state_list.stdout_lines'
+
+- name: Remove router resource from terraform state
+  command: terraform state rm openstack_networking_router_v2.router
+  args:
+    chdir: "{{ socok8s_workspace }}/skuba-terraform/"
+  when: '"openstack_networking_router_v2.router" in _terraform_state_list.stdout_lines'

--- a/playbooks/roles/caasp4/tasks/_setup_nodes_terraform_import_resources.yml
+++ b/playbooks/roles/caasp4/tasks/_setup_nodes_terraform_import_resources.yml
@@ -1,0 +1,53 @@
+---
+#
+# (c) Copyright 2019 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+- name: Does the terraform state exist
+  stat:
+    path: "{{ skuba_ci_terraform_workspace }}/terraform.tfstate"
+  register: _terraform_state_file
+
+- name: Get current state from terraform
+  command: terraform state list
+  args:
+    chdir: "{{ socok8s_workspace }}/skuba-terraform/"
+  register: _terraform_state_list
+  changed_when: False
+  when: _terraform_state_file.stat.exists
+
+- name: Import internal network resource to terraform
+  command: "terraform import openstack_networking_network_v2.network {{ deploy_on_openstack_internal_network_id }}"
+  args:
+    chdir: "{{ skuba_ci_terraform_workspace }}"
+  when: 'not _terraform_state_file.stat.exists or "openstack_networking_network_v2.network" not in _terraform_state_list.stdout_lines'
+
+- name: Import internal subnet resource to terraform
+  command: "terraform import openstack_networking_subnet_v2.subnet {{ deploy_on_openstack_internal_subnet_id }}"
+  args:
+    chdir: "{{ skuba_ci_terraform_workspace }}"
+  when: 'not _terraform_state_file.stat.exists or "openstack_networking_subnet_v2.subnet" not in _terraform_state_list.stdout_lines'
+
+- name: Import router resource to terraform
+  command: "terraform import openstack_networking_router_v2.router {{ deploy_on_openstack_router_id }}"
+  args:
+    chdir: "{{ skuba_ci_terraform_workspace }}"
+  when: 'not _terraform_state_file.stat.exists or "openstack_networking_router_v2.router" not in _terraform_state_list.stdout_lines'
+
+- name: Import router interface resource to terraform
+  command: "terraform import openstack_networking_router_interface_v2.router_interface {{ deploy_on_openstack_router_interface_id }}"
+  args:
+    chdir: "{{ skuba_ci_terraform_workspace }}"
+  when: 'not _terraform_state_file.stat.exists or "openstack_networking_router_interface_v2.router_interface" not in _terraform_state_list.stdout_lines'

--- a/playbooks/roles/caasp4/tasks/cleanup_nodes.yml
+++ b/playbooks/roles/caasp4/tasks/cleanup_nodes.yml
@@ -1,0 +1,39 @@
+---
+#
+# (c) Copyright 2019 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+# NOTE(toabctl): We import the resources (which are created by the network heat
+# stack in setup_nodes.yml so we need to remove the resources again from
+# terraform state and let heat handle the reource cleanup
+
+- name: Does the terraform state exist
+  stat:
+    path: "{{ skuba_ci_terraform_workspace }}/terraform.tfstate"
+  register: _terraform_state_file
+
+- name: Remove existing networking resources from terraform state
+  include_tasks: _cleanup_nodes_terraform_remove_resources.yml
+  when: _terraform_state_file.stat.exists
+
+- name: Destroy terraform plan
+  terraform:
+    project_path: "{{ skuba_ci_terraform_workspace }}"
+    state: absent
+
+- name: Drop skuba openstack terraform files
+  file:
+    path: "{{ skuba_ci_terraform_workspace }}"
+    state: absent

--- a/playbooks/roles/caasp4/tasks/setup_k8s.yml
+++ b/playbooks/roles/caasp4/tasks/setup_k8s.yml
@@ -1,0 +1,71 @@
+---
+#
+# (c) Copyright 2019 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+- name: Get skuba version
+  command: skuba version
+  changed_when: False
+  register: _skuba_version
+
+- name: Show skuba version
+  debug:
+    # NOTE: skuba is currently showing the version at stderr (see https://github.com/SUSE/skuba/issues/412)
+    msg: "{{ _skuba_version.stdout }}{{ _skuba_version.stderr }}"
+
+- name: Get terraform output variables
+  command: terraform output -json
+  args:
+    chdir: "{{ skuba_ci_terraform_workspace }}"
+  changed_when: False
+  register: _terraform_json_output
+
+- name: Set terraform json output fact
+  set_fact:
+    _terraform_json_output: "{{ _terraform_json_output.stdout|from_json }}"
+
+- name: Is skuba cluster dir available
+  stat:
+    path: "{{ skuba_cluster_basedir }}/{{ skuba_cluster_name }}"
+  register: _skuba_cluster_dir
+
+- name: Init skuba cluster
+  command: "skuba cluster init --control-plane {{ _terraform_json_output.ip_load_balancer.value }} {{ skuba_cluster_name }}"
+  args:
+    chdir: "{{ skuba_cluster_basedir }}"
+  when: not _skuba_cluster_dir.stat.exists
+
+- name: Get skuba cluster status
+  command: "skuba cluster status"
+  args:
+    chdir: "{{ skuba_cluster_basedir }}/{{ skuba_cluster_name }}"
+  register: _skuba_cluster_status
+  changed_when: False
+
+# TODO(toabctl): support more than one master
+- name: Bootstrap first master node
+  command: "skuba node bootstrap master-0 -s -t {{ _terraform_json_output.ip_masters.value[0] }} -u {{ skuba_ci_terraform_image_username }}"
+  args:
+    chdir: "{{ skuba_cluster_basedir }}/{{ skuba_cluster_name }}"
+  when: not _skuba_cluster_status.stdout | regex_search("^master-0.*", multiline=True)
+
+- name: Join worker nodes
+  command: "skuba node join worker-{{ idx }} -r worker -s -t {{ item }} -u {{ skuba_ci_terraform_image_username }}"
+  args:
+    chdir: "{{ skuba_cluster_basedir }}/{{ skuba_cluster_name }}"
+  loop: "{{ _terraform_json_output.ip_workers.value }}"
+  loop_control:
+    index_var: idx
+  when: not _skuba_cluster_status.stdout | regex_search('^worker-' ~ idx ~ '.*', multiline=True)

--- a/playbooks/roles/caasp4/tasks/setup_nodes.yml
+++ b/playbooks/roles/caasp4/tasks/setup_nodes.yml
@@ -1,0 +1,88 @@
+---
+#
+# (c) Copyright 2019 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+- name: Copy skuba openstack terraform files to socok8s workspace
+  copy:
+    src: "{{ playbook_dir }}/../submodules/skuba/ci/infra/openstack/"
+    dest: "{{ skuba_ci_terraform_workspace }}"
+    mode: 0775
+    force: no
+
+- name: Create a terraform variable file
+  template:
+    src: skuba-terraform.tfvars.j2
+    dest: "{{ skuba_ci_terraform_workspace }}/terraform.tfvars"
+  vars:
+    image_name: "{{ skuba_ci_terraform_image_name }}"
+    image_username: "{{ skuba_ci_terraform_image_username }}"
+    image_password: "{{ skuba_ci_terraform_image_password }}"
+    # NOTE(toabctl):  net/subnet/router variable names must match the names from heat-templates/openstack-network
+    internal_net: "{{ socok8s_envname }}-net"
+    internal_subnet: "{{ socok8s_envname }}-subnet"
+    internal_router: "{{ socok8s_envname }}-router"
+    external_net: "{{ deploy_on_openstack_external_network }}"
+    stack_name: "{{ socok8s_envname }}-caasp4"
+    subnet_cidr: "{{ deploy_on_openstack_internal_subnet_cidr }}"
+    master_count: "{{ skuba_ci_terraform_master_count }}"
+    master_flavor: "{{ skuba_ci_terraform_master_flavor }}"
+    worker_count: "{{ skuba_ci_terraform_worker_count }}"
+    worker_flavor: "{{ skuba_ci_terraform_worker_flavor }}"
+    authorized_keys: "{{ skuba_ci_terraform_autorized_keys_files }}"
+    ntp_servers:
+      - "0.novell.pool.ntp.org"
+      - "1.novell.pool.ntp.org"
+      - "2.novell.pool.ntp.org"
+      - "3.novell.pool.ntp.org"
+
+- name: Hidden terraform dir available
+  stat:
+    path: "{{ skuba_ci_terraform_workspace }}/.terraform"
+  register: _terraform_hidden_dir
+
+- name: Initialize terraform in the workspace dir
+  command: terraform init -input=false
+  args:
+    chdir: "{{ skuba_ci_terraform_workspace }}"
+  when: not _terraform_hidden_dir.stat.exists
+
+# NOTE(toabctl): The network resources are already created
+# via a heat stack when running "./run.sh deploy_network"
+# So only "import" to terraform. Otherwise terraform tries to create
+# the same resources again
+- name: Import existing networking resources to terraform
+  include_tasks: _setup_nodes_terraform_import_resources.yml
+
+- name: Apply terraform plan in the workspace dir
+  terraform:
+    project_path: "{{ skuba_ci_terraform_workspace }}"
+    state: present
+
+- name: Get terraform output variables
+  command: terraform output -json
+  args:
+    chdir: "{{ skuba_ci_terraform_workspace }}"
+  changed_when: False
+  register: _terraform_json_output
+
+- name: Set terraform json output fact
+  set_fact:
+    _terraform_json_output: "{{ _terraform_json_output.stdout|from_json }}"
+
+- name: Extend inventory in workspace with newly created caasp nodes
+  template:
+    src: inventory-caasp4.yml.j2
+    dest: "{{ socok8s_workspace }}/inventory/caasp4.yml"

--- a/playbooks/roles/caasp4/templates/inventory-caasp4.yml.j2
+++ b/playbooks/roles/caasp4/templates/inventory-caasp4.yml.j2
@@ -1,0 +1,34 @@
+---
+caasp-masters:
+  hosts:
+{% for master_ip in _terraform_json_output.ip_masters.value %}
+    {{ master_ip }}
+{% endfor %}
+
+caasp-workers:
+  hosts:
+{% for worker_ip in _terraform_json_output.ip_workers.value %}
+    {{ worker_ip }}
+{% endfor %}
+
+airship-openstack-control-workers:
+  hosts: &firsttwoworkers
+{% for worker_ip in _terraform_json_output.ip_workers.value %}
+{% if loop.index <= 2 %}
+    {{ worker_ip }}
+{% endif %}
+{% endfor %}
+
+airship-ucp-workers:
+  hosts: *firsttwoworkers
+
+airship-openstack-compute-workers:
+  hosts:
+{% for worker_ip in _terraform_json_output.ip_workers.value %}
+{% if loop.index > 2 %}
+    {{ worker_ip }}
+{% endif %}
+{% endfor %}
+
+airship-kube-system-workers:
+  hosts: *firsttwoworkers

--- a/playbooks/roles/caasp4/templates/skuba-terraform.tfvars.j2
+++ b/playbooks/roles/caasp4/templates/skuba-terraform.tfvars.j2
@@ -1,0 +1,44 @@
+# This file is managed by ansible and based on terraform.tfvars.ci.example from github.com/SUSE/skuba
+image_name = "{{ image_name }}"
+internal_net = "{{ internal_net }}"
+internal_subnet = "{{ internal_subnet }}"
+internal_router = "{{ internal_router }}"
+external_net = "{{ external_net }}"
+stack_name = "{{ stack_name }}"
+subnet_cidr = "{{ subnet_cidr }}"
+masters = {{ master_count }}
+workers = {{ worker_count }}
+master_size = "{{ master_flavor }}"
+worker_size = "{{ worker_flavor }}"
+
+username = "{{ image_username }}"
+password = "{{ image_password }}"
+
+repositories = {
+    caasp_40_devel_sle15sp1 = "http://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/"
+    sle15sp1_pool = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA/standard/"
+    sle15sp1_update = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update/standard/"
+    sle15_pool = "http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/"
+    sle15_update = "http://download.suse.de/ibs/SUSE:/SLE-15:/Update/standard/"
+    suse_ca = "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/"
+}
+
+packages = [
+  "kernel-default",
+  "-kernel-default-base",
+  "ca-certificates-suse",
+  "patterns-caasp-Node",
+]
+
+authorized_keys = [
+{% for key in authorized_keys %}
+  "{{ key }}",
+{% endfor %}
+]
+
+ntp_servers = [
+{% for server in ntp_servers %}
+  "{{ server }}",
+{% endfor %}
+]
+

--- a/run.sh
+++ b/run.sh
@@ -65,7 +65,12 @@ case "$deployment_action" in
         deploy_ses
         ;;
     "deploy_caasp")
+        # this is CaaSP 3
         deploy_caasp
+        ;;
+    "deploy_caasp4")
+        # this is CaaSP 4
+        deploy_caasp4
         ;;
     "deploy_ccp_deployer")
         # CCP deployer is a node that will be used to control k8s cluster,
@@ -143,6 +148,9 @@ case "$deployment_action" in
         ;;
     "teardown")
         teardown
+        ;;
+    "clean_caasp4")
+        clean_caasp4
         ;;
     "clean_k8s")
         clean_k8s

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -24,10 +24,19 @@ function deploy_ses(){
 }
 function deploy_caasp(){
     source ${scripts_absolute_dir}/pre-flight-checks.sh check_openstack_environment_is_ready_for_deploy
-    echo "Starting caasp deploy"
+    echo "Starting CaaSP 3 deploy"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-create_caasp.yml
-    echo "CaaSP deployed successfully"
+    echo "CaaSP 3 deployed successfully"
 }
+function deploy_caasp4(){
+    source ${scripts_absolute_dir}/pre-flight-checks.sh check_openstack_environment_is_ready_for_deploy
+    source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp4_skuba_available
+    source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp4_terraform_available
+    echo "Starting CaaSP 4 deploy"
+    run_ansible ${socok8s_absolute_dir}/playbooks/openstack-deploy_caasp4.yml
+    echo "CaaSP 4 deployed successfully"
+}
+
 function deploy_ccp_deployer() {
     source ${scripts_absolute_dir}/pre-flight-checks.sh check_openstack_environment_is_ready_for_deploy
     echo "Creating CCP deploy node"
@@ -41,11 +50,20 @@ function enroll_caasp_workers() {
     echo "Enrolling caasp worker nodes into the cluster"
     run_ansible ${socok8s_absolute_dir}/playbooks/generic-enroll_caasp_workers.yml
 }
+function clean_caasp4(){
+    if command -v terraform; then
+        source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp4_skuba_available
+        source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp4_terraform_available
+        echo "Delete CaaSP 4"
+        run_ansible ${socok8s_absolute_dir}/playbooks/openstack-delete_caasp4.yml
+    fi
+}
 function clean_openstack(){
     echo "Deleting on OpenStack"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-osh_instance.yml -e osh_node_delete=True
-    echo "Delete Caasp nodes"
+    echo "Delete CaaSP 3 nodes"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-delete_caasp.yml
+    clean_caasp4
     echo "Delete SES node"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-ses_aio_instance.yml -e ses_node_delete=True
     echo "Delete network stack"

--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -28,6 +28,22 @@ check_openstack_env_vars_set (){
     fi
 }
 
+check_caasp4_skuba_available(){
+    echo "Checking for CaaSP 4 that SUSE/skuba is available"
+    if ! [ -d submodules/skuba ]; then
+        echo "submodules/skuba directory not available. Can not deploy CaaSP 4"
+        exit
+    fi
+}
+check_caasp4_terraform_available(){
+    echo "Checking for CaaSP 4 that terraform is available"
+    command -v terraform 1> /dev/null
+    if [ $? -ne 0 ]; then
+        echo "terraform executable not in \$PATH. Can not deploy CaaSP 4"
+        exit
+    fi
+}
+
 check_openstack_environment_is_ready_for_deploy (){
     echo "Running OpenStack pre-flight checks"
     check_openstack_env_vars_set #Do not try to grep without ensuring the vars are set
@@ -91,7 +107,7 @@ validate_cli_options (){
        exit 1
    fi
 
-   OPTIONS=(deploy test update_openstack add_openstack_compute remove_openstack_compute remove_deployment deploy_network deploy_ses deploy_caasp configure_ccp_deployer deploy_ccp_deployer enroll_caasp_workers patch_upstream build_images deploy_osh setup_caasp_workers_for_openstack setup_hosts setup_openstack setup_airship setup_everything teardown clean_k8s clean_airship_not_images gather_logs)
+   OPTIONS=(deploy test update_openstack add_openstack_compute remove_openstack_compute remove_deployment deploy_network deploy_ses deploy_caasp deploy_caasp4 deploy_caasp4 configure_ccp_deployer deploy_ccp_deployer enroll_caasp_workers patch_upstream build_images deploy_osh setup_caasp_workers_for_openstack setup_hosts setup_openstack setup_airship setup_everything teardown clean_caasp4 clean_k8s clean_airship_not_images gather_logs)
 
    action=$1
    isvalid=false

--- a/script_library/run-ansible.sh
+++ b/script_library/run-ansible.sh
@@ -18,6 +18,11 @@ function run_ansible(){
         # Ensure default groupnames exist. It also DRY so that we automatically connect on hosts as root.
         # However don't force this by default if people already have an inventory.
         cp ${socok8s_absolute_dir}/examples/workdir/inventory/hosts.yml ${inventorydir}/default-inventory.yml
+        # create a group_vars dir called all. There you can put extra variables
+        # into files and these vars will be available for all hosts
+        # Note: This is different to extravars - extravars can not be overwritten
+        # but the vars in group_vars/all/ can be overwritten
+        mkdir -p ${inventorydir}/group_vars/all/
     fi
 
     if [[ -f ${extravarsfile} ]]; then


### PR DESCRIPTION
This PR adds an extra step "run.sh deploy_caasp4". It creates a k8s cluster but it does not yet integrate with the rest of the deployment (so you can not install osh on top of the caasp4 cluster).

I think it would be good to get this merged and then work on the integration