### PR TITLE
Fixed indentation problem in tempest site template

### DIFF
--- a/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
+++ b/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
@@ -28,11 +28,11 @@ data:
         --config-file /etc/tempest/tempest.conf \
         -w {{ tempest_workers }} \
         {{ tempest_test_args[tempest_test_type] }} \
-    {% if use_blacklist %}
+{% if use_blacklist %}
         --blacklist-file /etc/tempest/test-blacklist
       blacklist:
         {{ lookup('file', 'tempest_blacklist') | indent(8) }}
-    {% endif %}
+{% endif %}
       tempest:
         auth:
           tempest_roles: []


### PR DESCRIPTION
This change corrects an indentation problem caused during template processing that was pushing the 'tempest' key out of alignment. 