### PR TITLE
Remove references to inventory_hostname


### DIFF
--- a/playbooks/roles/airship-configure-worker/tasks/main.yml
+++ b/playbooks/roles/airship-configure-worker/tasks/main.yml
@@ -7,7 +7,7 @@
     - add_compute_node
 
 - name: Enroll node for Airship kube-system ingress
-  shell: "kubectl label nodes {{ inventory_hostname }} kube-ingress=enabled"
+  command: "kubectl label nodes {{ ansible_hostname }} kube-ingress=enabled"
   when: ('airship-kube-system-workers' in group_names)
   register: _enrollforucp
   changed_when:
@@ -19,7 +19,7 @@
     - skip_ansible_lint
 
 - name: Enroll node for Airship UCP
-  shell: "kubectl label nodes {{ inventory_hostname }} ucp-control-plane=enabled"
+  command: "kubectl label nodes {{ ansible_hostname }} ucp-control-plane=enabled"
   when: ('airship-ucp-workers' in group_names)
   register: _enrollforucp
   changed_when:
@@ -31,9 +31,7 @@
     - skip_ansible_lint
 
 - name: Enroll node for Airship Openstack control plane
-  shell: |
-    kubectl label nodes {{ inventory_hostname }} openstack-control-plane=enabled
-    kubectl label nodes {{ inventory_hostname }} openvswitch=enabled
+  command: "kubectl label nodes {{ ansible_hostname }} openstack-control-plane=enabled openvswitch=enabled"
   when: ('airship-openstack-control-workers' in group_names)
   register: _enrollforopenstackcp
   changed_when:
@@ -45,8 +43,8 @@
     - skip_ansible_lint
 
 - name: Enroll node for Airship Openstack L3 agent
-  shell: |
-    kubectl label nodes {{ inventory_hostname }} openstack-l3-agent=enabled
+  command: |
+    kubectl label nodes {{ ansible_hostname }} openstack-l3-agent=enabled
   when: ('airship-openstack-l3-agent-workers' in group_names)
   register: _enrollforopenstackl3agent
   changed_when:
@@ -58,9 +56,7 @@
     - skip_ansible_lint
 
 - name: Enroll node for Airship Openstack compute plane
-  shell: |
-    kubectl label nodes {{ inventory_hostname }} openstack-compute-node=enabled
-    kubectl label nodes {{ inventory_hostname }} openvswitch=enabled
+  command: "kubectl label nodes {{ ansible_hostname }} openstack-compute-node=enabled openvswitch=enabled"
   when: ('airship-openstack-compute-workers' in group_names)
   register: _enrollforopenstackcomp
   changed_when:
@@ -73,8 +69,8 @@
     - add_compute_node
 
 - name: Enroll node for Airship Openstack control plane primary class
-  shell: |
-    kubectl label nodes {{ inventory_hostname }} openstack-helm-node-class=primary
+  command: |
+    kubectl label nodes {{ ansible_hostname }} openstack-helm-node-class=primary
   when:
     - ('airship-openstack-control-workers' in group_names)
     - hostvars[inventory_hostname].primary is defined

--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -69,15 +69,15 @@
     - skip_ansible_lint
     - update_airship_osh_site
 
-- name: Copy site to Shipyard
+# TODO(evrardjp): Move this to copy: remote_src: yes when Ansible 2.8 is used.
+- name: copy site to Shipyard
   become: yes
-  delegate_to: '{{ inventory_hostname }}'
-  synchronize:
-    src: '{{ treasuremap_dir }}/{{ pegleg_output }}'
-    dest: '{{ upstream_repos_clone_folder }}/airship/shipyard'
+  command: "cp -r {{ treasuremap_dir }}/{{ pegleg_output }} {{ upstream_repos_clone_folder }}/airship/shipyard"
+  changed_when: true
   tags:
     - install
     - update_airship_osh_site
+    - skip_ansible_lint
 
 - name: Set up shipyard shell script
   set_fact:


### PR DESCRIPTION


Airship role is using inventory_hostname for hostnames.

This is a problem, as it represents the inventory
name, not the real node name. Kubernetes is using node name.

This fixes it by removing all the references in the airship side
of inventory_hostname to the ansible_hostname, which will be
gathered on the hosts by ansible, during the fact gathering step.

