### PR TITLE
[1.0] Switch to a smaller flavor for SES the instance

### DIFF
--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -6,7 +6,7 @@ deploy_on_openstack_keypairname: "{{ lookup('env','KEYNAME') }}"
 # the heat stack name that is used for the network stack (which includes net/subnet/router)
 deploy_on_openstack_network_stackname: "{{ socok8s_envname }}-network"
 deploy_on_openstack_sesnode_image: "SLES12-SP3"
-deploy_on_openstack_sesnode_flavor: "d4.xlarge"
+deploy_on_openstack_sesnode_flavor: "cloud-ses"
 deploy_on_openstack_sesnode_securitygroup: "all-incoming"
 # Userdata to prevent the ephemeral disk being mounted by cloud-init
 deploy_on_openstack_sesnode_userdata: |


### PR DESCRIPTION
We don't seem to need 16GB instances there currently. We originally
switch to d4.xlarge because of the ephemeral disk. But that is provided
by "cloud-ses" as well. Switching to a smaller flavor should save some
resources in the Cloud.

(cherry picked from commit 488d4760033fb21cebdf9bbf81d3a31dfced0785)

Backport of https://github.com/SUSE-Cloud/socok8s/pull/570