### PR TITLE
jenkins: Replace '_' on the ENVNAME as well

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -31,7 +31,7 @@ pipeline {
         /* Sanitize ENVNAME (lowercase and remove some problematic characters)
            as the names of the heat stacks will be derived from this. Also
            the CaaSP Velum automation has issues with mixed case hostnames. */
-        SOCOK8S_ENVNAME = "cloud-socok8s-${env.BRANCH_NAME.replaceAll("[^a-zA-Z0-9-_]+", "_").toLowerCase()}-${env.BUILD_NUMBER}"
+        SOCOK8S_ENVNAME = "cloud-socok8s-${env.BRANCH_NAME.replaceAll("[^a-zA-Z0-9-]+", "-").toLowerCase()}-${env.BUILD_NUMBER}"
         OS_CLOUD = "engcloud-cloud-ci"
         KEYNAME = "engcloud-cloud-ci"
         DELETE_ANYWAY = "YES"


### PR DESCRIPTION
As some of the hostname are also derived from the ENV_NAME we have to
replace the '_' character as well. Otherwise the velum automation will
choke on it.