### PR TITLE
Switch CaaSP workers to a larger flavor

### DIFF
--- a/files/caasp-stack.yaml
+++ b/files/caasp-stack.yaml
@@ -81,7 +81,7 @@ parameters:
   worker_flavor:
     type: string
     description: Worker Flavor
-    default: m1.large
+    default: m1.medlarge
     constraints:
       - custom_constraint: nova.flavor
   worker_count:


### PR DESCRIPTION
With the current default (m1.large, i.e. 8GB of RAM) deployments run out
of memory from time to time, with the OOM killer starting to kill
processes. Let's switch to a bigger flavor (m1.xlarge, i.e. 16GB of RAM)
to avoid that.