### PR TITLE
Jenkinsfile needs to skip teardown if only docs changes

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -109,6 +109,7 @@ pipeline {
                 timeout(time: 10, unit: 'MINUTES', activity: true)
             }
             steps {
+                sh 'touch /tmp/${SOCOK8S_ENVNAME}.needcleanup'
                 sh "./run.sh deploy_network"
             }
         }
@@ -199,7 +200,7 @@ pipeline {
         }
         cleanup {
             script {
-                    sh './run.sh teardown'
+                    sh '[ -f /tmp/${SOCOK8S_ENVNAME}.needcleanup ] && ./run.sh teardown && rm /tmp/${SOCOK8S_ENVNAME}.needcleanup'
                 }
         }
     }


### PR DESCRIPTION
When only the documentation has changed CI will skip the
creation of the cluster. In this case a cleanup (teardonw)
is not necessary and generates an error. This commit
removes the execution of the cleanup.