### PR TITLE
Introduce TERRAFORM_BINARY_PATH env var for custom terraform binary

### DIFF
--- a/playbooks/roles/caasp4/defaults/main.yml
+++ b/playbooks/roles/caasp4/defaults/main.yml
@@ -1,3 +1,6 @@
+# path to the terraform binary
+terraform_binary_path: "{{ (lookup('env','TERRAFORM_BINARY_PATH') | default('/usr/bin/terraform', true) ) }}"
+
 # A image that is available in the OpenStack cloud. That image is used to deploy
 # CaaSP 4 with the skuba ci terraforms
 skuba_ci_terraform_image_name: "SLE-15-SP1-JeOS-GM"

--- a/playbooks/roles/caasp4/tasks/_cleanup_nodes_terraform_remove_resources.yml
+++ b/playbooks/roles/caasp4/tasks/_cleanup_nodes_terraform_remove_resources.yml
@@ -16,32 +16,32 @@
 #
 
 - name: Get current state from terraform
-  command: terraform state list
+  command: "{{ terraform_binary_path }} state list"
   args:
     chdir: "{{ socok8s_workspace }}/skuba-terraform/"
   register: _terraform_state_list
   changed_when: False
 
 - name: Remove internal network resource from terraform state
-  command: terraform state rm openstack_networking_network_v2.network
+  command: "{{ terraform_binary_path }} state rm openstack_networking_network_v2.network"
   args:
     chdir: "{{ socok8s_workspace }}/skuba-terraform/"
   when: '"openstack_networking_network_v2.network" in _terraform_state_list.stdout_lines'
 
 - name: Remove internal subnet resource from terraform state
-  command: terraform state rm openstack_networking_subnet_v2.subnet
+  command: "{{ terraform_binary_path }} state rm openstack_networking_subnet_v2.subnet"
   args:
     chdir: "{{ socok8s_workspace }}/skuba-terraform/"
   when: '"openstack_networking_subnet_v2.subnet" in _terraform_state_list.stdout_lines'
 
 - name: Remove router interrface resource from terraform state
-  command: terraform state rm openstack_networking_router_interface_v2.router_interface
+  command: "{{ terraform_binary_path }} state rm openstack_networking_router_interface_v2.router_interface"
   args:
     chdir: "{{ socok8s_workspace }}/skuba-terraform/"
   when: '"openstack_networking_router_interface_v2.router_interface" in _terraform_state_list.stdout_lines'
 
 - name: Remove router resource from terraform state
-  command: terraform state rm openstack_networking_router_v2.router
+  command: "{{ terraform_binary_path }} state rm openstack_networking_router_v2.router"
   args:
     chdir: "{{ socok8s_workspace }}/skuba-terraform/"
   when: '"openstack_networking_router_v2.router" in _terraform_state_list.stdout_lines'

--- a/playbooks/roles/caasp4/tasks/_setup_nodes_terraform_import_resources.yml
+++ b/playbooks/roles/caasp4/tasks/_setup_nodes_terraform_import_resources.yml
@@ -21,7 +21,7 @@
   register: _terraform_state_file
 
 - name: Get current state from terraform
-  command: terraform state list
+  command: "{{ terraform_binary_path }} state list"
   args:
     chdir: "{{ socok8s_workspace }}/skuba-terraform/"
   register: _terraform_state_list
@@ -29,25 +29,25 @@
   when: _terraform_state_file.stat.exists
 
 - name: Import internal network resource to terraform
-  command: "terraform import openstack_networking_network_v2.network {{ deploy_on_openstack_internal_network_id }}"
+  command: "{{ terraform_binary_path }} import openstack_networking_network_v2.network {{ deploy_on_openstack_internal_network_id }}"
   args:
     chdir: "{{ skuba_ci_terraform_workspace }}"
   when: 'not _terraform_state_file.stat.exists or "openstack_networking_network_v2.network" not in _terraform_state_list.stdout_lines'
 
 - name: Import internal subnet resource to terraform
-  command: "terraform import openstack_networking_subnet_v2.subnet {{ deploy_on_openstack_internal_subnet_id }}"
+  command: "{{ terraform_binary_path }} import openstack_networking_subnet_v2.subnet {{ deploy_on_openstack_internal_subnet_id }}"
   args:
     chdir: "{{ skuba_ci_terraform_workspace }}"
   when: 'not _terraform_state_file.stat.exists or "openstack_networking_subnet_v2.subnet" not in _terraform_state_list.stdout_lines'
 
 - name: Import router resource to terraform
-  command: "terraform import openstack_networking_router_v2.router {{ deploy_on_openstack_router_id }}"
+  command: "{{ terraform_binary_path }} import openstack_networking_router_v2.router {{ deploy_on_openstack_router_id }}"
   args:
     chdir: "{{ skuba_ci_terraform_workspace }}"
   when: 'not _terraform_state_file.stat.exists or "openstack_networking_router_v2.router" not in _terraform_state_list.stdout_lines'
 
 - name: Import router interface resource to terraform
-  command: "terraform import openstack_networking_router_interface_v2.router_interface {{ deploy_on_openstack_router_interface_id }}"
+  command: "{{ terraform_binary_path }} import openstack_networking_router_interface_v2.router_interface {{ deploy_on_openstack_router_interface_id }}"
   args:
     chdir: "{{ skuba_ci_terraform_workspace }}"
   when: 'not _terraform_state_file.stat.exists or "openstack_networking_router_interface_v2.router_interface" not in _terraform_state_list.stdout_lines'

--- a/playbooks/roles/caasp4/tasks/cleanup_nodes.yml
+++ b/playbooks/roles/caasp4/tasks/cleanup_nodes.yml
@@ -30,6 +30,7 @@
 
 - name: Destroy terraform plan
   terraform:
+    binary_path: "{{ terraform_binary_path }}"
     project_path: "{{ skuba_ci_terraform_workspace }}"
     state: absent
 

--- a/playbooks/roles/caasp4/tasks/setup_k8s.yml
+++ b/playbooks/roles/caasp4/tasks/setup_k8s.yml
@@ -26,7 +26,7 @@
     msg: "{{ _skuba_version.stdout }}{{ _skuba_version.stderr }}"
 
 - name: Get terraform output variables
-  command: terraform output -json
+  command: "{{ terraform_binary_path }} output -json"
   args:
     chdir: "{{ skuba_ci_terraform_workspace }}"
   changed_when: False

--- a/playbooks/roles/caasp4/tasks/setup_nodes.yml
+++ b/playbooks/roles/caasp4/tasks/setup_nodes.yml
@@ -54,7 +54,7 @@
   register: _terraform_hidden_dir
 
 - name: Initialize terraform in the workspace dir
-  command: terraform init -input=false
+  command: "{{ terraform_binary_path }} init -input=false"
   args:
     chdir: "{{ skuba_ci_terraform_workspace }}"
   when: not _terraform_hidden_dir.stat.exists
@@ -68,11 +68,12 @@
 
 - name: Apply terraform plan in the workspace dir
   terraform:
+    binary_path: "{{ terraform_binary_path }}"
     project_path: "{{ skuba_ci_terraform_workspace }}"
     state: present
 
 - name: Get terraform output variables
-  command: terraform output -json
+  command: "{{ terraform_binary_path }} output -json"
   args:
     chdir: "{{ skuba_ci_terraform_workspace }}"
   changed_when: False

--- a/run.sh
+++ b/run.sh
@@ -41,6 +41,9 @@ DEPLOYMENT_MECHANISM=${DEPLOYMENT_MECHANISM:-"kvm"}
 # The base directory where workspace(s) are created in
 SOCOK8S_WORKSPACE_BASEDIR=${SOCOK8S_WORKSPACE_BASEDIR:-~}
 
+# The path to the terraform binary
+TERRAFORM_BINARY_PATH=${TERRAFORM_BINARY_PATH:-/usr/bin/terraform}
+
 source ${scripts_absolute_dir}/pre-flight-checks.sh check_common_env_vars_set
 source ${scripts_absolute_dir}/bootstrap-ansible-if-necessary.sh
 source ${scripts_absolute_dir}/pre-flight-checks.sh check_jq_present

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -51,7 +51,7 @@ function enroll_caasp_workers() {
     run_ansible ${socok8s_absolute_dir}/playbooks/generic-enroll_caasp_workers.yml
 }
 function clean_caasp4(){
-    if command -v terraform && [ -d submodules/skuba ]; then
+    if command -v ${TERRAFORM_BINARY_PATH} && [ -d submodules/skuba ]; then
         source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp4_skuba_available
         source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp4_terraform_available
         echo "Delete CaaSP 4"

--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -37,9 +37,9 @@ check_caasp4_skuba_available(){
 }
 check_caasp4_terraform_available(){
     echo "Checking for CaaSP 4 that terraform is available"
-    command -v terraform 1> /dev/null
+    command -v ${TERRAFORM_BINARY_PATH} 1> /dev/null
     if [ $? -ne 0 ]; then
-        echo "terraform executable not in \$PATH. Can not deploy CaaSP 4"
+        echo "${TERRAFORM_BINARY_PATH} executable not in \$PATH. Can not deploy CaaSP 4"
         exit
     fi
 }


### PR DESCRIPTION
For CaaSP4, terraform is used to setup the nodes. But the CaaSP4 code
needs terraform 0.11.X but in openSUSE Tumbleweed there is already
terraform 0.12.X which is incompatible (there are big differences
between 0.11 and 0.12).
To be able to continue with an older terraform version, make the used
binary configurable. Steps to use this:

- Download an 0.11 release from
  https://releases.hashicorp.com/terraform/
- Unpack the binary, make it executable and copy it to your ~/bin/
- export TERRAFORM_BINARY_PATH=~/bin/terraform-0.11

Now continue with the usual ./run caasp4 step to deploy CaaSP4.