### PR TITLE
Remove the cluster dir which is generated on cluster creation

### DIFF
--- a/playbooks/roles/caasp4/tasks/cleanup_nodes.yml
+++ b/playbooks/roles/caasp4/tasks/cleanup_nodes.yml
@@ -52,3 +52,8 @@
   file:
     path: "{{ skuba_ci_terraform_workspace }}"
     state: absent
+
+- name: Remove skuba cluster dir
+  file:
+    path: "{{ skuba_cluster_basedir }}/{{ skuba_cluster_name }}"
+    state: absent


### PR DESCRIPTION
Directory is generated and depends on skuba version, hence
it should be deleted when deleting caasp deployment.