### PR TITLE
Switch CI job to provo mirror for Leap

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -32,6 +32,7 @@ pipeline {
            as the names of the heat stacks will be derived from this. Also
            the CaaSP Velum automation has issues with mixed case hostnames. */
         SOCOK8S_ENVNAME = "cloud-socok8s-${env.BRANCH_NAME.replaceAll("[^a-zA-Z0-9-]+", "-").toLowerCase()}-${env.BUILD_NUMBER}"
+        SOCOK8S_OPENSUSE_MIRROR="https://provo-mirror.opensuse.org"
         OS_CLOUD = "engcloud-cloud-ci"
         KEYNAME = "engcloud-cloud-ci"
         DELETE_ANYWAY = "YES"

--- a/playbooks/openstack-osh_hostconfig.yml
+++ b/playbooks/openstack-osh_hostconfig.yml
@@ -8,6 +8,25 @@
     - name: Ensure all the openstack mechanism vars are loaded
       include_vars: "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
 
+    - name: Collect repo files for removal
+      find:
+        paths: "/etc/zypp/repos.d/"
+        patterns: "*.repo"
+      register: repo_files
+
+    - name: Clear existing repo config
+      file:
+        path: "{{ item['path'] }}"
+        state: absent
+      with_items: "{{ repo_files['files'] }}"
+
+    - name: Disable delta rpms
+      ini_file:
+        path: /etc/zypp/zypp.conf
+        section: main
+        option: download.use_deltarpm
+        value: "false"
+
     - name: Configure host repositories
       zypper_repository:
         name: "{{ item }}"

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -18,15 +18,21 @@ suse_osh_registry_location: "docker.io"
 suse_openstack_image_version: "rocky-opensuse_15"
 suse_infra_image_version: "latest-opensuse_15"
 
+obs_mirror: "{{ lookup('env','SOCOK8S_OPENSUSE_MIRROR') | default('https://download.opensuse.org', true) }}"
+ibs_mirror: http://ibs-mirror.prv.suse.net
+
 socok8s_repos_to_configure:
   SLE12SP3-product: http://provo-clouddata.cloud.suse.de/repos/x86_64/SLES12-SP3-Pool/
   SLE12SP3-update: http://provo-clouddata.cloud.suse.de/repos/x86_64/SLES12-SP3-Updates/
   SES5-product: http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-Enterprise-Storage-5-Pool/
   SES5-update: http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-Enterprise-Storage-5-Updates/
-  Leap15develtools: https://download.opensuse.org/repositories/devel:/tools/openSUSE_Leap_15.0/
-  socok8s: https://download.opensuse.org/repositories/Cloud:/socok8s:/master/openSUSE_Leap_15.0/
-  CAASP30-update: http://ibs-mirror.prv.suse.net/dist/ibs/SUSE/Updates/SUSE-CAASP/3.0/x86_64/update/
-  CAASP30-pool: http://ibs-mirror.prv.suse.net/dist/ibs/SUSE/Products/SUSE-CAASP/3.0/x86_64/product/
+  openSUSE-Leap-15.0-Oss: "{{ obs_mirror }}/distribution/leap/15.0/repo/oss/"
+  openSUSE-Leap-15.0-Update: "{{ obs_mirror }}/update/leap/15.0/oss/"
+  openSUSE-Leap-15.0-Cloud: "{{ obs_mirror }}/repositories/Cloud:/Tools/openSUSE_Leap_15.0/"
+  Leap15develtools: "{{ obs_mirror }}/repositories/devel:/tools/openSUSE_Leap_15.0/"
+  socok8s: "{{ obs_mirror }}/repositories/Cloud:/socok8s:/master/openSUSE_Leap_15.0/"
+  CAASP30-update: "{{ ibs_mirror }}/dist/ibs/SUSE/Updates/SUSE-CAASP/3.0/x86_64/update/"
+  CAASP30-pool: "{{ ibs_mirror }}/dist/ibs/SUSE/Products/SUSE-CAASP/3.0/x86_64/product/"
 
 ######################################################
 # Following variables are used by airship logic only

--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -20,10 +20,15 @@ deploy_on_openstack_ses_repos_per_imagename:
     - SLE12SP3-update
     - SES5-product
     - SES5-update
+
 deploy_on_openstack_osh_repos_per_imagename:
   openSUSE-Leap-15.0:
+    - openSUSE-Leap-15.0-Oss
+    - openSUSE-Leap-15.0-Update
+    - openSUSE-Leap-15.0-Cloud
     - Leap15develtools
     - socok8s
+
 deploy_on_openstack_caasp_repos_per_imagename:
   caasp-3.0.0-GM-OpenStack-qcow:
     - CAASP30-update


### PR DESCRIPTION
This commit changes the CI job to use the local openSUSE Leap mirrors in
the datacenter, which should give a bit of a speed up for the zypper dup
call. (And also help avoid issues when the external mirror
infrastructure is slow)

Additionally we disable the use of delta RPMs in that case. Which
doesn't give any benefit when using the local mirror.