### PR TITLE
Add 4 known smoke test failures to tempest_blacklist

### DIFF
--- a/playbooks/roles/airship-deploy-tempest/files/tempest_blacklist
+++ b/playbooks/roles/airship-deploy-tempest/files/tempest_blacklist
@@ -1,3 +1,7 @@
 #  Add tests to be blacklisted below using the following format:
 #  - (?:tempest\.api\.identity\.admin\.v3\.test_groups\.GroupsV3TestJSON\.test_list_groups)
 - (?:tempest\.api\.identity\.v3\.test_domains\.DefaultDomainTestJSON\.test_default_domain_exists)
+- (?:tempest\.api\.compute\.servers\.test_server_actions\.ServerActionsTestJSON\.test_reboot_server_hard)
+- (?:tempest\.api\.compute\.servers\.test_attach_interfaces\.AttachInterfacesUnderV243Test\.test_add_remove_fixed_ip)
+- (?:tempest\.scenario\.test_network_basic_ops\.TestNetworkBasicOps\.test_network_basic_ops)
+- (?:tempest\.scenario\.test_server_basic_ops\.TestServerBasicOps\.test_server_basic_ops)


### PR DESCRIPTION
This change adds 4 known smoke test failures to the default blacklist file.