### PR TITLE
SOC-10091 Update docs to reflect current reality


### DIFF
--- a/doc/source/deployment/requirements.rst
+++ b/doc/source/deployment/requirements.rst
@@ -10,12 +10,8 @@ requirements.
 Infrastructure
 --------------
 
-* The `Deployer` must run openSUSE Leap 15.0. See :ref:`setupdeployer` for
+* The `Deployer` must run SUSE SLE 15 SP1. See :ref:`setupdeployer` for
   required deployment tools and packages.
-
-  .. note::
-     To install openSUSE Leap 15.0, follow the instructions at
-     https://software.opensuse.org/distributions/leap.
 
 * The :term:`CaaS Platform` cluster must run the latest :term:`CaaS Platform`
   version 3.

--- a/doc/source/deployment/setup-deployer.rst
+++ b/doc/source/deployment/setup-deployer.rst
@@ -59,22 +59,9 @@ Deployer. Set up your workspace with the following steps:
 Installing the SUSE Containerized OpenStack software
 ----------------------------------------------------
 
-There are several ways to install the SUSE Containerized OpenStack software.
+We currently only allow to deploy master branch from sources.
 
-1. (Recommended) Install with an ISO image including required dependencies:
-
-   a. Download ``openSUSE-Addon-socok8s-x86_64-Media.iso`` from
-      https://download.opensuse.org/repositories/Cloud:/socok8s:/master/images/iso/
-   b. sudo zypper addrepo --refresh <PATH_TO_ISO_IMAGE> socok8s-iso
-   c. sudo zypper install socok8s (installs to /usr/share/socok8s)
-
-2. Install from the openSUSE repository including required dependencies:
-
-   a. sudo zypper addrepo --refresh \\
-      https://download.opensuse.org/repositories/Cloud:/socok8s:/master/openSUSE_Leap_15.0/ socok8s
-   b. sudo zypper install socok8s (installs to /usr/share/socok8s)
-
-3. (For developers only) Clone the repository.
+1. (For developers only) Clone the repository.
 
    The following software must be manually installed on your `Deployer` using zypper or pip install:
 

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -15,7 +15,7 @@ Glossary
 
 
    Deployer
-     openSUSE Leap 15 host used to deploy CCP.
+     SUSE SLE 15 SP1 host used to deploy CCP.
 
    LOCI
      The official OpenStack project to build Lightweight Open Container

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -92,10 +92,6 @@ Why...
    <insert your favorite language here>, mostly because the shell script grew
    organically out of actual use and CI needs.
 
-... Installing from sources?
-   Neither the socok8s repo nor the OpenStack-Helm project's repositories
-   have been packaged for Leap/SLE 15 yet.
-
 Image building process
 ======================
 
@@ -253,7 +249,7 @@ for deploying OSH later.
      localhost -> cloud             [label = "Start CaaSP3 stack"];
      localhost <- cloud             [label = "CaaSP inventory data"];
 
-     localhost -> cloud             [label = "Start Leap 15 node"];
+     localhost -> cloud             [label = "Start SLE 15 SP1 node"];
      localhost <- cloud             [label = "Deployer inventory data"];
 
      localhost -> deployer          [label = "Configure deployer" ];


### PR DESCRIPTION


The docs currently point to Leap, where in fact the deployer has
been targetting SLE15 SP1 for a while.

This should clarify the requirements.

