### PR TITLE
Move "Setup Retry Save Path" section

### DIFF
--- a/doc/source/deployment/configure.rst
+++ b/doc/source/deployment/configure.rst
@@ -152,6 +152,20 @@ For example:
   ceph_admin_keyring_b64key: QVFDMXZ6dGNBQUFBQUJBQVJKakhuYkY4VFpublRPL1RXUEROdHc9PQo=
   ceph_user_keyring_b64key: QVFDMXZ6dGNBQUFBQUJBQVJKakhuYkY4VFpublRPL1RXUEROdHc9PQo=
 
+Set Up Retry Files Save Path
+----------------------------
+
+Before beginning deployment, a path can be specified where Ansible retry files
+can be saved in order to avoid potential errors. The path should point to a
+user-writable directory. Set the path in either of the following ways:
+
+- ``export ANSIBLE_RETRY_FILES_SAVE_PATH=<PATH_TO_DIRECTORY>`` before deploying
+  with ``run.sh`` commands.
+- Set the value of `retry_files_save_path` in your Ansible configuration file.
+
+There is an option to disable creating these retry files by setting
+``retry_files_enabled = False`` in your Ansible configuration file.
+
 Configure for Kubernetes
 ------------------------
 
@@ -192,19 +206,6 @@ For example:
 
    socok8s_ext_vip: "10.10.10.10"
 
-Set Up Retry Files Save Path
-----------------------------
-
-Before beginning deployment, a path can be specified where Ansible retry files
-can be saved in order to avoid potential errors. The path should point to a
-user-writable directory. Set the path in either of the following ways:
-
-- ``export ANSIBLE_RETRY_FILES_SAVE_PATH=<PATH_TO_DIRECTORY>`` before deploying
-  with ``run.sh`` commands.
-- Set the value of `retry_files_save_path` in your Ansible configuration file.
-
-There is an option to disable creating these retry files by setting
-``retry_files_enabled = False`` in your Ansible configuration file.
 
 Configure the VIP that will be used for Airship UCP service endpoints
 --------------------------------------------------------------------------


### PR DESCRIPTION
"Setup Retry Save Path" section was in middle of consecutive networking
sections.