### PR TITLE
Jenkinsfile diff from common ancestor

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -57,7 +57,7 @@ pipeline {
                     /* Need to fetch master to check against it for the proper diff */
                     sh "git config --add remote.origin.fetch +refs/heads/master:refs/remotes/origin/master"
                     sh "git fetch --no-tags"
-                    List<String> sourceChanged = sh(returnStdout: true, script: "git diff --name-only origin/master..origin/${env.BRANCH_NAME}").split()
+                    List<String> sourceChanged = sh(returnStdout: true, script: "git diff --name-only origin/master...origin/${env.BRANCH_NAME}").split()
                     echo "Files changed for this PR:\n${sourceChanged.join('\n')}"
                     TestDocs = sourceChanged.any{it.contains("doc/")} or sourceChanged.any{it.contains("tox.ini")} or sourceChanged.any{it.contains("Jenkinsfile.integration")}
                     /* In the future we could add a conditional to auto TestFunctional if tox.ini or Jenkinsfile is changed */


### PR DESCRIPTION
In the 'check for updated files' Jenkins pipeline stage we diff the PR
branch with master to get the list of changed files.

We use git-diff with the '..' (two dots) syntax which calculates the absolute
difference between the two branches. This works OK when the PR branch has
recently being rebased and updated. Then the difference is exactly the
changes the PR wants to commit. The problem comes when the PR branch
hasn't been updated in a while. Then the absolute diff will include much
more changes than intended.

By using git-diff with the '...' (three dots) syntax, the diff will be
done from the first common ancestor and the changes in the PR branch.
This syntax is equivalent what a 'git merge' would do and is in line
with the default behavior from Github.

Ref:
https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-emgitdiffemltoptionsgtltcommitgtltcommitgt--ltpathgt82308203