### PR TITLE
caasp4: Only touch port security on openstack deploy

### DIFF
--- a/playbooks/roles/caasp4/defaults/main.yml
+++ b/playbooks/roles/caasp4/defaults/main.yml
@@ -1,6 +1,10 @@
 # path to the terraform binary
 terraform_binary_path: "{{ (lookup('env','TERRAFORM_BINARY_PATH') | default('/usr/bin/terraform', true) ) }}"
 
+# Which deployment method have we been started with. (This is guaranted to be set
+# when executed via ./run.sh
+socok8s_deployment_mechanism: "{{ lookup('env', 'DEPLOYMENT_MECHANISM') }}"
+
 ############################################################################
 # skuba terraform openstack provider specific variables
 ############################################################################

--- a/playbooks/roles/caasp4/tasks/setup_nodes.yml
+++ b/playbooks/roles/caasp4/tasks/setup_nodes.yml
@@ -95,5 +95,7 @@
   args:
     executable: /bin/bash
   changed_when: False
+  when:
+    - socok8s_deployment_mechanism == 'openstack'
   tags:
     - bug


### PR DESCRIPTION
Only disable Port security when DEPLOYMENT_MECHANISM=openstack. This
should fix libvirt based deployments.