### PR TITLE
Corrected requirements for ISO install.

### DIFF
--- a/doc/source/deployment/setup-deployer.rst
+++ b/doc/source/deployment/setup-deployer.rst
@@ -74,10 +74,9 @@ There are several ways to install the SUSE Containerized OpenStack software.
       https://download.opensuse.org/repositories/Cloud:/socok8s/openSUSE_Leap_15.0/ socok8s
    b. sudo zypper install socok8s (installs to /usr/share/socok8s)
 
-
 3. (For developers only) Clone the repository.
    
-   The following software must be manually installed on your `Deployer`:
+   The following software must be manually installed on your `Deployer` using zypper or pip install:
 
      * ansible >= 2.7.8
      * git-core

--- a/doc/source/deployment/setup-deployer.rst
+++ b/doc/source/deployment/setup-deployer.rst
@@ -37,18 +37,6 @@ Set Up Deployer
    }
 
 
-Base Software
--------------
-
-The following software must be installed on your `Deployer`:
-
-  * ansible>=2.7.0
-  * gcc
-  * git
-  * jq
-  * python3-netaddr
-  * python3-virtualenv
-
 Create SUSE Containerized OpenStack Workspace
 ---------------------------------------------
 
@@ -73,7 +61,7 @@ Installing the SUSE Containerized OpenStack software
 
 There are several ways to install the SUSE Containerized OpenStack software.
 
-1. Install with an ISO image including required dependencies:
+1. (Recommended) Install with an ISO image including required dependencies:
 
    a. Download ``openSUSE-Addon-socok8s-x86_64-Media.iso`` from
       https://download.opensuse.org/repositories/Cloud:/socok8s/images/iso/
@@ -87,7 +75,23 @@ There are several ways to install the SUSE Containerized OpenStack software.
    b. sudo zypper install socok8s (installs to /usr/share/socok8s)
 
 
-3. Clone the `socok8s GitHub repository <https://github.com/SUSE-Cloud/socok8s>`_.
+3. (For developers only) Clone the repository.
+   
+   The following software must be manually installed on your `Deployer`:
+
+     * ansible >= 2.7.8
+     * git-core
+     * jq
+     * python3-virtualenv
+     * python3-jmespath
+     * python3-netaddr
+     * python3-openstacksdk
+     * python3-openstackclient
+     * python3-heatclient
+     * which
+
+   After the required packages are installed, clone
+   `socok8s GitHub repository <https://github.com/SUSE-Cloud/socok8s>`.
    This repository uses submodules, which have additional code needed for the
    playbooks to work. Required dependencies must be installed manually.
 


### PR DESCRIPTION
Moved the base software section to the clone repository section so it's
clear to the user that ISO or rpm install does not require manual
installation of the requirements.