### PR TITLE
 Use SLE15SP1 for the deployer

### DIFF
--- a/playbooks/generic-deploy_airship.yml
+++ b/playbooks/generic-deploy_airship.yml
@@ -10,7 +10,7 @@
       vars:
         ext_vip: "{{ socok8s_ext_vip }}"
         zypper_extra_repos:
-          socok8s: "{{ socok8s_repos_to_configure['socok8s'] }}"
+          socok8s: "{{ socok8s_repos_to_configure['socok8s_SLE15SP1'] }}"
       when: redeploy_osh_only is not defined or not redeploy_osh_only
       tags:
         - install

--- a/playbooks/openstack-enroll_caasp_workers.yml
+++ b/playbooks/openstack-enroll_caasp_workers.yml
@@ -47,6 +47,20 @@
         dest: "{{ upstream_repos_clone_folder }}/ccp/"
 
 
+    # In SLE15SP1 the default bundler is 2.x while the velum Gemfile.lock has been bundled with 1.15.0 so we need to
+    # manually remove the BUNDLED WITH+1.15.0 text of the Gemfile.lock for it to install the dependencies
+    # This is only needed for CAASP3, can be removed once we move to CAASP4
+    - name: Remove "BUNDLED WITH" text from Gemfile.lock
+      lineinfile:
+        path: "{{ upstream_repos_clone_folder }}/ccp/velum-bootstrap/Gemfile.lock"
+        state: absent
+        regexp: "{{ item }}"
+      with_items:
+        - "^BUNDLED WITH$"
+        - "1.15.0$"
+
+
+
     # Ansible velum needs to get given a specific shell, bash, therefore
     # the shell module has to be used (command doesn't accept executable)
     # Skip ansible lint is therefore used, to avoid the warning that this task

--- a/playbooks/openstack-osh_hostconfig.yml
+++ b/playbooks/openstack-osh_hostconfig.yml
@@ -28,10 +28,12 @@
         value: "false"
 
     - name: Workaround stupid JeOS image bugs (bsc#1138727)
-      shell: "test -L /etc/resolv.conf || netconfig update -f"
+      file:
       args:
-        executable: /bin/sh
-        creates: /var/run/netconfig/resolv.conf
+        src: /var/run/netconfig/resolv.conf
+        dest: /etc/resolv.conf
+        state: link
+        force: yes
 
     - name: Configure host repositories
       zypper_repository:
@@ -40,6 +42,7 @@
         autorefresh: True
         auto_import_keys: yes
         state: present
+        disable_gpg_check: yes
       loop: "{{ deploy_on_openstack_osh_repos_per_imagename[deploy_on_openstack_oshnode_image] }}"
 
     - name: Add known vendors
@@ -47,7 +50,7 @@
         path: /etc/zypp/vendors.d/opensuse
         block: |
           [main]
-          vendors = suse,opensuse,obs://build.opensuse.org/Cloud:OpenStack,obs://build.opensuse.org/devel:languages:python
+          vendors = suse,opensuse,obs://build.opensuse.org/Cloud:OpenStack,obs://build.opensuse.org/devel:languages:python,obs://build.opensuse.org/Cloud,obs://build.opensuse.org/devel:languages:ruby
         create: yes
 
     - name: Zypper dist-upgrade

--- a/playbooks/openstack-osh_instance.yml
+++ b/playbooks/openstack-osh_instance.yml
@@ -20,3 +20,4 @@
         groupname_for_inventory: "soc-deployer"
         userdata: "{{ deploy_on_openstack_oshnode_userdata }}"
         delete: "{{ ((osh_node_delete | default('False')) | bool) }}"
+        python_interpreter: /usr/bin/python3

--- a/playbooks/roles/deploy-osh/defaults/main.yml
+++ b/playbooks/roles/deploy-osh/defaults/main.yml
@@ -17,7 +17,6 @@ suse_osh_deploy_packages:
   - gcc
   - make
   - jq
-  - rng-tools
   - curl #after this line these are the packages required for osh deploy itself
   - python-selinux
   - ceph-common

--- a/playbooks/roles/handle-nodes-on-openstack/tasks/create_on_openstack.yml
+++ b/playbooks/roles/handle-nodes-on-openstack/tasks/create_on_openstack.yml
@@ -37,6 +37,7 @@
         hosts:
           {{ servername }}:
             ansible_host: {{ floating_ip }}
+            {% if python_interpreter|default(False) %}ansible_python_interpreter: {{ python_interpreter }}{% endif %}
 
 - meta: refresh_inventory
 

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -31,7 +31,18 @@ socok8s_repos_to_configure:
   openSUSE-Leap-15.0-Update: "{{ obs_mirror }}/update/leap/15.0/oss/"
   openSUSE-Leap-15.0-Cloud: "{{ obs_mirror }}/repositories/Cloud:/Tools/openSUSE_Leap_15.0/"
   Leap15develtools: "{{ obs_mirror }}/repositories/devel:/tools/openSUSE_Leap_15.0/"
+  SLE-15-SP1-JeOS-GM-Full: http://download.suse.de/full/full-sle15-sp1-x86_64/
+  SLE-15-SP1-JeOS-GM-Update: http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update/standard/
+  # needed for python-barbicanclient
+  SLE-15-SP1-JeOS-GM-backports: "https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP1/standard/"
+  # needed for ruby2.5-devel
+  SLE-15-SP1-JeOS-GM-ruby: "https://download.opensuse.org/repositories/devel:/languages:/ruby/SLE_15_SP1/"
+  # needed for ruby2.5-rubygem-bundler
+  SLE-15-SP1-JeOS-GM-rubyextensions: "https://download.opensuse.org/repositories/devel:languages:ruby:extensions/SLE_15_SP1/"
+  # phantomjs
+  SLE-15-SP1-JeOS-GM-openstack-master: "https://download.opensuse.org/repositories/Cloud:/OpenStack:/Master/SLE_15_SP1/"
   socok8s: "{{ obs_mirror }}/repositories/Cloud:/socok8s:/master/openSUSE_Leap_15.0/"
+  socok8s_SLE15SP1: "https://download.opensuse.org/repositories/Cloud:/socok8s:/master/SLE_15_SP1/"
   CAASP30-update: "{{ ibs_mirror }}/dist/ibs/SUSE/Updates/SUSE-CAASP/3.0/x86_64/update/"
   CAASP30-pool: "{{ ibs_mirror }}/dist/ibs/SUSE/Products/SUSE-CAASP/3.0/x86_64/product/"
 

--- a/vars/deploy-on-openstack.yml
+++ b/vars/deploy-on-openstack.yml
@@ -30,6 +30,14 @@ deploy_on_openstack_osh_repos_per_imagename:
     - openSUSE-Leap-15.0-Cloud
     - Leap15develtools
     - socok8s
+  SLE-15-SP1-JeOS-GM:
+    - SLE-15-SP1-JeOS-GM-Full
+    - SLE-15-SP1-JeOS-GM-Update
+    - SLE-15-SP1-JeOS-GM-backports
+    - SLE-15-SP1-JeOS-GM-openstack-master
+    - SLE-15-SP1-JeOS-GM-ruby
+    - SLE-15-SP1-JeOS-GM-rubyextensions
+    - socok8s_SLE15SP1
 
 deploy_on_openstack_caasp_repos_per_imagename:
   caasp-3.0.0-GM-OpenStack-qcow:
@@ -39,7 +47,7 @@ deploy_on_openstack_caasp_image: "caasp-3.0.0-GM-OpenStack-qcow"
 deploy_on_openstack_caasp_workers: 3
 deploy_on_openstack_caasp_securitygroup: "{{ deploy_on_openstack_sesnode_securitygroup }}"
 deploy_on_openstack_caasp_stacknamefile: "{{ socok8s_workspace }}/stackname"
-deploy_on_openstack_oshnode_image: "openSUSE-Leap-15.0"
+deploy_on_openstack_oshnode_image: "SLE-15-SP1-JeOS-GM"
 deploy_on_openstack_oshnode_flavor: "m1.large"
 deploy_on_openstack_oshnode_securitygroup: "all-incoming"
 deploy_on_openstack_oshnode_userdata: |


### PR DESCRIPTION
  Removes 2 lines from the velum Gemfile.lock for bundle 2.0 compatibility
  Adds an extra vendor from the devel:languages:ruby for zypper
  Drops rng-tools from the required packages as it doesnt seem to be used
  Adds the needed repos for SLES15SP1-JeOS
  Changes the openstack image used from Leap 15.0 to SLES15SP1-JeOS