### PR TITLE
Drop pattern for caasp4 nodes (libvirt)

### DIFF
--- a/playbooks/roles/caasp4/templates/skuba-terraform-libvirt.tfvars.j2
+++ b/playbooks/roles/caasp4/templates/skuba-terraform-libvirt.tfvars.j2
@@ -29,7 +29,6 @@ packages = [
   "kernel-default",
   "-kernel-default-base",
   "ca-certificates-suse",
-  "patterns-caasp-Node",
   "ceph-common",
 ]
 


### PR DESCRIPTION
There is no need to install any package or pattern manually as
skuba will do so when joining the no9des into the cluster, so
just drop the uneeded pattern

This is commit ea584a0fe ported for the libvirt terraform
implementation.