### PR TITLE
docs: add ARA install

### DIFF
--- a/doc/source/suse-ecp/ose-localhost.rst
+++ b/doc/source/suse-ecp/ose-localhost.rst
@@ -69,6 +69,7 @@ Optionally, `localhost` can be preinstalled with the following software:
   * python3-jmespath
   * python3-openstacksdk
   * python3-netaddr
+  * python3-ara
 
 SUSE Containerized OpenStack only supports the Python3 variant of packages.
 Generally, the `python` command invokes Python version 2, which will not work


### PR DESCRIPTION
In the docs for localhost install instructions it is recommended to use
ARA for Ansible. Added install instructions for it.