### PR TITLE
Configurable timeout for airship update action

### DIFF
--- a/playbooks/roles/airship-deploy-osh/defaults/main.yml
+++ b/playbooks/roles/airship-deploy-osh/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 shipyard_image: "{{ suse_airship_registry_location }}/airshipit/shipyard:{{suse_airship_components_image_tag['shipyard']}}"
 airship_pegleg_image: "{{ suse_airship_registry_location }}/airshipit/pegleg:{{suse_airship_components_image_tag['pegleg']}}"
+airship_deploy_openstack_timeout: "{{ lookup('env', 'AIRSHIP_DEPLOY_OPENSTACK_TIMEOUT') | default('120',  True) }}"

--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -169,7 +169,7 @@
     - update_airship_osh_site
 
 # TODO(aagate): Add a changed_when: to help idempotency
-- name: Wait for update software action to complete... it can take up from 30-75 minutes
+- name: "Wait for update software action to complete... it can take up to {{ airship_deploy_openstack_timeout }} minutes"
   command: '{{ shipyard }} describe {{ shipyard_action_key }}'
   args:
     chdir: '{{ upstream_repos_clone_folder }}/airship/shipyard'
@@ -178,8 +178,8 @@
     OS_PASSWORD: "{{ lookup('password', secrets_location + '/ucp_shipyard_keystone_password ' + password_opts) }}"
   register: shipyard_desc_action
   until: shipyard_desc_action.stdout.find('Processing') < 0 and shipyard_desc_action.stdout.find('running') < 0
-  retries: 300
-  delay: 15
+  retries: "{{ airship_deploy_openstack_timeout | int * 2 }}"
+  delay: 30
   tags:
     - skip_ansible_lint
     - update_airship_osh_site


### PR DESCRIPTION
The CI jobs still run into timeouts every once in a while. This PR
incraeases the default timeout to 120 minutes (which might not even
be too unreasonable for larger deployments).

It also turns the timeout into an attribute so it can be override
via the AIRSHIP_DEPLOY_OPENSTACK_TIMEOUT enviroment variable.