### PR TITLE
Delegate cert copy to the host with the cert

### DIFF
--- a/playbooks/roles/registry-server-setup/tasks/apply-certs.yml
+++ b/playbooks/roles/registry-server-setup/tasks/apply-certs.yml
@@ -4,6 +4,7 @@
   copy:
     src: "{{ suse_registry_certs_dir }}/domain.crt"
     dest: "/etc/pki/trust/anchors"
+  delegate_to: "{{ groups['soc-deployer'][0] }}"
   become: yes
   register: _copy_ssc_result
 


### PR DESCRIPTION
We generate the docker registry certificate on the deployer host, in the
event that the ansible runner host is not the deployer host, the copy
task will fail because there is no certificate on the ansible localhost.
Delegate the task to the first host in the host group we generated the
certificate on.