### PR TITLE
Add ses-rook (SOC-10065)

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -26,6 +26,7 @@ pipeline {
         choice(choices: ['caasp3', 'caasp4'], description: 'Which caasp version to use?', name: 'caasp_version')
         booleanParam(name: 'run_tempest', defaultValue: false, description: 'Run tempest tests?')
         choice(choices: ['smoke', 'all'], description: 'Run smoke or all tempest tests?', name: 'tempest_test_type')
+        choice(choices: ['ses_aio', 'ses_rook'], description: 'Which ses version to use?', name: 'ses_version')
     }
 
     environment {
@@ -35,6 +36,7 @@ pipeline {
         SOCOK8S_ENVNAME = "cloud-socok8s-${env.BRANCH_NAME.replaceAll("[^a-zA-Z0-9-]+", "-").toLowerCase()}-${env.BUILD_NUMBER}"
         SOCOK8S_OPENSUSE_MIRROR="https://provo-mirror.opensuse.org"
         OS_CLOUD = "engcloud-socok8s-ci"
+        SOCOK8S_TEST_CEPH_ROOK="true"
         KEYNAME = "engcloud-cloud-ci"
         DELETE_ANYWAY = "YES"
         DEPLOYMENT_MECHANISM = "openstack"
@@ -153,6 +155,7 @@ pipeline {
                     }
                 }
                 stage('Deploy SES') {
+                    when { expression  { params.ses_version == "ses_aio" } }
                     steps {
                         sh "./run.sh deploy_ses"
                     }
@@ -188,6 +191,13 @@ pipeline {
             }
             steps {
                 sh "source ${WORKSPACE}/sock_${env.SOCOK8S_ENVNAME} && ./run.sh setup_caasp_workers_for_openstack"
+            }
+        }
+
+        stage('Deploy SES on Kubernetes with rook') {
+            when { expression  { params.ses_version == "ses_rook" } }
+            steps {
+                sh "./run.sh deploy_ses_rook"
             }
         }
 

--- a/playbooks/generic-delete_ses_rook.yml
+++ b/playbooks/generic-delete_ses_rook.yml
@@ -1,0 +1,43 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Caasp is deployed and we have workers
+      assert:
+        that: "{{ groups['caasp-workers'] | length > 0 }}"
+        fail_msg: You need Caasp deployed in order to deploy ses with rook
+        success_msg: Caasp workers found
+    - name: We have a deployer
+      assert:
+        that: "{{ groups['soc-deployer'] | length > 0 }}"
+        fail_msg: You need a soc-deployer node in order to deploy ses with rook
+        success_msg: Deployer found
+# TODO(itxaka): Remove this once the images are pushed to registry.suse.com
+- hosts: caasp-masters:caasp-workers
+  gather_facts: no
+  tasks:
+    - name: Revert insecure registry for registry.suse.de
+      become: true
+      replace:
+        path: "/etc/containers/registries.conf"
+        regexp: '^\[registries\.insecure]\nregistries = \["registry.suse.de"]\n'
+        replace: '[registries.insecure]\nregistries = []\n'
+      register: _registry_insecure
+      tags:
+        - bug
+    - name: Reload crio
+      become: true
+      systemd:
+        name: crio.service
+        state: reloaded
+      when: _registry_insecure.changed
+      tags:
+        - bug
+        - skip_ansible_lint
+- hosts: soc-deployer
+  gather_facts: no
+  any_errors_fatal: true
+  tasks:
+    - import_role:
+        name: ses-rook
+        tasks_from: remove_ses_rook

--- a/playbooks/generic-deploy_ses_rook.yml
+++ b/playbooks/generic-deploy_ses_rook.yml
@@ -1,0 +1,47 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Caasp is deployed and we have workers
+      assert:
+        that: "{{ groups['caasp-workers'] | length > 0 }}"
+        fail_msg: You need Caasp deployed in order to deploy ses with rook
+        success_msg: Caasp workers found
+    - name: We have a deployer
+      assert:
+        that: "{{ groups['soc-deployer'] | length > 0 }}"
+        fail_msg: You need a soc-deployer node in order to deploy ses with rook
+        success_msg: Deployer found
+# TODO(itxaka): Remove this once the images are pushed to registry.suse.com
+- hosts: caasp-masters:caasp-workers
+  gather_facts: no
+  tasks:
+    - name: Configure insecure registry for registry.suse.de
+      become: true
+      replace:
+        path: "/etc/containers/registries.conf"
+        regexp: '^\[registries\.insecure]\nregistries = \[]\n'
+        replace: '[registries.insecure]\nregistries = ["registry.suse.de"]\n'
+      register: _registry_insecure
+      tags:
+        - bug
+    - name: Reload crio
+      become: true
+      systemd:
+        name: crio.service
+        state: reloaded
+      when: _registry_insecure.changed
+      tags:
+        - bug
+        - skip_ansible_lint
+- hosts: soc-deployer
+  gather_facts: yes
+  any_errors_fatal: true
+  vars_files:
+    - "{{ playbook_dir }}/../vars/common-vars.yml"
+  tasks:
+    - import_role:
+        name: common-deployer
+        tasks_from: kubectl-setup
+    - import_role:
+        name: ses-rook

--- a/playbooks/roles/caasp4/templates/skuba-terraform-openstack.tfvars.j2
+++ b/playbooks/roles/caasp4/templates/skuba-terraform-openstack.tfvars.j2
@@ -10,6 +10,8 @@ masters = {{ master_count }}
 workers = {{ worker_count }}
 master_size = "{{ master_flavor }}"
 worker_size = "{{ worker_flavor }}"
+workers_vol_enabled = 1
+workers_vol_size = 10
 
 username = "{{ image_username }}"
 password = "{{ image_password }}"

--- a/playbooks/roles/ses-rook/defaults/main.yml
+++ b/playbooks/roles/ses-rook/defaults/main.yml
@@ -1,0 +1,5 @@
+ses_rook_repos:
+  ses_rook_sle15_sp1: "http://download.suse.de/ibs/Devel:/Storage:/6.0/SLE_15_SP1/"
+ses_rook_yaml_manifests_package: "rook-k8s-yaml"
+ses_rook_k8s_manifests_dir: "/usr/share/k8s-yaml/rook/ceph"
+ses_rook_config_path_in_caasp_workers: "/home/ses/var/lib/rook/"

--- a/playbooks/roles/ses-rook/files/test_pvc.yml
+++ b/playbooks/roles/ses-rook/files/test_pvc.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc
+  labels:
+    app: test
+spec:
+  storageClassName: rook-ceph-block
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/playbooks/roles/ses-rook/files/test_storageclass.yml
+++ b/playbooks/roles/ses-rook/files/test_storageclass.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: replicapool
+  namespace: rook-ceph
+spec:
+  failureDomain: host
+  replicated:
+    size: 3
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: rook-ceph-block
+provisioner: ceph.rook.io/block
+parameters:
+  blockPool: replicapool
+  clusterNamespace: rook-ceph
+  fstype: xfs
+reclaimPolicy: Delete

--- a/playbooks/roles/ses-rook/tasks/main.yml
+++ b/playbooks/roles/ses-rook/tasks/main.yml
@@ -1,0 +1,99 @@
+---
+- name: Add SES repositories
+  become: yes
+  zypper_repository:
+    name: "{{ item['key'] }}"
+    repo: "{{ item['value'] }}"
+    autorefresh: True
+    auto_import_keys: yes
+    state: present
+  loop: "{{ ses_rook_repos | dict2items }}"
+  tags:
+    - ses-rook-repository
+
+- name: Install packages
+  become: yes
+  package:
+    name: "{{ ses_rook_yaml_manifests_package }}"
+    state: present
+  register: install_packages
+  until: install_packages is success
+  retries: 5
+  delay: 2
+  tags:
+    - ses-rook-install
+
+- name: Point to registry.suse.de until images are published at registry.suse.com
+  replace:
+    path: "{{ item }}"
+    regexp: 'registry.suse.com/ses/6/'
+    replace: 'registry.suse.de/devel/storage/6.0/containers/ses/6/'
+  loop:
+    - "{{ ses_rook_k8s_manifests_dir }}/operator.yaml"
+    - "{{ ses_rook_k8s_manifests_dir }}/cluster.yaml"
+    - "{{ ses_rook_k8s_manifests_dir }}/toolbox.yaml"
+
+- name: Create rook operator
+  command: "kubectl apply -f common.yaml -f operator.yaml"
+  register: _rook_operator_creation
+  args:
+    chdir: "{{ ses_rook_k8s_manifests_dir }}"
+  changed_when: "'created' in _rook_operator_creation.stdout"
+
+- name: Wait for rook operator to be running
+  command: "kubectl get pods -n rook-ceph -l app=rook-ceph-operator -o jsonpath='{.items[].status.containerStatuses[].ready}'"
+  register: _rook_ceph_operator_status
+  until: "'false' not in _rook_ceph_operator_status.stdout"
+  retries: 30
+  delay: 10
+  changed_when: False
+
+- name: Deploy Ceph cluster
+  command: "kubectl apply -f cluster.yaml"
+  register: _rook_ceph_cluster_creation
+  args:
+    chdir: "{{ ses_rook_k8s_manifests_dir }}"
+  changed_when: "'created' in _rook_ceph_cluster_creation.stdout"
+
+- name: Wait for Ceph cluster to be launched
+  shell: "kubectl get pods -n rook-ceph -l app={{ item }} -o jsonpath='{.items[].status.containerStatuses[].ready}' || echo 'false'"
+  register: _rook_ceph_cluster_status
+  until: "'false' not in _rook_ceph_cluster_status.stdout"
+  retries: 60
+  delay: 10
+  changed_when: False
+  loop:
+    - rook-ceph-mgr
+    - rook-ceph-mon
+    - rook-ceph-agent
+
+- name: Deploy Ceph toolbox
+  command: "kubectl apply -f toolbox.yaml"
+  register: _rook_ceph_toolbox_creation
+  args:
+    chdir: "{{ ses_rook_k8s_manifests_dir }}"
+  changed_when: "'created' in _rook_ceph_toolbox_creation.stdout"
+
+- name: Wait for Ceph toolbox to be running
+  command: "kubectl get pods -n rook-ceph -l app=rook-ceph-tools -o jsonpath='{.items[].status.containerStatuses[].ready}'"
+  register: _rook_ceph_toolbox_status
+  until: "'false' not in _rook_ceph_toolbox_status.stdout"
+  retries: 30
+  delay: 10
+  changed_when: False
+
+- name: Wait for Ceph to be ready
+  shell: "kubectl -n rook-ceph exec $(kubectl -n rook-ceph get pod -l 'app=rook-ceph-tools' -o jsonpath='{.items[0].metadata.name}') ceph status"
+  register: _rook_ceph_health
+  until: "'HEALTH_OK' in _rook_ceph_health.stdout"
+  retries: 30
+  delay: 15
+
+
+# TODO(itxaka): Not sure why but I cannot just include_tasks here...
+- name: Test Ceph
+  import_role:
+    name: ses-rook
+    tasks_from: test_rook
+  when: lookup('env','SOCOK8S_TEST_CEPH_ROOK') | default(False)
+

--- a/playbooks/roles/ses-rook/tasks/remove_ses_rook.yml
+++ b/playbooks/roles/ses-rook/tasks/remove_ses_rook.yml
@@ -1,0 +1,71 @@
+---
+- name: Gather info about pods running
+  command: "kubectl -n rook-ceph get pods -o jsonpath='{.items[*].metadata.name}'"
+  register: _rook_ceph_pods
+  changed_when: False
+
+- name: Delete Ceph toolbox
+  command: "kubectl delete -f toolbox.yaml"
+  register: _rook_ceph_toolbox_delete
+  args:
+    chdir: "{{ ses_rook_k8s_manifests_dir }}"
+  when: "_rook_ceph_pods.stdout is regex('rook-ceph-tools-.*')"
+
+- name: Delete Ceph cluster
+  command: "kubectl delete -f cluster.yaml"
+  register: _rook_ceph_cluster_delete
+  args:
+    chdir: "{{ ses_rook_k8s_manifests_dir }}"
+  when: "_rook_ceph_pods.stdout is regex('rook-ceph-mon-.*')"
+
+- name: Delete rook operator
+  command: "kubectl delete -f common.yaml -f csi/rbac/cephfs/ -f csi/rbac/rbd/ -f operator-with-csi.yaml"
+  register: _rook_operator_delete
+  args:
+    chdir: "{{ ses_rook_k8s_manifests_dir }}"
+  when: "_rook_ceph_pods.stdout is regex('rook-ceph-operator-.*')"
+
+- name: Remove packages
+  become: yes
+  package:
+    name: "{{ ses_rook_yaml_manifests_package }}"
+    state: absent
+  register: remove_packages
+  until: remove_packages is success
+  retries: 5
+  delay: 2
+  tags:
+    - ses-rook-remove
+
+- name: Delete SES repositories
+  become: yes
+  zypper_repository:
+    name: "{{ item['key'] }}"
+    repo: "{{ item['value'] }}"
+    autorefresh: True
+    auto_import_keys: yes
+    state: absent
+  loop: "{{ ses_rook_repos | dict2items }}"
+  tags:
+    - ses-rook-repository-delete
+
+- name: Remove rook dir
+  become: true
+  delegate_to: "{{ item }}"
+  file:
+    state: absent
+    path: "{{ ses_rook_config_path_in_caasp_workers }}"
+  loop: "{{ groups['caasp-workers'] }}"
+
+- debug:
+    msg: |
+      ses-rook has been removed. If you want to relaunch this role and redeploy ses-rook, you will need to
+      clean up the disks, as they have been left with any test data+partitions that ceph created on them.
+      We can't do this manually as this re-initialized the disks so its a bit dangerous to automate.
+      You will need to run the following commands on each worker that had a disk used by ceph:
+
+      sgdisk --zap-all $DISK
+      ls /dev/mapper/ceph-* | xargs -I% -- dmsetup remove %
+      rm -rf /dev/ceph-*
+
+      This steps come from: https://rook.io/docs/rook/master/ceph-teardown.html

--- a/playbooks/roles/ses-rook/tasks/test_rook.yml
+++ b/playbooks/roles/ses-rook/tasks/test_rook.yml
@@ -1,0 +1,48 @@
+---
+- name: Copy storageclass definition
+  copy:
+    src: "{{ playbook_dir }}/roles/ses-rook/files/test_storageclass.yml"
+    dest: /tmp/test_storageclass.yml
+
+- name: Create storageclass
+  command: "kubectl create -f /tmp/test_storageclass.yml"
+  register: _rook_ceph_test_storageclass_create
+  changed_when: "'created' in _rook_ceph_test_storageclass_create.stdout"
+
+- name: Copy pvc definition
+  copy:
+    src: "{{ playbook_dir }}/roles/ses-rook/files/test_pvc.yml"
+    dest: /tmp/test_pvc.yml
+
+- name: Create pvc
+  command: "kubectl create -f /tmp/test_pvc.yml"
+  register: _rook_ceph_test_pvc_create
+  changed_when: "'created' in _rook_ceph_test_pvc_create.stdout"
+
+# test if pvc is bound i.e. it has been created and available
+# so we know that the ceph cluster+rook is working as expected
+- name: Wait until pvc is bound
+  command: "kubectl get pvc test-pvc -o jsonpath='{.status.phase}'"
+  register: _rook_ceph_test_pvc_status
+  until: "'Bound' in _rook_ceph_test_pvc_status.stdout"
+  retries: 15
+  delay: 10
+
+# now lets clean up everything as we dont want to have leftovers in the cluster
+- name: Delete pvc
+  command: "kubectl delete -f /tmp/test_pvc.yml"
+  register: _rook_ceph_test_pvc_create
+  changed_when: "'deleted' in _rook_ceph_test_pvc_create.stdout"
+
+- name: Delete storageclass
+  command: "kubectl delete -f /tmp/test_storageclass.yml"
+  register: _rook_ceph_test_storageclass_create
+  changed_when: "'deleted' in _rook_ceph_test_storageclass_create.stdout"
+
+- name: Clean up definition files
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /tmp/test_storageclass.yml
+    - /tmp/test_pvc.yml

--- a/run.sh
+++ b/run.sh
@@ -176,6 +176,12 @@ case "$deployment_action" in
     "test")
         deploy_tempest
         ;;
+    "deploy_ses_rook")
+        deploy_ses_rook
+        ;;
+    "delete_ses_rook")
+        delete_ses_rook
+        ;;
     *)
         echo "Invalid option, Check --help for valid options"
         ;;

--- a/script_library/deployment-actions-common.sh
+++ b/script_library/deployment-actions-common.sh
@@ -22,6 +22,16 @@ function deploy_osh(){
     run_ansible ${socok8s_absolute_dir}/playbooks/generic-deploy_osh.yml
 }
 
+function deploy_ses_rook(){
+    echo "Deploying SES on Kubernetes with rook"
+    run_ansible ${socok8s_absolute_dir}/playbooks/generic-deploy_ses_rook.yml
+}
+
+function delete_ses_rook(){
+    echo "Deleting SES with rook"
+    run_ansible ${socok8s_absolute_dir}/playbooks/generic-delete_ses_rook.yml
+}
+
 function deploy_airship(){
     echo "Deploying SUSE version of Airship"
     tagged_info=''

--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -141,7 +141,7 @@ validate_cli_options (){
        exit 1
    fi
 
-   OPTIONS=(deploy test update_openstack add_openstack_compute remove_openstack_compute remove_deployment deploy_network deploy_ses deploy_caasp deploy_caasp4 deploy_caasp4 configure_ccp_deployer deploy_ccp_deployer enroll_caasp_workers patch_upstream build_images deploy_osh setup_caasp_workers_for_openstack setup_hosts setup_openstack setup_airship setup_everything teardown clean_caasp4 clean_k8s clean_airship_not_images gather_logs)
+   OPTIONS=(deploy test update_openstack add_openstack_compute remove_openstack_compute remove_deployment deploy_network deploy_ses deploy_caasp deploy_caasp4 deploy_caasp4 configure_ccp_deployer deploy_ccp_deployer enroll_caasp_workers patch_upstream build_images deploy_osh setup_caasp_workers_for_openstack setup_hosts setup_openstack setup_airship setup_everything teardown clean_caasp4 clean_k8s clean_airship_not_images gather_logs deploy_ses_rook delete_ses_rook)
 
    action=$1
    isvalid=false


### PR DESCRIPTION
Add deploy_ses_rook

Adds a role for deploying ses via rook
Adds the actions deploy_ses_rook and delete_ses_rook to run.sh
Adds disks to the caasp4 workers as they are needed to provision
ceph via rook
Adds testing of the ceph cluster by provisioning a pvc on a ceph
block storageclass
Adds the ses-rook path to jenkins
Adds a new choice to select the normal ses or ses-rook in jenkins