### PR TITLE
Drop VIP patch

### DIFF
--- a/doc/source/deployment/configure.rst
+++ b/doc/source/deployment/configure.rst
@@ -205,20 +205,6 @@ For example:
    socok8s_ext_vip: "10.10.10.10"
 
 
-Configure the VIP that will be used for Airship UCP service endpoints
---------------------------------------------------------------------------
-
-Add `socok8s_dcm_vip:` with its appropriate value for your
-environment in your `env/extravars`. This should be an available IP
-on the Data Center Management (DCM) network (in development environment, it
-can be the same as CaaSP cluster network).
-
-For example:
-
-.. code-block:: yaml
-
-   socok8s_dcm_vip: "192.168.51.35"
-
 .. _configurecloudscaleprofile:
 
 Configure Cloud Scale Profile

--- a/doc/source/suse-ecp/ose-configure.rst
+++ b/doc/source/suse-ecp/ose-configure.rst
@@ -115,20 +115,6 @@ For example:
    socok8s_ext_vip: "10.10.10.10"
 
 
-Configure the VIP that will be used for Airship UCP service endpoints
----------------------------------------------------------------------
-
-Add `socok8s_dcm_vip:` with its appropriate value for your environment in your
-`env/extravars`. This should be an available IP on the data center management
-(DCM) network (in a development environment, it can be the same as a CaaSP
-cluster network).
-
-For example:
-
-.. code-block:: yaml
-
-   socok8s_dcm_vip: "192.168.51.35"
-
 Provide a kubeconfig file
 -------------------------
 

--- a/doc/source/user/minimal-network-example.rst
+++ b/doc/source/user/minimal-network-example.rst
@@ -30,7 +30,6 @@ The following configuration files reflect the diagram above.
 
     socok8s_deployment_goal: airship
     socok8s_ext_vip: 172.30.0.245
-    socok8s_dcm_vip: 172.30.0.246
     #either "minimal" or "ha"
     scale_profile: minimal
     redeploy_osh_only: false

--- a/doc/source/user/multi-network-example.rst
+++ b/doc/source/user/multi-network-example.rst
@@ -9,18 +9,6 @@ SES network configuration have their own respective documentation.
 .. nwdiag::
 
    nwdiag {
-     network dcm {
-       address = "172.30.0.x/24"
-       deployer [address = "172.30.0.10"];
-       group caasp {
-           color = "#EEEEEE";
-           caasp-admin [address = "172.30.0.11"];
-           caasp-master [address = "172.30.0.12"];
-           caasp-worker1 [address = "172.30.0.13"];
-           caasp-worker2 [address = "172.30.0.14"];
-       }
-       ses [address = "172.30.0.15"];
-     }
 
      network storage {
        address = "172.30.2.x/24"
@@ -48,7 +36,6 @@ The following configuration files reflect the diagram above.
 
     socok8s_deployment_goal: airship
     socok8s_ext_vip: 172.30.1.245
-    socok8s_dcm_vip: 172.30.0.246
     #either "minimal" or "ha"
     scale_profile: minimal
     redeploy_osh_only: false

--- a/examples/workdir/env/extravars
+++ b/examples/workdir/env/extravars
@@ -8,7 +8,6 @@ suse_osh_deploy_ceph_mons: ['192.168.50.10:6789']
 
 
 socok8s_ext_vip: 10.10.1.100
-socok8s_dcm_vip: 192.168.89.251
 #either "minimal" or "ha"
 scale_profile: ha
 redeploy_osh_only: false

--- a/heat-templates/openstack-network.yml
+++ b/heat-templates/openstack-network.yml
@@ -50,14 +50,6 @@ resources:
       router_id: { get_resource: router }
       subnet_id: { get_resource: subnet }
 
-  dcm_vip_port:
-    type: OS::Neutron::Port
-    properties:
-      name:
-        list_join: ['-', [ { get_param: prefix }, 'dcm-vip']]
-      network: { get_resource: network }
-      port_security_enabled: False
-
   # TODO: This should be improved in the future by creating two seperate networks for the two vip ports
   ext_vip_port:
     type: OS::Neutron::Port
@@ -77,7 +69,5 @@ outputs:
   router_id:
     description: Router ID
     value: { get_resource: router }
-  dcm_vip:
-    value: {get_attr: [dcm_vip_port, fixed_ips, 0, ip_address]}
   ext_vip:
     value: {get_attr: [ext_vip_port, fixed_ips, 0, ip_address]}

--- a/playbooks/generic-deploy_airship.yml
+++ b/playbooks/generic-deploy_airship.yml
@@ -8,7 +8,6 @@
   roles:
     - role: airship-setup-deployer
       vars:
-        dcm_vip: "{{ socok8s_dcm_vip }}"
         ext_vip: "{{ socok8s_ext_vip }}"
         zypper_extra_repos:
           socok8s: "{{ socok8s_repos_to_configure['socok8s'] }}"

--- a/playbooks/openstack-create_network.yml
+++ b/playbooks/openstack-create_network.yml
@@ -35,7 +35,7 @@
         block: |
           socok8s_{{ item.output_key }}: {{ item.output_value }}
       with_items: "{{ network_stack_create_output.stack.outputs }}"
-      when: ( item.output_key == 'dcm_vip') or ( item.output_key == 'ext_vip' )
+      when: item.output_key == 'ext_vip'
 
     - name: Add internal network ID to group_vars
       blockinfile:

--- a/playbooks/roles/airship-setup-deployer/defaults/main.yml
+++ b/playbooks/roles/airship-setup-deployer/defaults/main.yml
@@ -1,9 +1,6 @@
 ---
 # defaults file for suse-airship-deploy
 
-# IP on the Data Center Management (DCM) network
-dcm_vip: null
-
 # IP on the external network
 ext_vip: null
 

--- a/playbooks/roles/airship-setup-deployer/tasks/main.yml
+++ b/playbooks/roles/airship-setup-deployer/tasks/main.yml
@@ -76,17 +76,17 @@
     marker: "# {mark} ANSIBLE MANAGED BLOCK for VIP entries"
     block: |
       # UCP service public end points
-      {{ dcm_vip }} keystone.ucp.svc.cluster.local keystone-api.ucp.svc.cluster.local
-      {{ dcm_vip }} barbican.ucp.svc.cluster.local barbican-api.ucp.svc.cluster.local
-      {{ dcm_vip }} shipyard.ucp.svc.cluster.local
+      {{ ext_vip }} keystone.ucp.svc.cluster.local keystone-api.ucp.svc.cluster.local
+      {{ ext_vip }} barbican.ucp.svc.cluster.local barbican-api.ucp.svc.cluster.local
+      {{ ext_vip }} shipyard.ucp.svc.cluster.local
       # Openstack admin service and internal endpoints
-      {{ dcm_vip }} identity-api.openstack.svc.cluster.local
-      {{ dcm_vip }} image-api.openstack.svc.cluster.local
-      {{ dcm_vip }} volume-api.openstack.svc.cluster.local
-      {{ dcm_vip }} compute-api.openstack.svc.cluster.local
-      {{ dcm_vip }} network-api.openstack.svc.cluster.local
-      {{ dcm_vip }} dashboard-api.openstack.svc.cluster.local
-      {{ dcm_vip }} orchestration-api.openstack.svc.cluster.local
+      {{ ext_vip }} identity-api.openstack.svc.cluster.local
+      {{ ext_vip }} image-api.openstack.svc.cluster.local
+      {{ ext_vip }} volume-api.openstack.svc.cluster.local
+      {{ ext_vip }} compute-api.openstack.svc.cluster.local
+      {{ ext_vip }} network-api.openstack.svc.cluster.local
+      {{ ext_vip }} dashboard-api.openstack.svc.cluster.local
+      {{ ext_vip }} orchestration-api.openstack.svc.cluster.local
       # Openstack service public endpoints
       {{ ext_vip }} identity.openstack.svc.cluster.local
       {{ ext_vip }} image.openstack.svc.cluster.local

--- a/playbooks/roles/deploy-osh/templates/ingress-kube-system.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/ingress-kube-system.yaml.j2
@@ -12,13 +12,7 @@ network:
     # what type of vip manage machanism will be used
     # possible options: routed, keepalived
     mode: routed
-{# Remove this condition when https://review.openstack.org/#/c/640115 merges #}
-{% if developer_mode | bool %}
-    interfaces: ingress-vip
-    addrs: {{ socok8s_ext_vip }}
-{% else %}
     interface: ingress-vip
     addr: {{ socok8s_ext_vip }}
-{% endif %}
     external_policy_local: true
 {{ lookup('template','files/common-images-overrides.yml') | from_yaml | to_nice_yaml(indent=2) }}

--- a/playbooks/roles/dev-patcher/defaults/main.yml
+++ b/playbooks/roles/dev-patcher/defaults/main.yml
@@ -7,7 +7,4 @@ dev_patcher_packages:
 #merged patches will be skipped
 #unrelated patches will fail (because not cloned)
 #conflicting patches will fail (because need resolving)
-dev_patcher_patches:
-  # osh-infra: Add support for mulitple VIPS
-  - - 640115
-    - acdab0cd7f7c4c718d09029e4fb2722f616ecf4b
+dev_patcher_patches: []

--- a/site/soc/software/charts/ucp/kube-system-ingress/ingress.yaml
+++ b/site/soc/software/charts/ucp/kube-system-ingress/ingress.yaml
@@ -26,8 +26,8 @@ data:
         # what type of vip manage machanism will be used
         # possible options: routed, keepalived
         mode: routed
-        interfaces: ext-vip,dcm-vip
-        addrs: {{ socok8s_ext_vip }},{{ socok8s_dcm_vip }}
+        interface: ext-vip
+        addr: {{ socok8s_ext_vip }}
       external_policy_local: true
   source:
     type: local


### PR DESCRIPTION
Looks like the patch is not gonna be merged upstream and its
currently on merge conflict. Talked with Scott and he seems to
agree with this so the recomendation is to drop it and look
for an alternative solution

Meanwhile having the pathc in there block us from updating osh-infra
to the latest commit, which is necessary as neutron deployment
is currently broken due to a missing feature from htk which is
only available on the latest git versions, hence the need to
bump osh-infra to master for now.