### PR TITLE
Report custom context to github

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -4,6 +4,11 @@
 TestDocs = true
 TestFunctional = true
 
+void setBuildStatus(String state, String context) {
+    full_context = "continuous-integration/jenkins/$context"
+    sh "/home/jenkins/github-pr/github_pr.rb -a set-status -o SUSE-Cloud -r socok8s -p ${env.CHANGE_ID} -s $state -x $full_context -u ${env.GIT_COMMIT} -t ${env.RUN_DISPLAY_URL}"
+}
+
 pipeline {
 
     options {
@@ -44,6 +49,10 @@ pipeline {
     stages {
         stage('Show environment information') {
             steps {
+                // Set default CI job to success, we will manage the statuses ourselves
+                setBuildStatus("success", "pr-head")
+                // Set out custom status check to pending
+                setBuildStatus("pending", "${params.deployment}-${params.caasp_version}")
                 sh 'printenv'
             }
         }
@@ -205,7 +214,21 @@ pipeline {
     }
 
     post {
+        success {
+            script {
+                setBuildStatus("success", "${params.deployment}-${params.caasp_version}")
+            }
+        }
+        aborted {
+            script {
+                setBuildStatus("error", "${params.deployment}-${params.caasp_version}")
+            }
+        }
         failure {
+            script {
+                setBuildStatus("failure", "${params.deployment}-${params.caasp_version}")
+            }
+
             script {
                 if (env.hold_instance_for_debug == 'true') {
                     echo "You can reach this node by connecting to its floating IP as root user, with the default password of your image."


### PR DESCRIPTION
Use github-pr to report a combination of delivery mechanism +
caasp version to github in order to allow different jobs to run and
report back.

This allows us to run a combination of params for the same PR and
have easy forced checks for different paths, like airship+caasp3
and airship+caasp4, plus a variety of more combinations in the
future.

We could even have 2 jobs per PR in the future automatically,
but this is the first step to support that.

As a downside the normal context that reports automatically cannot
be disabled from jenkins as it would affect all other jobs that
use the github plugin, so instead we manage it ourselves and set it
to success at the start of the job as we create the other contexts,
so if this gets merged we should disable that mandatory check and enable
the airship+caasp3 instead