### PR TITLE
Improve error-detection for final deploy action

### DIFF
--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -177,7 +177,10 @@
     SHIPYARD_IMAGE: "{{ shipyard_image }}"
     OS_PASSWORD: "{{ lookup('password', secrets_location + '/ucp_shipyard_keystone_password ' + password_opts) }}"
   register: shipyard_desc_action
-  until: shipyard_desc_action.stdout.find('Processing') < 0 and shipyard_desc_action.stdout.find('running') < 0
+  until:
+    - shipyard_desc_action.stdout.find('Processing') == -1
+    - shipyard_desc_action.stdout.find('running') == -1
+    - shipyard_desc_action.stdout.find('Error') != 0
   retries: 240
   delay: 15
   tags:


### PR DESCRIPTION
Keep waiting for the deploy to finish even if a transient error is
raised during polling. Also change the other two checks to look for the
specific not-found return-value of -1.