### PR TITLE
Decouple airship-setup-deployer from common socok8s vars

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -127,6 +127,7 @@ pipeline {
                 stage('Deploy CCP Deployer') {
                     steps {
                         sh "./run.sh deploy_ccp_deployer"
+                        sh "./run.sh configure_ccp_deployer"
                     }
                 }
             }

--- a/doc/source/suse-ecp/ose-targets.rst
+++ b/doc/source/suse-ecp/ose-targets.rst
@@ -85,6 +85,12 @@ Create the deployer node:
 
    ./run.sh deploy_ccp_deployer
 
+Configure the deployer node:
+
+.. code-block:: console
+
+   ./run.sh configure_ccp_deployer
+
 Enroll all the :term:`CaaSP` nodes into their roles (master, admin, and workers):
 
 .. code-block:: console

--- a/playbooks/generic-deploy_airship.yml
+++ b/playbooks/generic-deploy_airship.yml
@@ -2,8 +2,16 @@
 - hosts: soc-deployer
   gather_facts: yes
   any_errors_fatal: true
+  vars_files:
+    - "{{ playbook_dir }}/../vars/common-vars.yml"
+    - "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
   roles:
     - role: airship-setup-deployer
+      vars:
+        dcm_vip: "{{ socok8s_dcm_vip }}"
+        ext_vip: "{{ socok8s_ext_vip }}"
+        zypper_extra_repos:
+          socok8s: "{{ socok8s_repos_to_configure['socok8s'] }}"
       when: redeploy_osh_only is not defined or not redeploy_osh_only
       tags:
         - install

--- a/playbooks/openstack-configure_ccp_deployer.yml
+++ b/playbooks/openstack-configure_ccp_deployer.yml
@@ -15,4 +15,4 @@
 # under the License.
 #
 
-- import_playbook: openstack-osh_instance.yml
+- import_playbook: openstack-osh_hostconfig.yml

--- a/playbooks/roles/airship-setup-deployer/defaults/main.yml
+++ b/playbooks/roles/airship-setup-deployer/defaults/main.yml
@@ -1,8 +1,18 @@
 ---
 # defaults file for suse-airship-deploy
 
+# IP on the Data Center Management (DCM) network
+dcm_vip: null
+
+# IP on the external network
+ext_vip: null
+
 # Location of the kubeconfig file, fetched from velum UI.
 kubeconfig_file_path: "{{ socok8s_deploy_config_location }}/kubeconfig"
+
+# extra repositories that will be added. key should be the repo name,
+# value the repo url
+zypper_extra_repos: {}
 
 suse_airship_deploy_packages:
   - ca-certificates

--- a/playbooks/roles/airship-setup-deployer/tasks/main.yml
+++ b/playbooks/roles/airship-setup-deployer/tasks/main.yml
@@ -1,18 +1,13 @@
 ---
-- name: Load standard variables
-  include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
-
-- name: Load vip from user variables
-  include_vars: "{{ socok8s_extravars }}"
-
-- name: Add socok8s repository
+- name: Add zypper extra repositories
   become: yes
   zypper_repository:
-    name: "socok8s"
-    repo: "{{ socok8s_repos_to_configure['socok8s'] }}"
+    name: "{{ item['key'] }}"
+    repo: "{{ item['value'] }}"
     autorefresh: True
     auto_import_keys: yes
     state: present
+  loop: "{{ zypper_extra_repos | dict2items }}"
 
 - name: Install system packages
   become: yes
@@ -81,26 +76,26 @@
     marker: "# {mark} ANSIBLE MANAGED BLOCK for VIP entries"
     block: |
       # UCP service public end points
-      {{ socok8s_dcm_vip }} keystone.ucp.svc.cluster.local keystone-api.ucp.svc.cluster.local
-      {{ socok8s_dcm_vip }} barbican.ucp.svc.cluster.local barbican-api.ucp.svc.cluster.local
-      {{ socok8s_dcm_vip }} shipyard.ucp.svc.cluster.local
+      {{ dcm_vip }} keystone.ucp.svc.cluster.local keystone-api.ucp.svc.cluster.local
+      {{ dcm_vip }} barbican.ucp.svc.cluster.local barbican-api.ucp.svc.cluster.local
+      {{ dcm_vip }} shipyard.ucp.svc.cluster.local
       # Openstack admin service and internal endpoints
-      {{ socok8s_dcm_vip }} identity-api.openstack.svc.cluster.local
-      {{ socok8s_dcm_vip }} image-api.openstack.svc.cluster.local
-      {{ socok8s_dcm_vip }} volume-api.openstack.svc.cluster.local
-      {{ socok8s_dcm_vip }} compute-api.openstack.svc.cluster.local
-      {{ socok8s_dcm_vip }} network-api.openstack.svc.cluster.local
-      {{ socok8s_dcm_vip }} dashboard-api.openstack.svc.cluster.local
-      {{ socok8s_dcm_vip }} orchestration-api.openstack.svc.cluster.local
+      {{ dcm_vip }} identity-api.openstack.svc.cluster.local
+      {{ dcm_vip }} image-api.openstack.svc.cluster.local
+      {{ dcm_vip }} volume-api.openstack.svc.cluster.local
+      {{ dcm_vip }} compute-api.openstack.svc.cluster.local
+      {{ dcm_vip }} network-api.openstack.svc.cluster.local
+      {{ dcm_vip }} dashboard-api.openstack.svc.cluster.local
+      {{ dcm_vip }} orchestration-api.openstack.svc.cluster.local
       # Openstack service public endpoints
-      {{ socok8s_ext_vip }} identity.openstack.svc.cluster.local
-      {{ socok8s_ext_vip }} image.openstack.svc.cluster.local
-      {{ socok8s_ext_vip }} volume.openstack.svc.cluster.local
-      {{ socok8s_ext_vip }} compute.openstack.svc.cluster.local
-      {{ socok8s_ext_vip }} network.openstack.svc.cluster.local
-      {{ socok8s_ext_vip }} dashboard.openstack.svc.cluster.local
-      {{ socok8s_ext_vip }} nova-novncproxy.openstack.svc.cluster.local
-      {{ socok8s_ext_vip }} orchestration.openstack.svc.cluster.local
+      {{ ext_vip }} identity.openstack.svc.cluster.local
+      {{ ext_vip }} image.openstack.svc.cluster.local
+      {{ ext_vip }} volume.openstack.svc.cluster.local
+      {{ ext_vip }} compute.openstack.svc.cluster.local
+      {{ ext_vip }} network.openstack.svc.cluster.local
+      {{ ext_vip }} dashboard.openstack.svc.cluster.local
+      {{ ext_vip }} nova-novncproxy.openstack.svc.cluster.local
+      {{ ext_vip }} orchestration.openstack.svc.cluster.local
 
 - name: Creates /etc/openstack directory
   become: yes

--- a/run.sh
+++ b/run.sh
@@ -72,6 +72,9 @@ case "$deployment_action" in
         # as we shouldn't do it on caasp cluster (microOS and others)
         deploy_ccp_deployer
         ;;
+    "configure_ccp_deployer")
+        configure_ccp_deployer
+        ;;
     "enroll_caasp_workers")
         enroll_caasp_workers
         ;;
@@ -107,6 +110,7 @@ case "$deployment_action" in
         deploy_ses
         deploy_caasp
         deploy_ccp_deployer
+        configure_ccp_deployer
         enroll_caasp_workers
         ;;
     "setup_openstack")
@@ -130,6 +134,7 @@ case "$deployment_action" in
         deploy_ses
         deploy_caasp
         deploy_ccp_deployer
+        configure_ccp_deployer
         enroll_caasp_workers
         setup_caasp_workers_for_openstack
         patch_upstream

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -33,6 +33,10 @@ function deploy_ccp_deployer() {
     echo "Creating CCP deploy node"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-deploy_ccp_deployer.yml
 }
+function configure_ccp_deployer() {
+    echo "Configure CCP deployer node"
+    run_ansible ${socok8s_absolute_dir}/playbooks/openstack-configure_ccp_deployer.yml
+}
 function enroll_caasp_workers() {
     echo "Enrolling caasp worker nodes into the cluster"
     run_ansible ${socok8s_absolute_dir}/playbooks/generic-enroll_caasp_workers.yml

--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -91,7 +91,7 @@ validate_cli_options (){
        exit 1
    fi
 
-   OPTIONS=(deploy test update_openstack add_openstack_compute remove_openstack_compute remove_deployment deploy_network deploy_ses deploy_caasp deploy_ccp_deployer enroll_caasp_workers patch_upstream build_images deploy_osh setup_caasp_workers_for_openstack setup_hosts setup_openstack setup_airship setup_everything teardown clean_k8s clean_airship_not_images gather_logs)
+   OPTIONS=(deploy test update_openstack add_openstack_compute remove_openstack_compute remove_deployment deploy_network deploy_ses deploy_caasp configure_ccp_deployer deploy_ccp_deployer enroll_caasp_workers patch_upstream build_images deploy_osh setup_caasp_workers_for_openstack setup_hosts setup_openstack setup_airship setup_everything teardown clean_k8s clean_airship_not_images gather_logs)
 
    action=$1
    isvalid=false


### PR DESCRIPTION
Try to keep roles as separated as possible. That makes the role
reusable also for non socok8s cases and the role has an interface (the
variables) to interact with.
Note: airship-setup-deployer still depends on the common-deployer
role.
x