### PR TITLE
Caasp4 Cleanup: fix a typo

### DIFF
--- a/playbooks/roles/caasp4/tasks/cleanup_nodes.yml
+++ b/playbooks/roles/caasp4/tasks/cleanup_nodes.yml
@@ -21,7 +21,7 @@
 
 - name: Does the terraform workspace exist
   stat:
-    path: skuba_ci_terraform_workspace
+    path: "{{ skuba_ci_terraform_workspace }}"
   register: _terraform_workspace
 
 - name: Does the terraform state exist


### PR DESCRIPTION
Add jinja syntax to dereference the variable instead of treating it
as a string literal.