### PR TITLE
Add ability to use a blacklist file with tempest run

### DIFF
--- a/playbooks/roles/airship-deploy-tempest/defaults/main.yml
+++ b/playbooks/roles/airship-deploy-tempest/defaults/main.yml
@@ -13,3 +13,4 @@ openstack_external_network_name: "public"
 openstack_external_subnet_name: "public-subnet"
 openstack_project_network_cidr: "172.0.4.0/24"
 cirros_test_image_url: "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
+use_blacklist: true

--- a/playbooks/roles/airship-deploy-tempest/files/tempest_blacklist
+++ b/playbooks/roles/airship-deploy-tempest/files/tempest_blacklist
@@ -1,0 +1,3 @@
+#  Add tests to be blacklisted below using the following format:
+#  - (?:tempest\.api\.identity\.admin\.v3\.test_groups\.GroupsV3TestJSON\.test_list_groups)
+- (?:tempest\.api\.identity\.v3\.test_domains\.DefaultDomainTestJSON\.test_default_domain_exists)

--- a/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
+++ b/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
@@ -23,7 +23,16 @@ data:
         backoffLimit: 0
         restartPolicy: Never
     conf:
-      script: "tempest run --config-file /etc/tempest/tempest.conf -w {{ tempest_workers }} {{ tempest_test_args[tempest_test_type] }}"
+      script: |
+        tempest run \
+        --config-file /etc/tempest/tempest.conf \
+        -w {{ tempest_workers }} \
+        {{ tempest_test_args[tempest_test_type] }} \
+    {% if use_blacklist %}
+        --blacklist-file /etc/tempest/test-blacklist
+      blacklist:
+        {{ lookup('file', 'tempest_blacklist') | indent(8) }}
+    {% endif %}
       tempest:
         auth:
           tempest_roles: []


### PR DESCRIPTION
Since we've identified at least one smoke test that will need to be excluded, this change will allow the use of a blacklist file with tempest run. The blacklist file can be modified following the example format, and it's located at roles/airship-deploy-tempest/files/tempest_blacklist. 

Default is true, but if it's desired to turn off the blacklist, a key can be added in extravars:
use_blacklist: false