### PR TITLE
CI: Publish ARA reports

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -39,6 +39,9 @@ pipeline {
         ANSIBLE_VERBOSITY = 2
         ANSIBLE_STDOUT_CALLBACK = "yaml"
         USER = "jenkins" /* Why isn't this set in the jenkins environment? */
+        USE_ARA = "True"
+        SOCOK8S_USE_VIRTUALENV = "True"
+        ARA_DIR = "$WORKSPACE"
     }
 
     stages {
@@ -211,6 +214,19 @@ pipeline {
     }
 
     post {
+        always {
+            script {
+                sh 'ara generate html ara_report'
+            }
+            publishHTML target: [
+                        allowMissing: false,
+                        alwaysLinkToLastBuild: false,
+                        keepAll: true,
+                        reportDir: 'ara_report',
+                        reportFiles: 'index.html',
+                        reportName: 'ARA Report'
+            ]
+        }
         failure {
             script {
                 if (env.hold_instance_for_debug == 'true') {


### PR DESCRIPTION
Same as the docs, publish ARA reports so its easier
to troubleshoot what went wrong and get timing info
on playbooks