### PR TITLE
Workspace dir needed for ARA config

### DIFF
--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -11,6 +11,12 @@ check_common_env_vars_set (){
     fi
 
     echo "Using ${SOCOK8S_WORKSPACE_BASEDIR}/${SOCOK8S_ENVNAME}-workspace as workspace directory"
+
+    # Needed for the Ansible ARA check step
+    if [ ! -d ${SOCOK8S_WORKSPACE_BASEDIR}/${SOCOK8S_ENVNAME}-workspace ]; then
+        echo "Creating workspace directory at ${SOCOK8S_WORKSPACE_BASEDIR}/${SOCOK8S_ENVNAME}-workspace"
+        mkdir -p ${SOCOK8S_WORKSPACE_BASEDIR}/${SOCOK8S_ENVNAME}-workspace
+    fi
 }
 
 check_openstack_env_vars_set (){


### PR DESCRIPTION
The directory needed for ARA config is created either when the virtual
environment is created or in the first call of run_ansible. In case you
are not using a virtual environment and you are using ARA that directory
will be missing and the pre-fligh-checks would fail. This patch adds that
directory in such case.