### PR TITLE
kill the ssh-agent and the end of the run

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -266,6 +266,8 @@ pipeline {
         }
         cleanup {
             script {
+                // Do not leave the ssh-agent running
+                sh "pkill -f 'ssh-agent -a /tmp/${env.SOCOK8S_ENVNAME}'"
                 if (fileExists("/tmp/${env.SOCOK8S_ENVNAME}.needcleanup")) {
                     sh './run.sh teardown'
                     sh 'rm /tmp/${SOCOK8S_ENVNAME}.needcleanup'


### PR DESCRIPTION
we launch a per-job ssh-agent for caasp4 so we should clean it up
when we finish