### PR TITLE
Use newer syntax for search() tests

### DIFF
--- a/playbooks/openstack-update_and_reboot_caasp.yml
+++ b/playbooks/openstack-update_and_reboot_caasp.yml
@@ -42,7 +42,7 @@
     - name: Perform transactional-update
       command: transactional-update cleanup dup
       register: transactional_update_result
-      changed_when: "transactional_update_result.stdout|search('Please reboot your machine')"
+      changed_when: "transactional_update_result.stdout is search('Please reboot your machine')"
       failed_when: "transactional_update_result.rc != 0"
       notify: Reboot host
 

--- a/playbooks/roles/airship-configure-caasp/tasks/main.yml
+++ b/playbooks/roles/airship-configure-caasp/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: create namespaces in CaaSP
   command: "kubectl apply -f /tmp/namespaces.yaml --overwrite=true"
   register: create_namespaces_result
-  changed_when: "create_namespaces_result.stdout|search('created')"
+  changed_when: "create_namespaces_result.stdout is search('created')"
   tags:
     - run
 
@@ -32,6 +32,6 @@
 - name: Create privileged ClusterRoleBinding in CaaSP
   command: "kubectl apply -f /tmp/privileged-cluster-role-binding.yml --overwrite=true"
   register: create_privileged_cluster_role_binding_result
-  changed_when: "create_privileged_cluster_role_binding_result.stdout|search('created')"
+  changed_when: "create_privileged_cluster_role_binding_result.stdout is search('created')"
   tags:
     - run

--- a/playbooks/roles/airship-configure-caasp/tasks/privileged-cluster-role-binding.yml
+++ b/playbooks/roles/airship-configure-caasp/tasks/privileged-cluster-role-binding.yml
@@ -8,4 +8,4 @@
 - name: Apply privileged ClusterRoleBinding
   command: "kubectl apply -f /tmp/privileged-cluster-role-binding.yml --overwrite=true"
   register: create_privileged_cluster_role_binding_result
-  changed_when: "create_privileged_cluster_role_binding_result.stdout|search('created')"
+  changed_when: "create_privileged_cluster_role_binding_result.stdout is search('created')"

--- a/playbooks/roles/airship-deploy-ucp/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/tasks/main.yml
@@ -168,7 +168,7 @@
 - name: Apply Armada cluster role binding
   command: "kubectl apply -f {{ socok8s_deploy_config_location }}/armada-cluster-role-binding.yaml"
   register: armada_cluster_role_binding_result
-  changed_when: "armada_cluster_role_binding_result.stdout|search('created')"
+  changed_when: "armada_cluster_role_binding_result.stdout is search('created')"
   tags:
     - install
 
@@ -182,7 +182,7 @@
 - name: Deploy Armada pod to CaaSP
   command: "kubectl apply -f {{ socok8s_deploy_config_location }}/armada.yaml"
   register: armada_pod_deploy_result
-  changed_when: "armada_pod_deploy_result.stdout|search('created')"
+  changed_when: "armada_pod_deploy_result.stdout is search('created')"
   tags:
     - install
 


### PR DESCRIPTION
Using the older filter syntax for search() tests raises a deprecation
warning. Change to the new test syntax added in ansible 2.4, the old syntax
is scheduled for removal in ansible 2.9.