### PR TITLE
Switch to Cloud:socok8s:master repo/iso

### DIFF
--- a/doc/source/deployment/setup-deployer.rst
+++ b/doc/source/deployment/setup-deployer.rst
@@ -76,14 +76,14 @@ There are several ways to install the SUSE Containerized OpenStack software.
 1. Install with an ISO image including required dependencies:
 
    a. Download ``openSUSE-Addon-socok8s-x86_64-Media.iso`` from
-      https://download.opensuse.org/repositories/Cloud:/socok8s/images/iso/
+      https://download.opensuse.org/repositories/Cloud:/socok8s:/master/images/iso/
    b. sudo zypper addrepo --refresh <PATH_TO_ISO_IMAGE> socok8s-iso
    c. sudo zypper install socok8s (installs to /usr/share/socok8s)
 
 2. Install from the openSUSE repository including required dependencies:
 
    a. sudo zypper addrepo --refresh \\
-      https://download.opensuse.org/repositories/Cloud:/socok8s/openSUSE_Leap_15.0/ socok8s
+      https://download.opensuse.org/repositories/Cloud:/socok8s:/master/openSUSE_Leap_15.0/ socok8s
    b. sudo zypper install socok8s (installs to /usr/share/socok8s)
 
 

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -25,7 +25,7 @@ socok8s_repos_to_configure:
   SES5-product: http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-Enterprise-Storage-5-Pool/
   SES5-update: http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-Enterprise-Storage-5-Updates/
   Leap15develtools: https://download.opensuse.org/repositories/devel:/tools/openSUSE_Leap_15.0/
-  socok8s: https://download.opensuse.org/repositories/Cloud:/socok8s/openSUSE_Leap_15.0/
+  socok8s: https://download.opensuse.org/repositories/Cloud:/socok8s:/master/openSUSE_Leap_15.0/
   CAASP30-update: http://ibs-mirror.prv.suse.net/dist/ibs/SUSE/Updates/SUSE-CAASP/3.0/x86_64/update/
   CAASP30-pool: http://ibs-mirror.prv.suse.net/dist/ibs/SUSE/Products/SUSE-CAASP/3.0/x86_64/product/
 


### PR DESCRIPTION
Cloud:socok8s is now for the stable/1.0 (Tech Preview) code but
development continues.
Use Cloud:socok8s:master for that.
x