### PR TITLE
[1.0] Update to freeze osh images

### DIFF
--- a/site/soc/software/charts/osh/openstack-compute-kit/libvirt.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/libvirt.yaml
@@ -11,7 +11,11 @@ metadata:
       component: libvirt
     actions:
       - method: replace
-        path: .values
+        path: .values.labels.agent
+      - method: delete
+        path: .values.ceph_client
+      - method: merge
+        path: .
   storagePolicy: cleartext
 data:
   wait:

--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -166,7 +166,7 @@ data:
         keystone_api: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
         keystone_domain_manage: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
       libvirt:
-        libvirt: "{{ suse_osh_registry_location }}/openstackhelm/libvirt:{{ suse_libvirt_image_version }}"
+        libvirt: "{{ suse_osh_registry_location }}/openstackhelm/libvirt:{{ suse_infra_image_version}}"
       mariadb:
         prometheus_mysql_exporter_helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       memcached: {}
@@ -213,6 +213,7 @@ data:
         openvswitch_vswitchd: "{{ suse_osh_registry_location }}/openstackhelm/openvswitch:{{ suse_infra_image_version }}"
       rabbitmq:
         prometheus_rabbitmq_exporter_helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        rabbitmq_init: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       tempest:
         tempest_run_tests: "{{ suse_osh_registry_location }}/openstackhelm/tempest:{{ suse_infra_image_version }}"
         ks_user: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
@@ -284,7 +285,9 @@ data:
       memcached: {}
       postgresql: {}
       promenade: {}
-      rabbitmq: {}
+      rabbitmq:
+        prometheus_rabbitmq_exporter_helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
+        rabbitmq_init: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       shipyard:
         shipyard: "{{ suse_airship_registry_location }}/airshipit/shipyard:{{ suse_airship_components_image_tag['shipyard'] }}"
         shipyard_db_sync: "{{ suse_airship_registry_location }}/airshipit/shipyard:{{ suse_airship_components_image_tag['shipyard'] }}"

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -15,8 +15,8 @@ socok8s_registry_certkey: "{{ socok8s_workspace }}/certs/domain.key"
 socok8s_caasp_environment_details: "{{ socok8s_workspace }}/environment.json"
 socok8s_libvirtuuid: "{{ socok8s_workspace }}/libvirt.uuid"
 suse_osh_registry_location: "docker.io"
-suse_openstack_image_version: "rocky-opensuse_15"
-suse_infra_image_version: "latest-opensuse_15"
+suse_openstack_image_version: "rocky-opensuse_15-20190613"
+suse_infra_image_version: "opensuse_15-20190613"
 
 socok8s_repos_to_configure:
   SLE12SP3-product: http://provo-clouddata.cloud.suse.de/repos/x86_64/SLES12-SP3-Pool/


### PR DESCRIPTION
Updated to use freezing osh and osh-infra images with date tag on 2019/06/13.
Changed RabbitMQ to also use opensuse image for db init.
Fixed libvirt chart to the overrides for image tag actully works to use
the freezing osh infra image tag.

(cherry picked from commit 6548d4509a5be98dde549f6deed341987391b613)