### PR TITLE
caasp4 cleanup: fix corner case

### DIFF
--- a/playbooks/roles/caasp4/tasks/cleanup_nodes.yml
+++ b/playbooks/roles/caasp4/tasks/cleanup_nodes.yml
@@ -19,6 +19,11 @@
 # stack in setup_nodes.yml so we need to remove the resources again from
 # terraform state and let heat handle the reource cleanup
 
+- name: Does the terraform workspace exist
+  stat:
+    path: skuba_ci_terraform_workspace
+  register: _terraform_workspace
+
 - name: Does the terraform state exist
   stat:
     path: "{{ skuba_ci_terraform_workspace }}/terraform.tfstate"
@@ -32,6 +37,7 @@
   terraform:
     project_path: "{{ skuba_ci_terraform_workspace }}"
     state: absent
+  when: _terraform_workspace.stat.exists
 
 - name: Drop skuba openstack terraform files
   file:


### PR DESCRIPTION
There is an issue with the cleanup of caasp 4 that will try to
remove the terraform plan even if the terraform workspace
does not exists, which leads to a failure

This patch adds a check for the workspace existing to trigger the
task to remove the terraform plan