### PR TITLE
[1.0] Do not deploy glance with the values intended for Newton

### DIFF
--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -295,6 +295,7 @@
   vars:
     _component_runcommand: "./tools/deployment/multinode/100-glance.sh"
     _component_run_env:
+      OSH_OPENSTACK_RELEASE: "{{ suse_osh_openstack_release }}"
       OSH_EXTRA_HELM_ARGS_GLANCE: >
         --values=./glance/values_overrides/rocky-opensuse_15.yaml
         --values=/tmp/socok8s-susedefaults-glance.yaml
@@ -382,7 +383,7 @@
         --values=/tmp/socok8s-susedefaults-neutron.yaml
         --values=/tmp/socok8s-useroverrides-neutron.yaml
         {{ lookup('env', 'OSH_EXTRA_HELM_ARGS_NEUTRON') | default('', True) }}
-      OSH_OPENSTACK_RELEASE: "rocky"
+      OSH_OPENSTACK_RELEASE: "{{ suse_osh_openstack_release }}"
       OSH_EXTRA_HELM_ARGS_NOVA: >
         --values=./nova/values_overrides/opensuse_15.yaml
         --values=./nova/values_overrides/rocky-opensuse_15.yaml

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -17,6 +17,7 @@ socok8s_libvirtuuid: "{{ socok8s_workspace }}/libvirt.uuid"
 suse_osh_registry_location: "docker.io"
 suse_openstack_image_version: "rocky-opensuse_15-20190613"
 suse_infra_image_version: "opensuse_15-20190613"
+suse_osh_openstack_release: "rocky"
 
 obs_mirror: "{{ lookup('env','SOCOK8S_OPENSUSE_MIRROR') | default('https://download.opensuse.org', true) }}"
 ibs_mirror: http://ibs-mirror.prv.suse.net


### PR DESCRIPTION
glance deployment script (100-glance.sh) sets OSH_OPENSTACK_RELEASE:="newton"

(cherry picked from commit bdbf8628d9739739a054b71bfea5cfc1311d2163)

Backport of https://github.com/SUSE-Cloud/socok8s/pull/565