### PR TITLE
doc: deploy_network prerequisite for manual steps

### DIFF
--- a/doc/source/suse-ecp/ose-targets.rst
+++ b/doc/source/suse-ecp/ose-targets.rst
@@ -67,6 +67,12 @@ requirements:
 *  When SES is deployed as AIO, two additional 60GB storage disks must be added
    to the node for OSD.
 
+Create network:
+
+.. code-block:: console
+
+   ./run.sh deploy_network
+
 Configure SES-AIO:
 
 .. code-block:: console


### PR DESCRIPTION
In the doc section to deploy SES and CaaSP for SUSE developers, there's
a step-by-step section to deploy them with run.sh, but it needs the
'deploy_network' step before. That step is already included in the
aggregated 'setup_hosts' step.