### PR TITLE
Fixing incorrect user names in generated ses_config

### DIFF
--- a/playbooks/roles/common-ses/templates/ses-config.yml.j2
+++ b/playbooks/roles/common-ses/templates/ses-config.yml.j2
@@ -8,21 +8,21 @@ ceph_conf:
 cinder:
   key: {{ client_cinder_file_key }}
   rbd_store_pool: "{{ airship_ses_pools_prefix | default('') }}volumes"
-  rbd_store_user: "{{ airship_ses_pools_prefix | default('') }}cinder"
+  rbd_store_user: "cinder"
 cinder-backup:
   key: {{ client_cinder_backup_file_key }}
   rbd_store_pool: "{{ airship_ses_pools_prefix | default('') }}cinder_backup"
-  rbd_store_user: "{{ airship_ses_pools_prefix | default('') }}cinder-backup"
+  rbd_store_user: "cinder-backup"
 nova:
   rbd_store_pool: "{{ airship_ses_pools_prefix | default('') }}nova"
 glance:
   key: {{ client_glance_file_key }}
   rbd_store_pool: "{{ airship_ses_pools_prefix | default('') }}images"
-  rbd_store_user: "{{ airship_ses_pools_prefix | default('') }}glance"
+  rbd_store_user: "glance"
 libvirt:
   key: {{ client_cinder_file_key }}
   rbd_store_pool: "{{ airship_ses_pools_prefix | default('') }}vms"
-  rbd_store_user: "{{ airship_ses_pools_prefix | default('') }}cinder"
+  rbd_store_user: "cinder"
 {% if ( radosgw_keystone|default(False, true)) %}
 radosgw_urls: "http://{{ hostvars[groups['ses_nodes'][0]].ansible_default_ipv4.address }}:8080/swift/v1"
 {% endif %}


### PR DESCRIPTION
As part of SES integration via automation repo, we are only creating
SES pools with prefix. We cware not creating users with that prefix.
So removing prefix usage for rbd_store_user(s) in ses_config yaml
file.