### PR TITLE
Modify the message of minimum version required for ansible

### DIFF
--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -106,7 +106,7 @@ check_ansible_requirements (){
     fi
     # We need ansible version 2.8 minimum
     if [[ $(ansible --version | awk 'NR==1 { gsub(/[.]/,""); print substr($2,0,2); }' ) -lt "28" ]]; then
-        echo "Insufficent version of ansible: 2.8 or greater is required."
+        echo "Insufficent version of ansible: 2.8.3 or greater is required."
         echo "Install from your system packages or set SOCOK8S_USE_VIRTUALENV=True to install ansible and other requirements into a virtualenv."
         exit 1
     fi


### PR DESCRIPTION
Now is set to 2.8 but it doesn't work with 2.8.1 version so
it is confusing.

Testing with version 2.8.3 this works. So The message has been
modified

