### PR TITLE
Use the workspace directory for storing ansible retry files

### DIFF
--- a/script_library/run-ansible.sh
+++ b/script_library/run-ansible.sh
@@ -31,7 +31,9 @@ function run_ansible(){
     fi
 
     pushd ${socok8s_absolute_dir}
-        ansible-playbook ${extra_vars:-} -i ${inventorydir} $@ -v
+        # ANSIBLE_RETRY_FILES_SAVE_PATH sets a location where ansible retry files should be located
+        # We are setting it explicitely to the socok8s_workspace directory which is user-writable
+        ANSIBLE_RETRY_FILES_SAVE_PATH=${socok8s_workspace} ansible-playbook ${extra_vars:-} -i ${inventorydir} $@ -v
     popd
     set +x
 }


### PR DESCRIPTION
Without this, packaged version of socok8s would try to create retry
files under /usr/share/socok8s which is only writable for root.

See SOC-9467