### PR TITLE
keystone: remove uneeded bootstrap script

### DIFF
--- a/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
@@ -68,22 +68,4 @@ data:
             Allow from all
           </IfModule>
         </Directory>
-    bootstrap:
-      # We override this due to SOC-9409: admin role not assigned to admin user on the default domain
-      # upstream patch: https://review.opendev.org/662993
-      # TODO(itxaka): remove once upstream patch is merged and airship git sha for openstack-helm updated
-      script: |
-        #NOTE(gagehugo): As of Rocky, keystone creates a member role by default
-        openstack role create --or-show member
-        openstack role add \
-              --user="${OS_USERNAME}" \
-              --user-domain="${OS_USER_DOMAIN_NAME}" \
-              --project-domain="${OS_PROJECT_DOMAIN_NAME}" \
-              --project="${OS_PROJECT_NAME}" \
-              "member"
-        # admin needs the admin role for the default domain
-        openstack role add \
-              --user="${OS_USERNAME}" \
-              --domain="default" \
-              "admin"
 ...


### PR DESCRIPTION
patches have been merged upstream[0][1] so we dont need this anymore
as its fixed

[0] https://review.opendev.org/662992
[1] https://review.opendev.org/662993