### PR TITLE
[1.0] jenkins: Sanitize the socok8s enviroment name

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -28,8 +28,10 @@ pipeline {
     }
 
     environment {
-        /* use lowercase SOCOK8S_ENVNAME. CaaSP Velum doesn't like it otherwise */
-        SOCOK8S_ENVNAME = "cloud-socok8s-${env.BRANCH_NAME.toLowerCase()}-${env.BUILD_NUMBER}"
+        /* Sanitize ENVNAME (lowercase and remove some problematic characters)
+           as the names of the heat stacks will be derived from this. Also
+           the CaaSP Velum automation has issues with mixed case hostnames. */
+        SOCOK8S_ENVNAME = "cloud-socok8s-${env.BRANCH_NAME.replaceAll("[^a-zA-Z0-9-_]+", "_").toLowerCase()}-${env.BUILD_NUMBER}"
         OS_CLOUD = "engcloud-cloud-ci"
         KEYNAME = "engcloud-cloud-ci"
         DELETE_ANYWAY = "YES"


### PR DESCRIPTION
SOCOK8S_ENVNAME is used to generate the names for some of the heat
stacks we create. So we need to make sure it doesn't contain any
problematic characters for that. (This should fix the currenty build
failures for the stable/1.0 branch)

(cherry picked from commit 461775c236f07f96149905fb33d9495d90ced1e1)