### PR TITLE
More prominently documents the insecure flag

### DIFF
--- a/doc/source/suse-ecp/ose-localhost.rst
+++ b/doc/source/suse-ecp/ose-localhost.rst
@@ -185,6 +185,7 @@ The following is an example if you are running on an "engcloud":
    clouds:
      engcloud:
        region_name: CustomRegion
+       insecure: False
        auth:
          auth_url: https://keystone_url/v3
          username: john # your username here


### PR DESCRIPTION
I happened to skim over the existing, quick mention of the insecure
flag and spent more time than necessary attempting to resolve
SSL certificate verification failures. This fix more prominently
documents the insecure flag to save users' time.