### PR TITLE
SOC-10090 - Adding Rook.io to learning materials

### DIFF
--- a/doc/source/contributor/index.rst
+++ b/doc/source/contributor/index.rst
@@ -23,6 +23,7 @@ in the following sections.
    airship.rst
    cluster-api.rst
    metalcubed.rst
+   rook-io.rst
 
 
 

--- a/doc/source/contributor/rook-io.rst
+++ b/doc/source/contributor/rook-io.rst
@@ -1,0 +1,18 @@
+Rook.io
+==============
+
+Rook is a Storage Orchestrator for Kubernetes
+
+List of interesting links:
+--------------------------
+
+* Documentation
+    https://rook.io/docs/rook/v1.0/
+
+* Ceph quickstart & specifics documents
+    https://rook.io/docs/rook/v1.0/ceph-quickstart.html
+
+    https://rook.io/docs/rook/v1.0/ceph-storage.html
+
+* Introductory video & demostration
+    https://www.youtube.com/watch?v=mCljCGIE-hM


### PR DESCRIPTION
Rook.io is going to be part of socok8s to deploy SES v6
so is interesting to have understand how it works before
work on this.

This PR help to the developer with some interesting links
to documentation and videos.