### PR TITLE
Add openstack and heat clients to requirements.txt

### DIFF
--- a/script_library/requirements.txt
+++ b/script_library/requirements.txt
@@ -4,3 +4,5 @@ jmespath==0.9.3
 requests==2.21.0
 ara==0.16.3
 openstacksdk==0.22.0
+python-openstackclient
+python-heatclient


### PR DESCRIPTION
When using a virtualenv, we need to install the openstack and heat CLIs.