### PR TITLE
caasp4: Allow to override repo mirros

### DIFF
--- a/playbooks/roles/caasp4/defaults/main.yml
+++ b/playbooks/roles/caasp4/defaults/main.yml
@@ -26,6 +26,11 @@ skuba_ci_terraform_libvirt_image_password: "linux"
 ############################################################################
 # skuba terraform common variables
 ############################################################################
+# Download mirror to use for internal IBS repositories
+skuba_ci_terraform_ibs_mirror_uri: "http://download.suse.de/ibs"
+# Download mirror to use for "official" products and updates (can e.g. point
+# to a local rmt mirror)
+skuba_ci_terraform_rmt_mirror_uri: "http://download.suse.de/ibs"
 # number of master nodes
 skuba_ci_terraform_master_count: 1
 # number of worker nodes

--- a/playbooks/roles/caasp4/tasks/setup_terraform_workspace_libvirt.yml
+++ b/playbooks/roles/caasp4/tasks/setup_terraform_workspace_libvirt.yml
@@ -30,6 +30,8 @@
     image_uri: "{{ skuba_ci_terraform_libvirt_image_uri }}"
     image_username: "{{ skuba_ci_terraform_libvirt_image_username }}"
     image_password: "{{ skuba_ci_terraform_libvirt_image_password }}"
+    ibs_mirror_uri: "{{ skuba_ci_terraform_ibs_mirror_uri }}"
+    rmt_mirror_uri: "{{ skuba_ci_terraform_rmt_mirror_uri }}"
     stack_name: "{{ socok8s_envname }}-caasp4"
     master_count: "{{ skuba_ci_terraform_master_count }}"
     worker_count: "{{ skuba_ci_terraform_worker_count }}"

--- a/playbooks/roles/caasp4/templates/skuba-terraform-libvirt.tfvars.j2
+++ b/playbooks/roles/caasp4/templates/skuba-terraform-libvirt.tfvars.j2
@@ -13,25 +13,25 @@ masters = {{ master_count }}
 workers = {{ worker_count }}
 
 repositories = {
-  caasp_devel = "http://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/"
-  suse_ca = "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/"
-  sle_server_pool = "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"
-  basesystem_pool = "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/"
-  containers_pool = "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product/"
-  serverapps_pool = "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/"
-  sle_server_updates = "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/"
-  basesystem_updates = "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/"
-  containers_updates = "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update/"
-  serverapps_updates = "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/"
+  caasp_devel = "{{ ibs_mirror_uri }}/Devel:/CaaSP:/4.0/SLE_15_SP1/"
+  suse_ca = "{{ ibs_mirror_uri }}/SUSE:/CA/SLE_15_SP1/"
+  sle_server_pool = "{{ rmt_mirror_uri }}/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"
+  basesystem_pool = "{{ rmt_mirror_uri }}/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/"
+  containers_pool = "{{ rmt_mirror_uri }}/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product/"
+  serverapps_pool = "{{ rmt_mirror_uri }}/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/"
+  sle_server_updates = "{{ rmt_mirror_uri }}/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/"
+  basesystem_updates = "{{ rmt_mirror_uri }}/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/"
+  containers_updates = "{{ rmt_mirror_uri }}/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update/"
+  serverapps_updates = "{{ rmt_mirror_uri }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/"
 }
 
 lb_repositories = {
-  sle_server_pool    = "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"
-  basesystem_pool    = "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/"
-  ha_pool            = "http://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/15/x86_64/product/"
-  sle_server_updates = "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/"
-  basesystem_updates = "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/"
-  ha_updates         = "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-HA/15/x86_64/update/"
+  sle_server_pool    = "{{ rmt_mirror_uri }}/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"
+  basesystem_pool    = "{{ rmt_mirror_uri }}/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/"
+  ha_pool            = "{{ rmt_mirror_uri }}/SUSE/Products/SLE-Product-HA/15/x86_64/product/"
+  sle_server_updates = "{{ rmt_mirror_uri }}/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/"
+  basesystem_updates = "{{ rmt_mirror_uri }}/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/"
+  ha_updates         = "{{ rmt_mirror_uri }}/SUSE/Updates/SLE-Product-HA/15/x86_64/update/"
 }
 
 packages = [

--- a/playbooks/roles/caasp4/templates/skuba-terraform-libvirt.tfvars.j2
+++ b/playbooks/roles/caasp4/templates/skuba-terraform-libvirt.tfvars.j2
@@ -25,6 +25,15 @@ repositories = {
   serverapps_updates = "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/"
 }
 
+lb_repositories = {
+  sle_server_pool    = "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"
+  basesystem_pool    = "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/"
+  ha_pool            = "http://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/15/x86_64/product/"
+  sle_server_updates = "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/"
+  basesystem_updates = "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/"
+  ha_updates         = "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-HA/15/x86_64/update/"
+}
+
 packages = [
   "kernel-default",
   "-kernel-default-base",


### PR DESCRIPTION
This is currently limited to the libvirt templates. I still need to adapt it for the OpenStack case. (Makes sense to offer choice there as well. E.g. depending on which cloud is used.