### PR TITLE
Turn the developer mode off for primary CI job (SOC-9363)

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -35,7 +35,6 @@ pipeline {
         OS_CLOUD = "engcloud-cloud-ci"
         KEYNAME = "engcloud-cloud-ci"
         DELETE_ANYWAY = "YES"
-        SOCOK8S_DEVELOPER_MODE = "True"
         DEPLOYMENT_MECHANISM = "openstack"
         ANSIBLE_STDOUT_CALLBACK = "yaml"
         USER = "jenkins" /* Why isn't this set in the jenkins environment? */


### PR DESCRIPTION
Developer mode is used for building the images which we are not
testing in CI anyway.
And we want the job to be close to end-user scenario.