### PR TITLE
CaaSP 4 deploy should fail if requirements are not met


### DIFF
--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -38,14 +38,14 @@ check_caasp4_skuba_dir_available(){
     echo "Checking for CaaSP 4 that SUSE/skuba is available"
     if ! [ -d submodules/skuba ]; then
         echo "submodules/skuba directory not available. Can not deploy CaaSP 4"
-        exit
+        exit 1
     fi
 }
 check_caasp4_skuba_available(){
     echo "Checking for CaaSP 4 that skuba is available"
     if ! rpm -q --quiet skuba; then
         echo "skuba package is not installed. Can not deploy CaaSP 4"
-        exit
+        exit 1
     fi
 }
 check_caasp4_terraform_available(){
@@ -53,14 +53,14 @@ check_caasp4_terraform_available(){
     command -v ${TERRAFORM_BINARY_PATH} 1> /dev/null
     if [ $? -ne 0 ]; then
         echo "${TERRAFORM_BINARY_PATH} executable not in \$PATH. Can not deploy CaaSP 4"
-        exit
+        exit 1
     fi
 }
 check_caasp4_ssh_agent_running(){
     echo "Checking if ssh-agent is running"
     if ! ssh-add -L >/dev/null ; then
         echo "ssh agent is not running or does not contain any identities"
-        exit
+        exit 1
     fi
 }
 check_openstack_environment_is_ready_for_deploy (){


### PR DESCRIPTION


By default we don't return an error code when doing the
pre-flight checks.

This is a problem, as things might look okay, and the deploy
continues, where it should stop.

This should fix it.

