### PR TITLE
Airship deployer: install python packages as rpm, not from pip [ SOC-9494 ]

### DIFF
--- a/playbooks/roles/airship-setup-deployer/defaults/main.yml
+++ b/playbooks/roles/airship-setup-deployer/defaults/main.yml
@@ -12,14 +12,15 @@ suse_airship_deploy_packages:
   - uuid-runtime
   - docker
   - curl
-  - python2-setuptools
-  - python2-pip
+  - python3-setuptools
+  - python3-pip
+  - python3-cmd2
   - python-devel
 
-suse_airship_deploy_python_libs:
-  - "cmd2<=0.8.7"
-  - python-openstackclient
-  - python-heatclient
+suse_airship_openstackclient_packages:
+  - python3-barbicanclient
+  - python3-heatclient
+  - python3-openstackclient
 
 # Keep this until helm is packaged as rpm
 helm_download_url: "https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get"

--- a/playbooks/roles/airship-setup-deployer/tasks/main.yml
+++ b/playbooks/roles/airship-setup-deployer/tasks/main.yml
@@ -26,12 +26,11 @@
   tags:
     - install
 
-- name: Pip install python libraries
+- name: Install OpenStack client packages
   become: yes
-  pip:
-    name: "{{ suse_airship_deploy_python_libs }}"
-  register: install_python_libs
-  until: install_python_libs is success
+  package:
+    name: "{{ suse_airship_openstackclient_packages }}"
+    state: present
   retries: 5
   delay: 2
   tags:


### PR DESCRIPTION
At this point deployer has repositories set up, no need for pip.