### PR TITLE
New version of helm toolkit is required for master versions of charts

### DIFF
--- a/vars/manifest.yml
+++ b/vars/manifest.yml
@@ -2,7 +2,7 @@
 upstream_repos:
   openstack-helm-infra:
     src: https://opendev.org/openstack/openstack-helm-infra
-    version: 3ba03ed8eacdc30098ecb09324b61db0f8e102ac
+    version: 565fb4606b54444f4ea126a598ec0519c8aec75c
     dest_subdir: openstack
   openstack-helm:
     src: https://opendev.org/openstack/openstack-helm


### PR DESCRIPTION
We need at least https://github.com/openstack/openstack-helm-infra/commit/0925f50e2aea5fccc06ab4781b66e615a1d1b7b0
because that was followed by changes in helm charts

It's likely we're gonna need https://github.com/openstack/openstack-helm-infra/commit/565fb4606b54444f4ea126a598ec0519c8aec75c
as well.