### PR TITLE
Make sure shipyard can read the pegleg output

### DIFF
--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -86,6 +86,13 @@
     - install
     - always
 
+- name: Make sure shipyard can read the pegleg output
+  become: yes
+  file:
+    path: '{{ upstream_repos_clone_folder }}/airship/shipyard/{{ pegleg_output }}'
+    recurse: yes
+    mode: '+r'
+
 # TODO(aagate): Add a changed_when: to help idempotency
 - name: Create config docs in Shipyard
   command: '{{ shipyard }} create configdocs {{ socok8s_site_name }}-design --replace --directory=/target/{{ pegleg_output }}'
@@ -97,6 +104,7 @@
   register: shipyard_create_config
   failed_when:
     - shipyard_create_config.stdout.find('Error') == 0
+    - shipyard_create_config.stdout.find('Traceback') == 0
     - "no_revision_error_msg not in shipyard_create_config.stdout"
   tags:
     - install


### PR DESCRIPTION
The treasuremap.yaml file created by pegleg may not be readable by
shipyard, make sure it is world-readable.