### PR TITLE
Adding tempest usage for existing integration job

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -24,6 +24,8 @@ pipeline {
         /* first value in the list is the default */
         choice(choices: ['airship', 'osh'], description: 'Which deployment mechanism?', name: 'deployment')
         choice(choices: ['caasp3', 'caasp4'], description: 'Which caasp version to use?', name: 'caasp_version')
+        booleanParam(name: 'run_tempest', defaultValue: false, description: 'Run tempest tests?')
+        choice(choices: ['smoke', 'all'], description: 'Run smoke or all tempest tests?', name: 'tempest_test_type')
     }
 
     environment {
@@ -206,6 +208,26 @@ pipeline {
             }
             steps {
                 sh "source ${WORKSPACE}/sock_${env.SOCOK8S_ENVNAME} && ./run.sh setup_airship"
+            }
+        }
+
+        stage('Run Tempest') {
+            options {
+                timeout(time: 240, unit: 'MINUTES', activity: true)
+            }
+            when {
+                allOf {
+                    expression { env.run_tempest == 'true' }
+                    expression { params.deployment == 'airship' }
+                    expression { return  TestFunctional }
+                }
+            }
+            steps {
+                sh """
+                  export TEMPEST_TEST_TYPE=${env.tempest_test_type}
+                  export AIRSHIP_TEMPEST_LOG_STDOUT=True
+                  ./run.sh test
+                """
             }
         }
     }

--- a/playbooks/roles/airship-deploy-tempest/defaults/main.yml
+++ b/playbooks/roles/airship-deploy-tempest/defaults/main.yml
@@ -9,8 +9,16 @@ tempest_enable_cinder_service: true
 tempest_enable_glance_service: true
 tempest_enable_nova_service: true
 tempest_enable_neutron_service: true
-openstack_external_network_name: "public"
-openstack_external_subnet_name: "public-subnet"
-openstack_project_network_cidr: "172.0.4.0/24"
+tempest_provider_physical_network: external
+tempest_network_prefix: "{{ lookup('env', 'SOCOK8S_ENVNAME') }}-tempest"
+openstack_external_network_name: "{{ tempest_network_prefix}}-public"
+openstack_external_subnet_name: "{{ tempest_network_prefix }}-public-subnet"
+# used by tempest, input required for kvm deployment mechanism
+openstack_project_network_cidr:
+# used by tempest for ssh connection to servers, input used in kvm deployment mechanism
+openstack_external_network_cidr:
+tempest_network_address_start_index: 10
 cirros_test_image_url: "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
 use_blacklist: true
+# Flag to hide tempest pod logs during ansible tempest run. Default is True (show tempest logs)
+print_tempest_log: "{{ lookup('env','AIRSHIP_TEMPEST_LOG_STDOUT') | default('True', true) | bool }}"

--- a/playbooks/roles/airship-deploy-tempest/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-tempest/tasks/main.yml
@@ -5,6 +5,9 @@
   tags:
     - always
 
+- name: Prepare enviroment for running tempest tests
+  include: prepare-tempest.yml
+
 - name: Set site path
   set_fact:
     site_path: "{{ upstream_repos_clone_folder }}/airship/treasuremap/site/{{ socok8s_site_name }}"
@@ -104,16 +107,51 @@
     - "'not found' not in helm_result.stderr"
   changed_when: helm_result.stdout is search('deleted')
 
-- name: Update site software via Shipyard
-  include_role:
-    name: airship-deploy-osh
-    apply:
-      tags:
-        - update_airship_osh_site
+- name: Update site software via Shipyard to configure and execute tempest tests
+  block:
+    - include_role:
+        name: airship-deploy-osh
+        apply:
+          tags:
+            - update_airship_osh_site
 
-- name: Check tempest run output
-  debug:
-    msg:
-      - "Tempest job execution is completed. Check the output of this tempest run for details"
-      - "kubectl logs -n openstack <tempest-run_pod_name>"
+  always:
+    - name: Get latest tempest run pod name if there
+      command: kubectl get pods -n openstack -l application=tempest,component=run-tests --sort-by=.metadata.creationTimestamp --no-headers -o jsonpath="{.items[-1:].metadata.name}"
+      ignore_errors: yes
+      register: _tempest_run_pod_name
 
+    - name: Log if missing tempest run pod
+      debug:
+        msg:
+          - "Tempest test execution pod not found (likely some software update error)."
+          - "Check kubernetes artifact logs for details."
+          - "You can gather artifact logs via following command if needed"
+          - "./run.sh gather_logs"
+      when:
+        - _tempest_run_pod_name.rc != 0
+
+    - name: Gather logs from tempest pods if there
+      command: "kubectl logs -n openstack {{ _tempest_run_pod_name.stdout }}"
+      register: _tempest_logs_out
+      when:
+        - _tempest_run_pod_name.rc == 0
+        - print_tempest_log
+
+    - name: Show command for gathering tempest logs
+      debug:
+        msg:
+          - "Tempest job execution is completed. Check the output of this tempest run for details"
+          - "kubectl logs -n openstack {{ _tempest_run_pod_name.stdout }}"
+      when:
+        - _tempest_run_pod_name.rc == 0
+        - not print_tempest_log
+
+    - name: Show tempest logs after tempest job execution
+      debug:
+        msg:
+          - "Tempest job execution is completed. Check follwing output for any tempest test failures"
+          - "{{ _tempest_logs_out.stdout_lines }}"
+      when:
+        - _tempest_run_pod_name.rc == 0
+        - print_tempest_log

--- a/playbooks/roles/airship-deploy-tempest/tasks/prepare-tempest.yml
+++ b/playbooks/roles/airship-deploy-tempest/tasks/prepare-tempest.yml
@@ -1,0 +1,85 @@
+---
+- name: Get deployment mechanism value
+  set_fact:
+    deployment_mechanism: "{{ lookup('env', 'DEPLOYMENT_MECHANISM') }}"
+  tags:
+    - always
+
+- name: Load openstack mechanism variables
+  include_vars: "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
+  when:
+    - deployment_mechanism == 'openstack'
+  tags:
+    - always
+
+- name: Get tempest network cidr and test type for its execution
+  set_fact:
+    openstack_project_network_cidr: "{{ deploy_on_openstack_internal_subnet_cidr }}"
+    # env variable is used to pass test type from CI. If that is not set, then use value via extravars
+    # variable or ansible variable default value
+    tempest_test_type: "{{ lookup('env', 'TEMPEST_TEST_TYPE') | default(tempest_test_type, true) }}"
+  when:
+    - deployment_mechanism == 'openstack'
+
+- name: Print tempest project and external network cidr value
+  debug:
+    msg:
+    - "openstack_project_network_cidr = {{ openstack_project_network_cidr }}"
+    - "openstack_external_network_cidr = {{ openstack_external_network_cidr }}"
+
+- name: Make sure that tempest project network cidr is present and correctly defined
+  assert:
+    that:
+      - openstack_project_network_cidr | default(false, true)
+      - openstack_project_network_cidr.split('/') | length == 2
+      - openstack_project_network_cidr.split('/')[1] | int(-1) != -1
+    fail_msg: "Required tempest network CIDR value for 'openstack_project_network_cidr' is missing or has invalid format"
+
+- name: Make sure that tempest external network cidr is correctly defined if set
+  assert:
+    that:
+      - openstack_external_network_cidr.split('/') | length == 2
+      - openstack_external_network_cidr.split('/')[1] | int(-1) != -1
+    fail_msg: "Provided tempest network CIDR value for 'openstack_external_network_cidr' has invalid format"
+  when:
+    - openstack_external_network_cidr | default(false, true)
+
+- name: Set tempest external network cidr to project network cidr if missing
+  set_fact:
+    openstack_external_network_cidr: "{{ openstack_project_network_cidr }}"
+  when:
+    - not openstack_external_network_cidr | default(false, true)
+
+- name: Get tempest external network details
+  command: "openstack network show {{ openstack_external_network_name }} -f value -c id"
+  environment:
+    OS_CLOUD: openstack
+  register: tempest_network_id_result
+  ignore_errors: yes
+  changed_when: False
+
+- name: Get tempest external subnet CIDR
+  command: "openstack subnet show {{ openstack_external_subnet_name }} -f value -c cidr"
+  environment:
+    OS_CLOUD: openstack
+  register: tempest_subnet_cidr_result
+  ignore_errors: yes
+  changed_when: False
+
+- name: Create tempest external network
+  command: "openstack network create --provider-network-type flat --provider-physical-network {{ tempest_provider_physical_network }} --external {{ openstack_external_network_name }}"
+  environment:
+    OS_CLOUD: openstack
+  register: tempest_network_create_result
+  changed_when: False
+  when:
+    - tempest_network_id_result.rc != 0
+
+- name: Create tempest external sub-network
+  command: "openstack subnet create --network {{ openstack_external_network_name }} --subnet-range {{ openstack_external_network_cidr }} --allocation-pool start={{ openstack_external_network_cidr |  next_nth_usable(tempest_network_address_start_index) }},end={{ openstack_external_network_cidr |  ipaddr('last_usable') }} --gateway {{ openstack_external_network_cidr |  ipaddr('next_usable')  }} --no-dhcp {{ openstack_external_subnet_name }}"
+  environment:
+    OS_CLOUD: openstack
+  register: tempest_network_create_result
+  changed_when: False
+  when:
+    - tempest_subnet_cidr_result.rc != 0

--- a/run.sh
+++ b/run.sh
@@ -35,8 +35,9 @@ if [[ "${SOCOK8S_DEVELOPER_MODE:-False}" == "True" ]]; then
 fi
 
 # USE an env var to setup where to deploy to
-# by default, ccp will deploy on openstack for inception style fun (and CI).
+# by default, ccp will deploy on kvm
 DEPLOYMENT_MECHANISM=${DEPLOYMENT_MECHANISM:-"kvm"}
+export DEPLOYMENT_MECHANISM
 
 # The base directory where workspace(s) are created in
 SOCOK8S_WORKSPACE_BASEDIR=${SOCOK8S_WORKSPACE_BASEDIR:-~}


### PR DESCRIPTION
Adding additional tempest test run step when related flag is set.
Jobs are supposed to set the flag and tempest test type (full or smoke)
as input parameters.

In case of 'openstack' deployment mechanism (deploying in ECP cloud),
tempest network values are derived from variables in deploy-on-opnestack.
For 'kvm' deployment mechanism (deploying on baremetal or non-ECP
cloud), user is expected to provide 'openstack_project_network_cidr'
which is an existing behavior for running tempest test step.

Assuming CIDR value is defined and correct, playbooks will create
network and subnet needed for tempest tests execution as part of tempest
run step.