### PR TITLE
Use SLE15 for the deployer

### DIFF
--- a/playbooks/openstack-enroll_caasp_workers.yml
+++ b/playbooks/openstack-enroll_caasp_workers.yml
@@ -46,6 +46,16 @@
         src: "{{ playbook_dir }}/../files/velum-bootstrap.tar.xz"
         dest: "{{ upstream_repos_clone_folder }}/ccp/"
 
+    # In SLE15 the default bundler is 2.x while the velum Gemfile.lock has been bundled with 1.15.0 so we need to
+    # manually remove the BUNDLED WITH+1.15.0 text of the Gemfile.lock for it to install the dependencies
+    - name: Remove "BUNDLED WITH" text from Gemfile.lock
+      lineinfile:
+        path: "{{ upstream_repos_clone_folder }}/ccp/velum-bootstrap/Gemfile.lock"
+        state: absent
+        regexp: "{{ item }}"
+      with_items:
+        - "^BUNDLED WITH$"
+        - "1.15.0$"
 
     # Ansible velum needs to get given a specific shell, bash, therefore
     # the shell module has to be used (command doesn't accept executable)

--- a/playbooks/openstack-osh_hostconfig.yml
+++ b/playbooks/openstack-osh_hostconfig.yml
@@ -47,7 +47,7 @@
         path: /etc/zypp/vendors.d/opensuse
         block: |
           [main]
-          vendors = suse,opensuse,obs://build.opensuse.org/Cloud:OpenStack,obs://build.opensuse.org/devel:languages:python
+          vendors = suse,opensuse,obs://build.opensuse.org/Cloud:OpenStack,obs://build.opensuse.org/devel:languages:python, obs://build.opensuse.org/devel:languages:ruby
         create: yes
 
     - name: Zypper dist-upgrade

--- a/playbooks/roles/deploy-osh/defaults/main.yml
+++ b/playbooks/roles/deploy-osh/defaults/main.yml
@@ -17,7 +17,6 @@ suse_osh_deploy_packages:
   - gcc
   - make
   - jq
-  - rng-tools
   - curl #after this line these are the packages required for osh deploy itself
   - python-selinux
   - ceph-common

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -32,6 +32,20 @@ socok8s_repos_to_configure:
   openSUSE-Leap-15.0-Cloud: "{{ obs_mirror }}/repositories/Cloud:/Tools/openSUSE_Leap_15.0/"
   Leap15develtools: "{{ obs_mirror }}/repositories/devel:/tools/openSUSE_Leap_15.0/"
   socok8s: "{{ obs_mirror }}/repositories/Cloud:/socok8s:/master/openSUSE_Leap_15.0/"
+  SLES15-JeOS-OpenStack-Cloud-GM-Pool: http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/
+  SLES15-JeOS-OpenStack-Cloud-GM-Update: http://download.suse.de/ibs/SUSE:/SLE-15:/Update/standard/
+  # needed for python-barbicanclient
+  SLES15-JeOS-OpenStack-Cloud-GM-backports: "{{ obs_mirror }}/repositories/openSUSE:/Backports:/SLE-15/standard/"
+  # may not be needed?
+  SLES15-JeOS-OpenStack-Cloud-GM-Cloud:  "{{ obs_mirror }}/repositories/Cloud:/Tools/SLE_15/"
+  # needed for gcc
+  SLES15-JeOS-OpenStack-Cloud-GM-develtools: "{{ ibs_mirror }}/ibs/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product/"
+  # needed for phantomjs
+  SLES15-JeOS-OpenStack-Cloud-GM-develtools2: "{{ obs_mirror }}/repositories/devel:/tools/SLE_15/"
+  # needed for ruby2.5-devel
+  SLES15-JeOS-OpenStack-Cloud-GM-ruby: "{{ obs_mirror }}/repositories/devel:/languages:/ruby/SLE_15/"
+
+  socok8s_SLE15: "{{ obs_mirror }}/repositories/Cloud:/socok8s:/master/SLE_15/"
   CAASP30-update: "{{ ibs_mirror }}/dist/ibs/SUSE/Updates/SUSE-CAASP/3.0/x86_64/update/"
   CAASP30-pool: "{{ ibs_mirror }}/dist/ibs/SUSE/Products/SUSE-CAASP/3.0/x86_64/product/"
 

--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -30,6 +30,16 @@ deploy_on_openstack_osh_repos_per_imagename:
     - openSUSE-Leap-15.0-Cloud
     - Leap15develtools
     - socok8s
+  SLES15-JeOS-OpenStack-Cloud-GM:
+    - SLES15-JeOS-OpenStack-Cloud-GM-Pool
+    - SLES15-JeOS-OpenStack-Cloud-GM-Update
+    - SLES15-JeOS-OpenStack-Cloud-GM-Cloud
+    - SLES15-JeOS-OpenStack-Cloud-GM-develtools
+    - SLES15-JeOS-OpenStack-Cloud-GM-develtools2
+    - SLES15-JeOS-OpenStack-Cloud-GM-ruby
+    - SLES15-JeOS-OpenStack-Cloud-GM-rubyextensions
+    - SLES15-JeOS-OpenStack-Cloud-GM-backports
+    - socok8s_SLE15
 
 deploy_on_openstack_caasp_repos_per_imagename:
   caasp-3.0.0-GM-OpenStack-qcow:
@@ -39,7 +49,7 @@ deploy_on_openstack_caasp_image: "caasp-3.0.0-GM-OpenStack-qcow"
 deploy_on_openstack_caasp_workers: 3
 deploy_on_openstack_caasp_securitygroup: "{{ deploy_on_openstack_sesnode_securitygroup }}"
 deploy_on_openstack_caasp_stacknamefile: "{{ socok8s_workspace }}/stackname"
-deploy_on_openstack_oshnode_image: "openSUSE-Leap-15.0"
+deploy_on_openstack_oshnode_image: "SLES15-JeOS-OpenStack-Cloud-GM"
 deploy_on_openstack_oshnode_flavor: "m1.large"
 deploy_on_openstack_oshnode_securitygroup: "all-incoming"
 deploy_on_openstack_oshnode_userdata: |


### PR DESCRIPTION
Uses SLE15 for the deployer.

 - Removes 2 lines from the velum Gemfile.lock for bundle 2.0 compatibility
 - Adds an extra vendor from the devel:languages:ruby for zypper
 - Drops rng-tools from the required packages as it doesnt seem to be used
 - Adds the needed repos for SLES15-JeOS
 - Changes the openstack image used from Leap 15.0 to SLES15-JeOS