### PR TITLE
Revert "doc: add content about retry file path (SOC-9467)"

### DIFF
--- a/doc/source/deployment/configure.rst
+++ b/doc/source/deployment/configure.rst
@@ -192,19 +192,6 @@ For example:
 
    socok8s_ext_vip: "10.10.10.10"
 
-Set Up Retry Files Save Path
-----------------------------
-
-Before beginning deployment, a path can be specified where Ansible retry files
-can be saved in order to avoid potential errors. The path should point to a
-user-writable directory. Set the path in either of the following ways:
-
-- ``export ANSIBLE_RETRY_FILES_SAVE_PATH=<PATH_TO_DIRECTORY>`` before deploying
-  with ``run.sh`` commands.
-- Set the value of `retry_files_save_path` in your Ansible configuration file.
-
-There is an option to disable creating these retry files by setting
-``retry_files_enabled = False`` in your Ansible configuration file.
 
 Configure the VIP that will be used for Airship UCP service endpoints
 --------------------------------------------------------------------------


### PR DESCRIPTION
Reverts SUSE-Cloud/socok8s#509

This documentation is not needed in master branch, where we set ANSIBLE_RETRY_FILES_SAVE_PATH from ansible so it points to the writable work dir