### PR TITLE
Updating jenkins file to work with pipeline plugin

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -30,10 +30,12 @@ pipeline {
     }
 
     environment {
+        /* env.BRANCH_NAME is available in multibranch plugin but not in pipeline plugin used in daily integration job */
+        BRANCH_NAME_ONLY="${env.GIT_BRANCH.replaceAll("origin/", "")}"
         /* Sanitize ENVNAME (lowercase and remove some problematic characters)
            as the names of the heat stacks will be derived from this. Also
            the CaaSP Velum automation has issues with mixed case hostnames. */
-        SOCOK8S_ENVNAME = "cloud-socok8s-${env.BRANCH_NAME.replaceAll("[^a-zA-Z0-9-]+", "-").toLowerCase()}-${env.BUILD_NUMBER}"
+        SOCOK8S_ENVNAME = "cloud-socok8s-${BRANCH_NAME_ONLY.replaceAll("[^a-zA-Z0-9-]+", "-").toLowerCase()}-${env.BUILD_NUMBER}"
         SOCOK8S_OPENSUSE_MIRROR="https://provo-mirror.opensuse.org"
         OS_CLOUD = "engcloud-socok8s-ci"
         SOCOK8S_TEST_CEPH_ROOK="true"
@@ -60,7 +62,7 @@ pipeline {
             }
         }
         stage('Check for updated files') {
-            when { expression { env.BRANCH_NAME != 'master' } }
+            when { expression { env.BRANCH_NAME_ONLY != 'master' } }
             steps {
                 script {
                     /* When doing PRs, make sure we don't test everything by default */
@@ -70,7 +72,7 @@ pipeline {
                     /* Need to fetch master to check against it for the proper diff */
                     sh "git config --add remote.origin.fetch +refs/heads/master:refs/remotes/origin/master"
                     sh "git fetch --no-tags"
-                    List<String> sourceChanged = sh(returnStdout: true, script: "git diff --name-only origin/master...origin/${env.BRANCH_NAME}").split()
+                    List<String> sourceChanged = sh(returnStdout: true, script: "git diff --name-only origin/master...origin/${env.BRANCH_NAME_ONLY}").split()
                     echo "Files changed for this PR:\n${sourceChanged.join('\n')}"
                     TestDocs = sourceChanged.any{it.contains("doc/")} or sourceChanged.any{it.contains("tox.ini")} or sourceChanged.any{it.contains("Jenkinsfile.integration")}
                     /* In the future we could add a conditional to auto TestFunctional if tox.ini or Jenkinsfile is changed */


### PR DESCRIPTION
Recently in daily tempest integration job, encountered error while
running Jenkinsfile. Issue was related to env.BRANCH_NAME variable
which is not available in pipeline plugin and is used for daily
tempest integration job. This value is available for multibranch
job.

So using GIT_BRANCH env variable instead.
In GIT_BRANCH has similar value as BRANCH_NAME.
In some cases it may have, 'origin/' as suffix so removing it
if its there.