### PR TITLE
Don't try to remove a non-existent caaspv4 cluster

### DIFF
--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -63,7 +63,6 @@ function clean_openstack(){
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-osh_instance.yml -e osh_node_delete=True
     echo "Delete CaaSP 3 nodes"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-delete_caasp.yml
-    clean_caasp4
     echo "Delete SES node"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-ses_aio_instance.yml -e ses_node_delete=True
     echo "Delete network stack"


### PR DESCRIPTION
Attempting to run a teardown action on a default deployment fails due to
a missing terraform binary. Remove the caaspv4 cleanup from the teardown
action since a default deployment will deploy caaspv3. The caaspv3
cleanup can be replaced with the caaspv4 cleanup when we update the
setup_hosts action to deploy caaspv4 instead of caaspv3.