### PR TITLE
CI: track changes to jenkinsfile

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -4,6 +4,7 @@
 DocsChanged = false
 PlaybooksChanged = false
 ToxChanged = false
+JenkinsfileChanged = false
 
 
 pipeline {
@@ -66,13 +67,21 @@ pipeline {
                         if (sourceChanged[i].contains("tox.ini")) {
                             ToxChanged = true
                         }
+                        if (sourceChanged[i].contains("Jenkinsfile.integration")) {
+                            JenkinsfileChanged = true
+                        }
                     }
                 }
             }
         }
 
         stage('Lint Ansible playbooks') {
-            when { expression { return PlaybooksChanged } }
+            when {
+                anyOf {
+                    expression { return PlaybooksChanged }
+                    expression { return JenkinsfileChanged }
+                }
+            }
 
             options {
                 timeout(time: 5, unit: 'MINUTES', activity: true)
@@ -87,6 +96,7 @@ pipeline {
                 anyOf {
                     expression { return DocsChanged }
                     expression { return ToxChanged }
+                    expression { return JenkinsfileChanged }
                 }
              }
              options {


### PR DESCRIPTION
Track changes to jenkinsfile file in case we want to run the
full pipeline when something changes tot est that all steps are
correct