### PR TITLE
Give useful output if armada-api times out

### DIFF
--- a/playbooks/roles/airship-deploy-ucp/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/tasks/main.yml
@@ -251,28 +251,39 @@
     - install
     - skip_ansible_lint
 
-# TODO(aagate): Add a changed_when: to help idempotency
-- name: Wait until Armada api pod is deployed
-  command: 'kubectl get pod -l application=armada,component=api -n {{ ucp_namespace_name }} -o jsonpath="{.items[0].metadata.name}"'
-  register: armada_results
-  until: armada_results.stdout.find('armada-api-') == 0
-  retries: 180
-  delay: 10
-  tags:
-    - skip_ansible_lint
+- block:
+    # TODO(aagate): Add a changed_when: to help idempotency
+    - name: Wait until Armada api pod is deployed
+      command: 'kubectl get pod -l application=armada,component=api -n {{ ucp_namespace_name }} -o jsonpath="{.items[0].metadata.name}"'
+      register: armada_results
+      until: armada_results.stdout.find('armada-api-') == 0
+      retries: 180
+      delay: 10
+      tags:
+        - skip_ansible_lint
 
-- name: Set armada api pod name
-  set_fact: armada_api_pod_name={{ armada_results.stdout }}
+    - name: Set armada api pod name
+      set_fact: armada_api_pod_name={{ armada_results.stdout }}
 
-- debug:
-    msg: "armada-api pod found: {{ armada_api_pod_name }}"
+    - debug:
+        msg: "armada-api pod found: {{ armada_api_pod_name }}"
 
-# TODO(aagate): Add a changed_when: to help idempotency
-- name: Wait until Airship api becomes ready
-  command: "kubectl get pod {{ armada_api_pod_name }} -n {{ ucp_namespace_name }} -o jsonpath='{.status.containerStatuses[].ready}'"
-  register: armada_api_pod_status
-  until: armada_api_pod_status.stdout == "true"
-  retries: 60
-  delay: 10
-  tags:
-    - skip_ansible_lint
+    # TODO(aagate): Add a changed_when: to help idempotency
+    - name: Wait until Airship api becomes ready
+      command: "kubectl get pod {{ armada_api_pod_name }} -n {{ ucp_namespace_name }} -o jsonpath='{.status.containerStatuses[].ready}'"
+      register: armada_api_pod_status
+      until: armada_api_pod_status.stdout == "true"
+      retries: 60
+      delay: 10
+      tags:
+        - skip_ansible_lint
+
+  rescue:
+    - name: List all ucp pods
+      command: "kubectl get pods -n {{ ucp_namespace_name }}"
+      register: list_ucp_pods
+
+    - name: "Armada api pod not ready, all {{ ucp_namespace_name }} pods have been listed for debugging"
+      debug:
+        var: list_ucp_pods.stdout_lines
+      failed_when: true


### PR DESCRIPTION
If we time out waiting for the armada api pod, give a list of all pods
running in the ucp namespace. This will hopefully make the output from
automated test runs more useful for determining the cause of the error.