### PR TITLE
Check if ssh-agent is running for openstack deployment

### DIFF
--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -33,6 +33,7 @@ function deploy_caasp4(){
     source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp4_skuba_available
     source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp4_terraform_available
     source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp4_terraform_version
+    source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp4_ssh_agent_running
     echo "Starting CaaSP 4 deploy"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-deploy_caasp4.yml
     echo "CaaSP 4 deployed successfully"


### PR DESCRIPTION
CaaSP4 requires ssh-agent running so let's check (and fail) early
before we get messages that terraform cannot connect to the nodes.