### PR TITLE
[1.0] Update openstack helm image tag to 20190620

### DIFF
--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -166,7 +166,7 @@ data:
         keystone_api: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
         keystone_domain_manage: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
       libvirt:
-        libvirt: "{{ suse_osh_registry_location }}/openstackhelm/libvirt:{{ suse_infra_image_version}}"
+        libvirt: "{{ suse_osh_registry_location }}/openstackhelm/libvirt:rocky-opensuse_15-20190620"
       mariadb:
         prometheus_mysql_exporter_helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       memcached: {}


### PR DESCRIPTION
Update to the new date tag 20190620 which contains the libvirt fix that
includes the missing block rbd pakcage.