### PR TITLE
[1.0] Fix neutron dnsmasq failure

### DIFF
--- a/playbooks/roles/airship-configure-worker/defaults/main.yml
+++ b/playbooks/roles/airship-configure-worker/defaults/main.yml
@@ -4,3 +4,5 @@ ceph_namespace_name: "{{ ceph_namespace | default('ceph') }}"
 openstack_namespace_name: "{{ openstack_namespace | default('openstack') }}"
 
 suse_cp_node_create_subvolume: false
+apparmor_profiles:
+  - usr.sbin.dnsmasq

--- a/playbooks/roles/airship-configure-worker/files/usr.sbin.dnsmasq
+++ b/playbooks/roles/airship-configure-worker/files/usr.sbin.dnsmasq
@@ -1,0 +1,5 @@
+# Site-specific additions and overrides for 'usr.sbin.dnsmasq'
+# neutron containers need the following access to launch dnsmasq
+  /etc/neutron/dnsmasq.conf r,
+  /var/lib/neutron/dhcp/ rw,
+  /var/lib/neutron/dhcp/** rw,

--- a/playbooks/roles/airship-configure-worker/handlers/main.yml
+++ b/playbooks/roles/airship-configure-worker/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Reload apparmor profile
+  command: "apparmor_parser -r /etc/apparmor.d/{{ item.item }}"
+  when: item.changed
+  loop: "{{ apparmor_copy.results | flatten(levels=1) }}"
+  loop_control:
+    label: "{{ item.item }}"

--- a/playbooks/roles/airship-configure-worker/tasks/main.yml
+++ b/playbooks/roles/airship-configure-worker/tasks/main.yml
@@ -87,3 +87,20 @@
     - _enrollforopenstackcp.stderr.find("already has a value (primary)") == -1
   tags:
     - skip_ansible_lint
+
+- name: Copy openstack apparmor profile into the workers
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/apparmor.d/local/{{ item }}"
+  loop: "{{ apparmor_profiles }}"
+  register: apparmor_copy
+  when:
+    - ('airship-openstack-control-workers' in group_names) or ('airship-openstack-compute-workers' in group_names)
+
+- name: Reload apparmor profile
+  command: "apparmor_parser -r /etc/apparmor.d/{{ item.item }}"
+  when: item.changed
+  loop: "{{ apparmor_copy.results | flatten(levels=1) }}"
+  loop_control:
+    label: "{{ item.item }}"
+

--- a/playbooks/roles/airship-configure-worker/tasks/main.yml
+++ b/playbooks/roles/airship-configure-worker/tasks/main.yml
@@ -94,13 +94,6 @@
     dest: "/etc/apparmor.d/local/{{ item }}"
   loop: "{{ apparmor_profiles }}"
   register: apparmor_copy
+  notify: Reload apparmor profile
   when:
     - ('airship-openstack-control-workers' in group_names) or ('airship-openstack-compute-workers' in group_names)
-
-- name: Reload apparmor profile
-  command: "apparmor_parser -r /etc/apparmor.d/{{ item.item }}"
-  when: item.changed
-  loop: "{{ apparmor_copy.results | flatten(levels=1) }}"
-  loop_control:
-    label: "{{ item.item }}"
-


### PR DESCRIPTION
With latest caasp, dnsmasq fails in the Neutron dhcp pod without read
permission to the dnsmasq conf file. The root cause is missing
appropriate apparmor configuration for the dnsmasq.

(cherry picked from commit 1ef53fd337c8b0c8c1c1543e7be0814a913ba7a8)