### PR TITLE
Fix libvirt image version tag

### DIFF
--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -177,7 +177,7 @@ data:
         keystone_api: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
         keystone_domain_manage: "{{ suse_osh_registry_location }}/openstackhelm/keystone:{{ suse_openstack_image_version }}"
       libvirt:
-        libvirt: "{{ suse_osh_registry_location }}/openstackhelm/libvirt:{{ suse_libvirt_image_version }}"
+        libvirt: "{{ suse_osh_registry_location }}/openstackhelm/libvirt:{{ suse_infra_image_version }}"
       mariadb:
         prometheus_mysql_exporter_helm_tests: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
       memcached: {}

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -56,7 +56,6 @@ socok8s_repos_to_configure:
 # Following variables are used by airship logic only
 ######################################################
 
-suse_libvirt_image_version: "ubuntu-xenial-1.3.1-1ubuntu10.24"
 suse_ovs_image_version: "v2.8.1"
 
 socok8s_deploy_config_location: "{{ socok8s_workspace }}"


### PR DESCRIPTION
The libvirt image tag version was set to ubuntu in the common vars.
Changed libvirt to point to the opensuse leap 15 image tag in the
versions.yaml and removed the value from common vars yaml.