### PR TITLE
Update playbook to remove become attribute.

### DIFF
--- a/playbooks/roles/common-ses/tasks/main.yml
+++ b/playbooks/roles/common-ses/tasks/main.yml
@@ -3,7 +3,6 @@
   include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
 
 - name: Create pools in SES for socok8s usage
-  become: yes
   include_role:
     name: ses
     tasks_from: openstack_config


### PR DESCRIPTION
OpenSUSE Leap 15.0 updated ansible to version 2.8. New version of
ansible produces this error.

ERROR! 'become' is not a valid attribute for a IncludeRole

Become was not necessary for this task because already running as root.