### PR TITLE
Make airship control plane node count configurable

### DIFF
--- a/playbooks/openstack-caasp_instance.yml
+++ b/playbooks/openstack-caasp_instance.yml
@@ -119,8 +119,8 @@
               {% endfor %}
 
               airship-openstack-control-workers:
-                hosts: &firsttwoworkers
-              {% for node in workers %}{% if loop.index <= 2 %}
+                hosts: &first_workers
+              {% for node in workers %}{% if loop.index <= airship_ucp_control_workers %}
                   {{ node.Name }}:
                     ansible_host: {{ node.Networks.split(',')[-1].replace(' ','') }}
                     ansible_user: root
@@ -131,12 +131,12 @@
               {% endfor %}
 
               airship-ucp-workers:
-                hosts: *firsttwoworkers
+                hosts: *first_workers
 
               airship-openstack-compute-workers:
                 hosts:
               {% for node in workers %}
-              {% if loop.index == 3 %}
+              {% if loop.index > airship_ucp_control_workers %}
                   {{ node.Name }}:
                     ansible_host: {{ node.Networks.split(',')[-1].replace(' ','') }}
                     ansible_user: root
@@ -147,7 +147,7 @@
               {% endfor %}
 
               airship-kube-system-workers:
-                hosts: *firsttwoworkers
+                hosts: *first_workers
 
         - meta: refresh_inventory
 

--- a/playbooks/roles/caasp4/templates/inventory-caasp4.yml.j2
+++ b/playbooks/roles/caasp4/templates/inventory-caasp4.yml.j2
@@ -20,9 +20,9 @@ caasp-workers:
     ansible_python_interpreter: /usr/bin/python3
 
 airship-openstack-control-workers:
-  hosts: &firsttwoworkers
+  hosts: &first_workers
 {% for worker_ip in _terraform_json_output.ip_workers.value %}
-{% if loop.index0 < 2 %}
+{% if loop.index0 < airship_ucp_control_workers %}
     worker-{{ loop.index0 }}:
       ansible_host: {{ worker_ip }}
 {% endif %}
@@ -32,7 +32,7 @@ airship-openstack-control-workers:
     ansible_python_interpreter: /usr/bin/python3
 
 airship-ucp-workers:
-  hosts: *firsttwoworkers
+  hosts: *first_workers
   vars:
     ansible_user: sles
     ansible_python_interpreter: /usr/bin/python3
@@ -40,7 +40,7 @@ airship-ucp-workers:
 airship-openstack-compute-workers:
   hosts:
 {% for worker_ip in _terraform_json_output.ip_workers.value %}
-{% if loop.index0 > 1 %}
+{% if loop.index0 >= airship_ucp_control_workers %}
     worker-{{ loop.index0}}:
       ansible_host: {{ worker_ip }}
 {% endif %}
@@ -50,7 +50,7 @@ airship-openstack-compute-workers:
     ansible_python_interpreter: /usr/bin/python3
 
 airship-kube-system-workers:
-  hosts: *firsttwoworkers
+  hosts: *first_workers
   vars:
     ansible_user: sles
     ansible_python_interpreter: /usr/bin/python3

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -138,6 +138,10 @@ scale_profile: "{{ lookup('env','scale_profile') | default('minimal', true) }}"
 #Set timeout for helm cleanup.
 helm_delete_timeout: 900
 
+# Number of caasp workers to use for the control plane,
+# the remainder will be used as computer hosts
+airship_ucp_control_workers: 2
+
 caasp4_deployed: false
 
 # Location of the kubeconfig file, fetched from velum UI (CaaSP3) or copied from cluster setup dir (CaaSP4)


### PR DESCRIPTION
Add an ansible variable for the number of caasp workers to use as
airship control plane workers instead of hard-coding to 2.