### PR TITLE
Increase airship update action timeout

### DIFF
--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -169,7 +169,7 @@
     - update_airship_osh_site
 
 # TODO(aagate): Add a changed_when: to help idempotency
-- name: Wait for update software action to complete... it can take up from 30-60 minutes
+- name: Wait for update software action to complete... it can take up from 30-75 minutes
   command: '{{ shipyard }} describe {{ shipyard_action_key }}'
   args:
     chdir: '{{ upstream_repos_clone_folder }}/airship/shipyard'
@@ -178,7 +178,7 @@
     OS_PASSWORD: "{{ lookup('password', secrets_location + '/ucp_shipyard_keystone_password ' + password_opts) }}"
   register: shipyard_desc_action
   until: shipyard_desc_action.stdout.find('Processing') < 0 and shipyard_desc_action.stdout.find('running') < 0
-  retries: 240
+  retries: 300
   delay: 15
   tags:
     - skip_ansible_lint


### PR DESCRIPTION
The current timeout of 60min doesn't seem to be enought. The ECP based
ci jobs are hitting that timeout occasionally.