### PR TITLE
Fix Jenkins cleanup

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -222,8 +222,11 @@ pipeline {
         }
         cleanup {
             script {
-                    sh '[ -f /tmp/${SOCOK8S_ENVNAME}.needcleanup ] && ./run.sh teardown && rm /tmp/${SOCOK8S_ENVNAME}.needcleanup'
+                if (fileExists("/tmp/${env.SOCOK8S_ENVNAME}.needcleanup")) {
+                    sh './run.sh teardown'
+                    sh 'rm /tmp/${SOCOK8S_ENVNAME}.needcleanup'
                 }
+            }
         }
     }
 }


### PR DESCRIPTION
Jenkins would fail if the needcleanup file didn't exist because the
shell test would return 1 which Jenkins considers a failure. Instead
properly test the file condition.