### PR TITLE
Do not run caasp3 steps on caasp4 testing

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -4,7 +4,6 @@
 TestDocs = true
 TestFunctional = true
 
-
 pipeline {
 
     options {
@@ -147,13 +146,27 @@ pipeline {
             }
         }
 
-        stage('Configure CaaSP workers') {
-            when { expression { return  TestFunctional } }
+        stage('Enroll CaaSP workers') {
+            when {
+                allOf {
+                    expression { return  TestFunctional }
+                    expression  { params.caasp_version == "caasp3" }
+                }
+            }
             options {
                 timeout(time: 10, unit: 'MINUTES', activity: true)
             }
             steps {
                 sh "./run.sh enroll_caasp_workers"
+            }
+        }
+
+        stage('Setup CaaSP workers for openstack') {
+            when { expression { return  TestFunctional } }
+            options {
+                timeout(time: 10, unit: 'MINUTES', activity: true)
+            }
+            steps {
                 sh "./run.sh setup_caasp_workers_for_openstack"
             }
         }


### PR DESCRIPTION
On caasp4 we are not using velum anymore so there is no need to run
the enroll caasp workers step.

This patch separates enroll_caasp_workers and
setup_caasp_workers_for_openstack into two steps so we can skip
uneeded ones on caasp4 CI testing