### PR TITLE
Build images for sle15sp1 and deploy.

### DIFF
--- a/images/airflow_Dockerfile.sle_15sp1
+++ b/images/airflow_Dockerfile.sle_15sp1
@@ -1,0 +1,137 @@
+# Copyright 2018 AT&T Intellectual Property.  All other rights reserved.
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# Docker image to run Airflow on Kubernetes
+ARG FROM=registry.suse.com/suse/sle15
+FROM ${FROM}
+
+LABEL org.opencontainers.image.authors='airship-discuss@lists.airshipit.org, irc://#airshipit@freenode'
+LABEL org.opencontainers.image.url='https://airshipit.org'
+LABEL org.opencontainers.image.documentation='https://airship-shipyard.readthedocs.org'
+LABEL org.opencontainers.image.source='https://opendev.org/airship/shipyard'
+LABEL org.opencontainers.image.vendor='The Airship Authors'
+LABEL org.opencontainers.image.licenses='Apache-2.0'
+
+# Do not prompt user for choices on installation/configuration of packages
+# Set port 8080 for Airflow Web
+# Set port 5555 for Airflow Flower
+# Set port 8793 for Airflow Worker
+ENV container docker
+ENV WEB_PORT 8080
+ENV FLOWER_PORT 5555
+ENV WORKER_PORT 8793
+ENV SLUGIFY_USES_TEXT_UNIDECODE yes
+
+# Expose port for applications
+EXPOSE $WEB_PORT
+EXPOSE $FLOWER_PORT
+EXPOSE $WORKER_PORT
+
+# Set ARG for usage during build
+ARG AIRFLOW_HOME=/usr/local/airflow
+ARG ctx_base=src/bin
+
+# Kubectl version
+ARG KUBECTL_VERSION=1.10.2
+
+RUN set -ex && \
+    zypper -q update -y ;\
+    zypper --non-interactive install --no-recommends \
+        ca-certificates \
+        curl \
+        git-core \
+        gcc-c++ \
+        libopenssl-devel \
+        netcat-openbsd \
+        netcfg \
+        which \
+        python3 \
+        python3-setuptools \
+        python3-pip \
+        python3-devel \
+        python3-python-dateutil \
+        make \
+    && python3 -m pip install -U pip \
+    && zypper clean -a \
+    && rm -rf \
+        /tmp/* \
+        /var/tmp/* \
+        /var/log/* \
+        /usr/share/man \
+        /usr/share/doc \
+        /usr/share/doc-base
+
+# Explicitly need to create usergroup with same name in suse
+RUN useradd -U -ms /bin/bash -d ${AIRFLOW_HOME} airflow
+
+# Things that change mostly infrequently
+RUN curl -L -o /usr/local/bin/kubectl \
+       https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
+    && chmod +x /usr/local/bin/kubectl
+
+# Dependency requirements
+# Note - removing snakebite (python 2 vs. 3). See:
+#    https://github.com/puckel/docker-airflow/issues/77
+COPY images/airflow/requirements.txt /tmp/
+RUN pip3 install -r /tmp/requirements.txt --no-cache-dir \
+    && pip3 uninstall -y snakebite || true
+
+# Copy scripts used in the container:
+COPY images/airflow/script/*.sh ${AIRFLOW_HOME}/
+
+# Copy configuration (e.g. logging config for Airflow):
+COPY images/airflow/config/*.py ${AIRFLOW_HOME}/config/
+
+# Change permissions
+RUN chown -R airflow:airflow ${AIRFLOW_HOME}
+
+# Setting the version explicitly for PBR
+ENV PBR_VERSION 0.1a1
+
+# Shipyard
+#
+# Shipyard provides core functionality used by the Airflow plugins/operators
+# Since Shipyard and Airflow are built together as images, this should prevent
+# stale or out-of-date code between these parts.
+# Shipyard requirements, source and installation
+COPY ${ctx_base}/shipyard_airflow/requirements.txt /tmp/api_requirements.txt
+RUN pip3 install -r /tmp/api_requirements.txt --no-cache-dir
+
+COPY ${ctx_base}/shipyard_airflow /tmp/shipyard/
+RUN cd /tmp/shipyard \
+    && python3 setup.py install
+
+# Note: The value for the dags and plugins directories that are sourced
+# from the values.yaml of the Shipyard Helm chart need to align with these
+# directories. If they do not, airflow will not find the intended dags and
+# plugins.
+#
+# Note: In the case of building images using the provided Makefile, a test is
+# run against the built-in dags provided with Airflow. Since there is no Helm
+# chart to reconfigure the airflow.cfg with these directories, these dags and
+# plugins are not known to Airflow during the image test.
+#
+# Copy the plugins and dags that will be used by this Airflow image:
+COPY ${ctx_base}/shipyard_airflow/shipyard_airflow/plugins ${AIRFLOW_HOME}/plugins/
+COPY ${ctx_base}/shipyard_airflow/shipyard_airflow/dags ${AIRFLOW_HOME}/dags/
+
+# Set work directory
+USER airflow
+WORKDIR ${AIRFLOW_HOME}
+
+# Execute entrypoint
+ENTRYPOINT ["./entrypoint.sh"]

--- a/images/armada_Dockerfile.sle_15sp1
+++ b/images/armada_Dockerfile.sle_15sp1
@@ -1,0 +1,69 @@
+# Copyright 2018 AT&T Intellectual Property.  All other rights reserved.
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+ARG FROM=registry.suse.com/suse/sle15
+FROM ${FROM}
+
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+EXPOSE 8000
+
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["server"]
+
+RUN mkdir -p /armada && \
+    zypper refresh && \
+    zypper up -y && \
+    zypper --non-interactive install \
+       curl \
+       tar \
+       python3 \
+       python3-devel \
+       python3-setuptools \
+       python3-pip \
+       gcc \
+       git-core \
+       libopenssl-devel \
+       make && \
+       pip install --upgrade pip && \
+       python3 -m pip install -U pip && \
+       zypper clean -a && \
+       rm -rf \
+         /tmp/* \
+         /var/tmp/* \
+         /usr/share/man \
+         /usr/share/doc \
+         /usr/share/doc-base
+
+WORKDIR /armada
+COPY requirements.txt /tmp/
+
+RUN \
+    pip3 install -r /tmp/requirements.txt && \
+    useradd -u 1000 -g users -d /armada armada && \
+    rm -rf /tmp/requirements.txt
+
+COPY . /armada
+
+RUN \
+    mv etc/armada /etc/ && \
+    cd /armada && \
+    chown -R armada:users /armada && \
+    python3 setup.py install
+
+USER armada

--- a/images/deckhand_Dockerfile.sle_15sp1
+++ b/images/deckhand_Dockerfile.sle_15sp1
@@ -1,0 +1,82 @@
+# Copyright 2018 AT&T Intellectual Property.  All other rights reserved.
+# (c) Copyright 2019 SUSE LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ARG FROM=registry.suse.com/suse/sle15
+FROM ${FROM}
+
+LABEL org.opencontainers.image.authors='airship-discuss@lists.airshipit.org, irc://#airshipit@freenode'
+LABEL org.opencontainers.image.url='https://airshipit.org'
+LABEL org.opencontainers.image.documentation='https://airship-deckhand.readthedocs.org'
+LABEL org.opencontainers.image.source='https://opendev.org/airship/deckhand'
+LABEL org.opencontainers.image.vendor='The Airship Authors'
+LABEL org.opencontainers.image.licenses='Apache-2.0'
+
+ENV container docker
+ENV PORT 9000
+
+# Expose port 9000 for application
+EXPOSE $PORT
+
+RUN set -x && \
+    zypper -q update -y && \
+    zypper install -y --no-recommends \
+    git-core \
+    curl \
+    netcat-openbsd \
+    python3 \
+    python3-setuptools \
+    python3-pip \
+    python3-devel \
+    python3-python-dateutil \
+    python3-dbm \
+    gcc \
+    gcc-c++ \
+    make \
+    libffi-devel \
+    libopenssl-devel \
+    && zypper --non-interactive --no-gpg-checks ar -f https://download.opensuse.org/repositories/devel:languages:python/openSUSE_Leap_15.1/devel:languages:python.repo \
+    && zypper --non-interactive --no-gpg-checks install python3-six-1.12.0-lp151.80.1.noarch \
+    && python3 -m pip install -U pip \
+    && zypper clean -a \
+    && rm -rf \
+        /tmp/* \
+        /var/tmp/* \
+        /usr/share/man \
+        /usr/share/doc \
+        /usr/share/doc-base
+
+# Create deckhand user
+RUN useradd -ms /bin/bash deckhand
+
+# Clone the deckhand repository
+COPY . /home/deckhand/
+
+# Change permissions
+RUN chown -R deckhand: /home/deckhand \
+    && chmod +x /home/deckhand/entrypoint.sh
+
+# Set work directory and install dependencies
+WORKDIR /home/deckhand
+RUN pip3 install -r requirements.txt
+RUN python3 setup.py install
+
+# Set user to deckhand
+USER deckhand
+
+# Execute entrypoint
+ENTRYPOINT ["/home/deckhand/entrypoint.sh"]
+
+CMD ["server"]

--- a/images/pegleg_Dockerfile.sle_15sp1
+++ b/images/pegleg_Dockerfile.sle_15sp1
@@ -1,0 +1,66 @@
+# Copyright 2018 AT&T Intellectual Property.  All other rights reserved.
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+ARG FROM=registry.suse.com/suse/sle15
+FROM ${FROM}
+
+ARG CFSSLURL=https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
+
+LABEL org.opencontainers.image.authors='airship-discuss@lists.airshipit.org, irc://#airshipit@freenode'
+LABEL org.opencontainers.image.url='https://airshipit.org'
+LABEL org.opencontainers.image.documentation='https://airship-pegleg.readthedocs.org'
+LABEL org.opencontainers.image.source='https://opendev.org/airship/pegleg'
+LABEL org.opencontainers.image.vendor='The Airship Authors'
+LABEL org.opencontainers.image.licenses='Apache-2.0'
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+RUN set -x \
+    && zypper up -y \
+    && zypper --non-interactive install \
+         curl \
+         gcc \
+         git-core \
+         openssh \
+         python3-dbm \
+         python3-devel \
+         python3-pip \
+         python3-setuptools \
+         which \
+    && python3 -m pip install -U pip \
+    && zypper --non-interactive --no-gpg-checks ar -f https://download.opensuse.org/repositories/devel:languages:python/openSUSE_Leap_15.1/devel:languages:python.repo \
+    && zypper --non-interactive --no-gpg-checks install python3-six-1.12.0-lp151.80.1.noarch \
+    && zypper clean -a \
+    && rm -rf \
+         /tmp/* \
+         /usr/share/doc \
+         /usr/share/doc-base \
+         /usr/share/man \
+         /var/log/* \
+         /var/tmp/*
+
+VOLUME /var/pegleg
+WORKDIR /var/pegleg
+
+COPY requirements.txt /opt/pegleg/requirements.txt
+RUN pip3 install --no-cache-dir -r /opt/pegleg/requirements.txt
+
+COPY tools/install-cfssl.sh /opt/pegleg/tools/install-cfssl.sh
+RUN /opt/pegleg/tools/install-cfssl.sh ${CFSSLURL}
+
+COPY . /opt/pegleg
+RUN pip3 install -e /opt/pegleg

--- a/images/shipyard_Dockerfile.sle_15sp1
+++ b/images/shipyard_Dockerfile.sle_15sp1
@@ -1,0 +1,105 @@
+# Copyright 2017 AT&T Intellectual Property.  All other rights reserved.
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ARG FROM=registry.suse.com/suse/sle15
+FROM ${FROM}
+
+LABEL org.opencontainers.image.authors='airship-discuss@lists.airshipit.org, irc://#airshipit@freenode'
+LABEL org.opencontainers.image.url='https://airshipit.org'
+LABEL org.opencontainers.image.documentation='https://airship-shipyard.readthedocs.org'
+LABEL org.opencontainers.image.source='https://git.openstack.org/openstack/airship-shipyard'
+LABEL org.opencontainers.image.vendor='The Airship Authors'
+LABEL org.opencontainers.image.licenses='Apache-2.0'
+
+ENV container docker
+ENV PORT 9000
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+# Setting the version explicitly for PBR
+ENV PBR_VERSION 0.1a1
+
+ARG ctx_base=src/bin
+
+# Expose port 9000 for application
+EXPOSE $PORT
+
+RUN set -ex && \
+    zypper --gpg-auto-import-keys refresh && \
+    zypper -q update -y && \
+    zypper --non-interactive install --no-recommends \
+        ca-certificates \
+        curl \
+        netcfg \
+        python3-devel \
+        python3-setuptools \
+    && zypper clean -a \
+    && rm -rf \
+        /tmp/* \
+        /var/tmp/* \
+        /usr/share/man \
+        /usr/share/doc \
+        /usr/share/doc-base
+
+# Create shipyard user
+RUN useradd -ms /bin/bash shipyard \
+    && mkdir -p /home/shipyard/shipyard \
+    && mkdir -p /home/shipyard/shipyard_client
+
+# Copy entrypoint.sh to /home/shipyard
+COPY ${ctx_base}/shipyard_airflow/entrypoint.sh /home/shipyard/entrypoint.sh
+# Change permissions and set up directories
+RUN chown -R shipyard: /home/shipyard \
+    && chmod +x /home/shipyard/entrypoint.sh
+
+# Requirements and Shipyard source
+COPY ${ctx_base}/shipyard_airflow/requirements.txt /home/shipyard/api_requirements.txt
+COPY ${ctx_base}/shipyard_client/requirements.txt /home/shipyard/client_requirements.txt
+COPY ${ctx_base}/shipyard_client /home/shipyard/shipyard_client/
+COPY ${ctx_base}/shipyard_airflow /home/shipyard/shipyard/
+
+# Build
+ RUN set -ex \
+    && buildDeps=' \
+      gcc \
+      git-core \
+      libopenssl-devel \
+      make \
+      python3-pip \
+    ' \
+    && zypper -q update -y \
+    && zypper --non-interactive install --no-recommends $buildDeps \
+    && python3 -m pip install -U pip \
+    && pip3 install -r /home/shipyard/client_requirements.txt --no-cache-dir \
+    && cd /home/shipyard/shipyard_client \
+    && python3 setup.py install \
+    && pip3 install -r /home/shipyard/api_requirements.txt --no-cache-dir \
+    && cd /home/shipyard/shipyard \
+    && python3 setup.py install \
+    && zypper remove -y --clean-deps $buildDeps \
+    && zypper clean -a \
+    && rm -rf \
+        /tmp/* \
+        /var/tmp/* \
+        /var/log/* \
+        /usr/share/man \
+        /usr/share/doc \
+        /usr/share/doc-base
+
+# Entrypoint
+ENTRYPOINT ["/home/shipyard/entrypoint.sh"]
+CMD ["server"]
+# Set user to shipyard
+USER shipyard

--- a/playbooks/roles/airship-deploy-ucp/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/tasks/main.yml
@@ -84,6 +84,14 @@
     dest:  '{{ site_path }}/profiles'
     mode: 0644
 
+- name: Copy armada sle_15sp1 docker file to upstream repo cloned directory.
+  copy:
+    src: '{{ playbook_dir }}/../images/armada_Dockerfile.sle_15sp1'
+    dest: '{{ upstream_repos_clone_folder }}/airship/armada/images/armada/Dockerfile.sle_15sp1'
+    mode: 0644
+  when:
+    - suse_airship_build_local_images
+
 - name: Build Armada image
   make:
     chdir: "{{ upstream_repos_clone_folder }}/airship/{{ item.repo_name }}"
@@ -101,6 +109,22 @@
     - { repo_name: "armada", target: "images", image_name: "armada" }
   tags:
     - install
+
+- name: Copy shipyard sle_15sp1 docker file to upstream repo cloned directory.
+  copy:
+    src: '{{ playbook_dir }}/../images/shipyard_Dockerfile.sle_15sp1'
+    dest: '{{ upstream_repos_clone_folder }}/airship/shipyard/images/shipyard/Dockerfile.sle_15sp1'
+    mode: 0644
+  when:
+    - suse_airship_build_local_images
+
+- name: Copy airflow sle_15sp1 docker file to upstream repo cloned directory.
+  copy:
+    src: '{{ playbook_dir }}/../images/airflow_Dockerfile.sle_15sp1'
+    dest: '{{ upstream_repos_clone_folder }}/airship/shipyard/images/airflow/Dockerfile.sle_15sp1'
+    mode: 0644
+  when:
+    - suse_airship_build_local_images
 
 - name: Build Shipyard images
   become: yes
@@ -122,6 +146,14 @@
   tags:
     - install
 
+- name: Copy deckhand sle_15sp1 docker file to upstream repo cloned directory.
+  copy:
+    src: '{{ playbook_dir }}/../images/deckhand_Dockerfile.sle_15sp1'
+    dest: '{{ upstream_repos_clone_folder }}/airship/deckhand/images/deckhand/Dockerfile.sle_15sp1'
+    mode: 0644
+  when:
+    - suse_airship_build_local_images
+
 - name: Build Deckhand images
   make:
     chdir: "{{ upstream_repos_clone_folder }}/airship/{{ item.repo_name }}"
@@ -139,6 +171,14 @@
     - { repo_name: "deckhand", target: "images", image_name: "deckhand" }
   tags:
     - install
+
+- name: Copy pegleg sle_15sp1 docker file to upstream repo cloned directory.
+  copy:
+    src: '{{ playbook_dir }}/../images/pegleg_Dockerfile.sle_15sp1'
+    dest: '{{ upstream_repos_clone_folder }}/airship/pegleg/images/pegleg/Dockerfile.sle_15sp1'
+    mode: 0644
+  when:
+    - suse_airship_build_local_images
 
 - name: Build Pegleg image
   make:

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -63,8 +63,8 @@ socok8s_deploy_config_location: "{{ socok8s_workspace }}"
 ucp_namespace_name: "{{ ucp_namespace | default('ucp') }}"
 
 # Variables used for building airship images locally
-suse_distro_identifier: opensuse_15
-suse_airship_components_base_image: "opensuse/leap:15.1"
+suse_distro_identifier: sle_15sp1
+suse_airship_components_base_image: "registry.suse.com/suse/sle15"
 
 # check if argument is set in commandline for airship_local_images_flag value
 # otherwise use corresponding environment variable to determine it


### PR DESCRIPTION
sle images are not in public repo so we need to build them locally
and push them to local registry.
Created docker files for all airship components to support sle_15sp1.
these files are copied to upstream directory before build images.