### PR TITLE
Sets CI's ANSIBLE_VERBOSITY to 2

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -36,6 +36,7 @@ pipeline {
         KEYNAME = "engcloud-cloud-ci"
         DELETE_ANYWAY = "YES"
         DEPLOYMENT_MECHANISM = "openstack"
+        ANSIBLE_VERBOSITY = 2
         ANSIBLE_STDOUT_CALLBACK = "yaml"
         USER = "jenkins" /* Why isn't this set in the jenkins environment? */
     }


### PR DESCRIPTION
With the default verbosity it is very difficult to triage issues hit
during CI runs. The additional outputted information should help.