### PR TITLE
[WIP][hackweek][fun] Run the deployer in a container

### DIFF
--- a/playbooks/docker-deploy_ccp_deployer.yml
+++ b/playbooks/docker-deploy_ccp_deployer.yml
@@ -1,0 +1,18 @@
+---
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+- import_playbook: docker-osh_instance.yml

--- a/playbooks/docker-osh_instance.yml
+++ b/playbooks/docker-osh_instance.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  gather_facts: no
+  connection: local
+  roles:
+    - role: handle-nodes-on-docker
+      vars:
+        servername_suffix: "deployer"
+        groupname_for_inventory: "soc-deployer"
+        delete: "{{ ((osh_node_delete | default('False')) | bool) }}"

--- a/playbooks/openstack-osh_hostconfig.yml
+++ b/playbooks/openstack-osh_hostconfig.yml
@@ -77,10 +77,15 @@
       tags:
         - skip_ansible_lint
 
+    - name: Check if running in a container
+      command: grep docker /proc/1/cgroup -qa
+      register: inside_docker
+
     - name: Reboot host
       reboot:
         reboot_timeout: 900
         connect_timeout: 90
+      when: inside_docker.rc == 1
 
     - name: Store facts
       setup:

--- a/playbooks/roles/common-deployer/tasks/helm-run.yml
+++ b/playbooks/roles/common-deployer/tasks/helm-run.yml
@@ -1,4 +1,8 @@
 ---
+- name: Check if running in a container
+  command: grep docker /proc/1/cgroup -qa
+  register: inside_docker
+
 - name: Copy systemd unit into place for helm server if running as non-root
   become: yes
   template:
@@ -14,6 +18,16 @@
     daemon_reload: yes
     name: helm-serve
     enabled: yes
+  when: inside_docker.rc == 1
+
+- name: check if port 8879 is open
+  shell: ss -tp state listening sport = :8879
+  register: helm_port
+
+- name: Run helm in the background
+  command: /usr/bin/helm serve &
+  poll: 0
+  when: inside_docker.rc == 0 and helm_port.rc != 0
 
 - name: Check if helm server is up
   wait_for:

--- a/playbooks/roles/deploy-osh/tasks/main.yml
+++ b/playbooks/roles/deploy-osh/tasks/main.yml
@@ -79,6 +79,7 @@
 
 - name: Ensure VIP is present in /etc/hosts for the services to deploy
   blockinfile:
+    unsafe_writes: yes
     path: /etc/hosts
     block: |
       {{ socok8s_ext_vip }} keystone.openstack.svc.cluster.local keystone

--- a/playbooks/roles/handle-nodes-on-docker/tasks/create_on_docker.yml
+++ b/playbooks/roles/handle-nodes-on-docker/tasks/create_on_docker.yml
@@ -1,0 +1,65 @@
+---
+- name: Pre-flight checks for the role
+  assert:
+    that:
+      - user_ssh_key is defined
+
+- name: Create server
+  docker_container:
+    name: "{{ servername }}"
+    image: opensuse/leap:15.0
+    command: ["sleep", "infinity"]
+
+# xml needed for zypper repo managemnet, iproute needed so ansible gathers network facts
+- name: Install sshd and python inside the container
+  command: docker exec {{ servername }} zypper --non-interactive in openssh python python-xml iproute tar gzip unzip xz which sudo
+
+- name: Create sshd keys inside the container
+  command: docker exec {{ servername }} ssh-keygen -A
+
+- name: Create ssh dir
+  command: docker exec {{ servername }} mkdir -p /root/.ssh/
+
+- name: Set proper perms for ssh dir
+  command: docker exec {{ servername }} chmod 700 /root/.ssh/
+
+- name: Copy user key into authorized keys
+  command: docker exec {{ servername }} bash -c "echo '{{ user_ssh_key }}' >> /root/.ssh/authorized_keys"
+
+- name: Set proper perms for authorized_keys
+  command: docker exec {{ servername }} chmod 600 /root/.ssh/authorized_keys
+
+- name: Run sshd inside the container
+  command: docker exec {{ servername }} /usr/sbin/sshd
+
+
+- name: Get server floating IP
+  set_fact:
+    floating_ip: "{{ ansible_facts.docker_container.NetworkSettings.IPAddress }}"
+
+- name: Extend inventory in workspace with newly created OSH deployer node
+  copy:
+    content: "{{ soc_aio_overrides }}"
+    dest: "{{ socok8s_workspace }}/inventory/{{ groupname_for_inventory }}.yml"
+  vars:
+    soc_aio_overrides: |
+      {{ groupname_for_inventory }}:
+        hosts:
+          {{ servername }}:
+            ansible_host: {{ floating_ip }}
+
+- meta: refresh_inventory
+
+- name: Get pubkey, and add it to known hosts
+  command: "ssh-keyscan -H {{ floating_ip | quote }}"
+  changed_when: false
+  register: _floatingkey
+  retries: 20
+  delay: 10
+  until: _floatingkey.stdout and _floatingkey.stdout.strip()
+
+- name: Insert known host
+  known_hosts:
+    state: present
+    name: "{{ floating_ip }}"
+    key: "{{ _floatingkey.stdout }}"

--- a/playbooks/roles/handle-nodes-on-docker/tasks/delete_on_docker.yml
+++ b/playbooks/roles/handle-nodes-on-docker/tasks/delete_on_docker.yml
@@ -1,0 +1,18 @@
+---
+- name: Delete container
+  docker_container:
+    name: "{{ servername }}"
+    state: absent
+
+# Looping will avoid the need to create a condition if no hosts
+# exists in the inventory.
+- name: Remove all hosts from this group known hosts
+  known_hosts:
+    state: absent
+    name: "{{ hostvars[item]['ansible_host'] }}"
+  loop: "{{ groups[groupname_for_inventory] }}"
+
+- name: Delete inventory
+  file:
+    state: absent
+    path: "{{ socok8s_workspace }}/inventory/{{ groupname_for_inventory }}.yml"

--- a/playbooks/roles/handle-nodes-on-docker/tasks/main.yml
+++ b/playbooks/roles/handle-nodes-on-docker/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Load vars
+  include_vars: "{{ item }}"
+  loop:
+    - "{{ playbook_dir }}/../vars/common-vars.yml"
+    - "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+
+- name: Define servername based on runtime
+  set_fact:
+    servername: "{{ socok8s_envname }}-{{ servername_suffix }}"
+
+- name: Create servers on docker
+  include_tasks: create_on_docker.yml
+  when:
+    - "not ( (delete | default(False)) | bool )"
+
+- name: Delete servers on docker
+  include_tasks: delete_on_docker.yml
+  when:
+    - "( (delete | default(False)) | bool )"

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -38,9 +38,15 @@ function deploy_caasp4(){
 }
 
 function deploy_ccp_deployer() {
-    source ${scripts_absolute_dir}/pre-flight-checks.sh check_openstack_environment_is_ready_for_deploy
+    if [[ ${SOCOK8S_DEPLOYER_DOCKER:-"NO"} == "YES" ]]
     echo "Creating CCP deploy node"
-    run_ansible ${socok8s_absolute_dir}/playbooks/openstack-deploy_ccp_deployer.yml
+    then
+        source ${scripts_absolute_dir}/pre-flight-checks.sh check_openstack_environment_is_ready_for_deploy
+        run_ansible ${socok8s_absolute_dir}/playbooks/openstack-deploy_ccp_deployer.yml
+    else
+        run_ansible ${socok8s_absolute_dir}/playbooks/docker-deploy_ccp_deployer.yml
+    fi
+
 }
 function configure_ccp_deployer() {
     echo "Configure CCP deployer node"


### PR DESCRIPTION
Runs the deployer in a docker container

 - We need to set unsafe_writes for editing /etc/hosts as the way
ansible does it its not compatible with containers
 - Avoid trying to reboot the containers by checking if we are inside one
 - Manually create the authorized_keys for ssh server to allow root to ssh
 - Launches a manual sshd
 - Requires a new extravar: user_ssh_key which contains the pub file for the
user ssh which will be added to the container

Everything works pretty good. Unfortunately, mixing this with openstack for
testing results in the deployer not being able to reach the openstack vip
I cannot test it fuirther, but pods get deployed properly