### PR TITLE
CI: build docs when they change

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -80,6 +80,33 @@ pipeline {
             }
         }
 
+        stage('Build docs') {
+             when {
+                anyOf {
+                    expression { return DocsChanged }
+                    expression { return ToxChanged }
+                }
+             }
+             options {
+                timeout(time: 5, unit: 'MINUTES', activity: true)
+             }
+             steps {
+                sh "tox -e docs"
+             }
+             post {
+                success {
+                    publishHTML target: [
+                        allowMissing: false,
+                        alwaysLinkToLastBuild: false,
+                        keepAll: true,
+                        reportDir: 'doc/build/html',
+                        reportFiles: 'index.html',
+                        reportName: 'Built Docs'
+                    ]
+                }
+             }
+        }
+
         stage('Create network') {
             options {
                 timeout(time: 10, unit: 'MINUTES', activity: true)


### PR DESCRIPTION
We currently do not build the docs so we are not sure if they are
properly done.

This enables the build of them if the dir has changed or the tox.ini
file has changed

Also, we take the opportunity to archive the docs if they were built
so they are accessible to download