### PR TITLE
Creating needcleaup file inside workspace in the Jenkinsfile

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -110,7 +110,7 @@ pipeline {
                 timeout(time: 10, unit: 'MINUTES', activity: true)
             }
             steps {
-                sh 'touch /tmp/${SOCOK8S_ENVNAME}.needcleanup'
+                sh 'touch ./.needcleanup'
                 sh "./run.sh deploy_network"
             }
         }
@@ -222,8 +222,8 @@ pipeline {
         }
         cleanup {
             script {
-                    sh '[ -f /tmp/${SOCOK8S_ENVNAME}.needcleanup ] && ./run.sh teardown && rm /tmp/${SOCOK8S_ENVNAME}.needcleanup'
-                }
+                sh 'if test -f ./.needcleanup; then ./run.sh teardown; fi'
+            }
         }
     }
 }


### PR DESCRIPTION
The needcleanup file removal is done after run.sh teardown.
This is a problem if teardown exists with an error, as the
needcleanup file won't be removed leaving gargage in /tmp,
This fixes it by moving this file into workspace

co-autors: @jhesketh @evrardjp 