### PR TITLE
bump osh repo for deploy_osh

### DIFF
--- a/vars/manifest.yml
+++ b/vars/manifest.yml
@@ -2,7 +2,7 @@
 upstream_repos:
   openstack-helm-infra:
     src: https://opendev.org/openstack/openstack-helm-infra
-    version: 565fb4606b54444f4ea126a598ec0519c8aec75c
+    version: master
     dest_subdir: openstack
   openstack-helm:
     src: https://opendev.org/openstack/openstack-helm


### PR DESCRIPTION
All repos are unfrozen when deploying just osh but openstack-helm-infra
This is currently resulting in an issue where the neutron chart from
master requires a change in osh-infra but infra is frozen to an older
version.

This bumps osh-infra to master like the other repos. This config is
only applied when using deploy_osh so it should not affect airship
deployment as that uses a different repo tracking
(site/soc/software/config/versions.yml)