### PR TITLE
Build against Leap 15.1 deployer image

### DIFF
--- a/playbooks/generic-clean_airship.yml
+++ b/playbooks/generic-clean_airship.yml
@@ -17,6 +17,8 @@
 - hosts: soc-deployer
   gather_facts: no
   any_errors_fatal: true
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   tasks:
     - name: Remove compute nodes.
       include_role:
@@ -27,6 +29,8 @@
 
 - hosts: soc-deployer
   gather_facts: no
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   pre_tasks:
     - name: Load generic vars
       include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
@@ -37,6 +41,8 @@
 - hosts: caasp-workers
   gather_facts: no
   any_errors_fatal: true
+  vars:
+    ansible_python_interpreter: /usr/bin/python2
   tasks:
     - name: Clean airship related existing images on worker node
       shell: |

--- a/playbooks/generic-clean_k8s.yml
+++ b/playbooks/generic-clean_k8s.yml
@@ -17,6 +17,8 @@
 
 - hosts: soc-deployer
   gather_facts: no
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   tasks:
     - name: Running cleanup script
       script: "{{ playbook_dir }}/../script_library/cleanup-k8s.sh"

--- a/playbooks/generic-collect-logs.yml
+++ b/playbooks/generic-collect-logs.yml
@@ -18,6 +18,7 @@
 - hosts: soc-deployer
   gather_facts: false
   vars:
+    ansible_python_interpreter: /usr/bin/python3
     # this is where on the target machine the logs will be copied
     logs_dir: "/tmp/socok8s_gather_logs"
     zuul:

--- a/playbooks/generic-deploy_airship.yml
+++ b/playbooks/generic-deploy_airship.yml
@@ -19,12 +19,27 @@
   hosts: ses_nodes[0]
   remote_user: root
   gather_facts: true
+  vars:
+    ansible_python_interpreter: /usr/bin/python2
   roles:
     - common-ses
 
-- hosts: soc-deployer:caasp-workers
+- hosts: soc-deployer
   gather_facts: false
   any_errors_fatal: true
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  roles:
+    - role: registry-server-setup
+      tags:
+        - install
+        - imagebuilder
+
+- hosts: caasp-workers
+  gather_facts: false
+  any_errors_fatal: true
+  vars:
+    ansible_python_interpreter: /usr/bin/python2
   roles:
     - role: registry-server-setup
       tags:
@@ -44,6 +59,8 @@
 - hosts: caasp-workers
   gather_facts: yes
   any_errors_fatal: true
+  vars:
+    ansible_python_interpreter: /usr/bin/python2
   roles:
     - role: airship-configure-worker
       when: redeploy_osh_only is not defined or not redeploy_osh_only

--- a/playbooks/generic-deploy_ses_aio.yml
+++ b/playbooks/generic-deploy_ses_aio.yml
@@ -24,6 +24,7 @@
   vars_files:
     - "{{ playbook_dir }}/../vars/common-vars.yml"
   vars:
+    ansible_python_interpreter: /usr/bin/python2
     ses_openstack_config: True
     ses_openstack_glance_pool:
       name: "{{ airship_ses_pools_prefix | default('') }}images"
@@ -51,5 +52,7 @@
   hosts: ses_nodes[0]
   remote_user: root
   gather_facts: false
+  vars:
+    ansible_python_interpreter: /usr/bin/python2
   tasks:
     - include: roles/common-ses/tasks/ses_config.yml

--- a/playbooks/generic-generate_certs_for_local_registry.yml
+++ b/playbooks/generic-generate_certs_for_local_registry.yml
@@ -24,5 +24,7 @@
   hosts: localhost
   gather_facts: yes
   connection: local
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   roles:
     - generate-certs

--- a/playbooks/generic-setup_caasp_workers_for_openstack.yml
+++ b/playbooks/generic-setup_caasp_workers_for_openstack.yml
@@ -6,6 +6,8 @@
   hosts: caasp-workers
   gather_facts: yes
   any_errors_fatal: true
+  vars:
+    ansible_python_interpreter: /usr/bin/python2
   roles:
     - role: setup-caasp-workers
       tags:

--- a/playbooks/openstack-caasp_instance.yml
+++ b/playbooks/openstack-caasp_instance.yml
@@ -4,6 +4,7 @@
   connection: local
   vars:
     stackname_suffix: "caasp"
+    ansible_python_interpreter: /usr/bin/python3
   tasks:
     - name: Load generic vars
       include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"

--- a/playbooks/openstack-create_network.yml
+++ b/playbooks/openstack-create_network.yml
@@ -2,6 +2,8 @@
 - hosts: localhost
   gather_facts: no
   connection: local
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   post_tasks:
     - name: Load generic vars
       include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"

--- a/playbooks/openstack-delete_caasp.yml
+++ b/playbooks/openstack-delete_caasp.yml
@@ -4,6 +4,7 @@
   connection: local
   vars:
     stackname_suffix: "caasp"
+    ansible_python_interpreter: /usr/bin/python3
   post_tasks:
     - name: Load generic vars
       include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"

--- a/playbooks/openstack-osh_hostconfig.yml
+++ b/playbooks/openstack-osh_hostconfig.yml
@@ -28,10 +28,11 @@
         value: "false"
 
     - name: Workaround stupid JeOS image bugs (bsc#1138727)
-      shell: "test -L /etc/resolv.conf || netconfig update -f"
-      args:
-        executable: /bin/sh
-        creates: /var/run/netconfig/resolv.conf
+      file:
+        src: /var/run/netconfig/resolv.conf
+        dest: /etc/resolv.conf
+        state: link
+        force: yes
 
     - name: Configure host repositories
       zypper_repository:
@@ -47,7 +48,7 @@
         path: /etc/zypp/vendors.d/opensuse
         block: |
           [main]
-          vendors = suse,opensuse,obs://build.opensuse.org/Cloud:OpenStack,obs://build.opensuse.org/devel:languages:python
+          vendors = suse,opensuse,obs://build.opensuse.org/Cloud:OpenStack
         create: yes
 
     - name: Zypper dist-upgrade

--- a/playbooks/openstack-osh_instance.yml
+++ b/playbooks/openstack-osh_instance.yml
@@ -2,6 +2,8 @@
 - hosts: localhost
   gather_facts: no
   connection: local
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   pre_tasks:
     - name: Load generic vars
       include_vars: "{{ item }}"

--- a/playbooks/openstack-ses_aio_hostconfig.yml
+++ b/playbooks/openstack-ses_aio_hostconfig.yml
@@ -6,6 +6,7 @@
       - rng-tools
     # Domain name to use in the deployment. Default assumes properly configured dns name.
     domainname: "{{ ansible_domain | default('openstack.local', True) }}"
+    ansible_python_interpreter: /usr/bin/python2
   tasks:
     - name: Ensure all the common vars are loaded
       include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"

--- a/playbooks/openstack-ses_aio_instance.yml
+++ b/playbooks/openstack-ses_aio_instance.yml
@@ -2,6 +2,8 @@
 - hosts: localhost
   gather_facts: no
   connection: local
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   pre_tasks:
     - name: Load generic vars
       include_vars: "{{ item }}"

--- a/playbooks/roles/airship-setup-deployer/defaults/main.yml
+++ b/playbooks/roles/airship-setup-deployer/defaults/main.yml
@@ -22,7 +22,8 @@ suse_airship_deploy_packages:
   - python3-setuptools
   - python3-pip
   - python3-cmd2
-  - python-devel
+  - python
+  - python-base
 
 suse_airship_openstackclient_packages:
   - python3-barbicanclient

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -30,8 +30,13 @@ socok8s_repos_to_configure:
   openSUSE-Leap-15.0-Oss: "{{ obs_mirror }}/distribution/leap/15.0/repo/oss/"
   openSUSE-Leap-15.0-Update: "{{ obs_mirror }}/update/leap/15.0/oss/"
   openSUSE-Leap-15.0-Cloud: "{{ obs_mirror }}/repositories/Cloud:/Tools/openSUSE_Leap_15.0/"
+  openSUSE-Leap-15.1-Oss: "{{ obs_mirror }}/distribution/leap/15.1/repo/oss/"
+  openSUSE-Leap-15.1-Update: "{{ obs_mirror }}/update/leap/15.1/oss/"
+  openSUSE-Leap-15.1-Cloud: "{{ obs_mirror }}/repositories/Cloud:/Tools/openSUSE_Leap_15.1/"
   Leap15develtools: "{{ obs_mirror }}/repositories/devel:/tools/openSUSE_Leap_15.0/"
+  develtools-opensuse151: "{{ obs_mirror }}/repositories/devel:/tools/openSUSE_Leap_15.1/"
   socok8s: "{{ obs_mirror }}/repositories/Cloud:/socok8s:/master/openSUSE_Leap_15.0/"
+  socok8s-opensuse151: "{{ obs_mirror }}/repositories/Cloud:/socok8s:/master/openSUSE_Leap_15.1/"
   CAASP30-update: "{{ ibs_mirror }}/dist/ibs/SUSE/Updates/SUSE-CAASP/3.0/x86_64/update/"
   CAASP30-pool: "{{ ibs_mirror }}/dist/ibs/SUSE/Products/SUSE-CAASP/3.0/x86_64/product/"
 

--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -30,6 +30,12 @@ deploy_on_openstack_osh_repos_per_imagename:
     - openSUSE-Leap-15.0-Cloud
     - Leap15develtools
     - socok8s
+  openSUSE-Leap-15.1-JeOS.x86_64-OpenStack-Cloud:
+    - openSUSE-Leap-15.1-Oss
+    - openSUSE-Leap-15.1-Update
+    - openSUSE-Leap-15.1-Cloud
+    - develtools-opensuse151
+    - socok8s-opensuse151
 
 deploy_on_openstack_caasp_repos_per_imagename:
   caasp-3.0.0-GM-OpenStack-qcow:
@@ -39,7 +45,7 @@ deploy_on_openstack_caasp_image: "caasp-3.0.0-GM-OpenStack-qcow"
 deploy_on_openstack_caasp_workers: 3
 deploy_on_openstack_caasp_securitygroup: "{{ deploy_on_openstack_sesnode_securitygroup }}"
 deploy_on_openstack_caasp_stacknamefile: "{{ socok8s_workspace }}/stackname"
-deploy_on_openstack_oshnode_image: "openSUSE-Leap-15.0"
+deploy_on_openstack_oshnode_image: "openSUSE-Leap-15.1-JeOS.x86_64-OpenStack-Cloud"
 deploy_on_openstack_oshnode_flavor: "m1.large"
 deploy_on_openstack_oshnode_securitygroup: "all-incoming"
 deploy_on_openstack_oshnode_userdata: |


### PR DESCRIPTION
This switches to the official JeOS image for openSUSE Leap 15.1.
Unfortunately this one doesn't have python 2.x embedded so
we need to be ultra correct in specifying the ansible python interpreter
everywhere. On the bright side that actually fixes the reality to
match the documentation (documenation didn't say that python 2.x
is required while it was actually required).