### PR TITLE
Notify Rocketchat channel on cleanup failure

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -267,8 +267,14 @@ pipeline {
                 // Do not leave the ssh-agent running
                 sh "pkill -f 'ssh-agent -a /tmp/${env.SOCOK8S_ENVNAME}'"
                 if (fileExists("/tmp/${env.SOCOK8S_ENVNAME}.needcleanup")) {
-                    sh './run.sh teardown'
-                    sh 'rm /tmp/${SOCOK8S_ENVNAME}.needcleanup'
+                    try {
+                        sh './run.sh teardown'
+                        sh 'rm /tmp/${SOCOK8S_ENVNAME}.needcleanup'
+                    } catch (e) {
+                        sh 'ansible-playbook playbooks/generic-notify_failure_rocket.yml -v'
+                        // manually set the build to failure if we could not cleanup resources
+                        currentBuild.result = 'FAILURE'
+                    }
                 }
             }
         }

--- a/playbooks/generic-notify_failure_rocket.yml
+++ b/playbooks/generic-notify_failure_rocket.yml
@@ -1,0 +1,21 @@
+---
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+- hosts: localhost
+  gather_facts: false
+  roles:
+    - role: notify-failure-rocket

--- a/playbooks/roles/notify-failure-rocket/defaults/main.yml
+++ b/playbooks/roles/notify-failure-rocket/defaults/main.yml
@@ -1,0 +1,22 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+rc_domain: "chat.suse.de"
+rc_protocol: "https"
+rc_url: "{{ rc_protocol }}://{{ rc_domain }}"
+rc_auth_info_creds: "https://gitlab.suse.de/cloud-qe/ardana-bm-info/raw/master/rc.yml"
+rc_channel: "cloud-airship"

--- a/playbooks/roles/notify-failure-rocket/tasks/main.yml
+++ b/playbooks/roles/notify-failure-rocket/tasks/main.yml
@@ -1,0 +1,44 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Load rocketchat auth variables
+  uri:
+    url: "{{ rc_auth_info_creds }}"
+    return_content: yes
+  register: rocket_vars
+  no_log: True
+
+- name: Set rc_token var
+  set_fact:
+    rc_token: "{{ (rocket_vars.content | from_yaml).rc_token  }}"
+  no_log: True
+
+- name: Notify RocketChat of the failure to clean up
+  rocketchat:
+    domain: "{{ rc_domain }}"
+    token: "{{ rc_token }}"
+    username: "Jenkins"
+    channel: "{{ rc_channel }}"
+    validate_certs: no
+    protocol: "{{ rc_protocol }}"
+    attachments:
+      - color: "danger"
+        text: "Failure in Job teardown for {{ lookup('env','BRANCH_NAME') }} on build number {{ lookup('env','BUILD_NUMBER') }}"
+        title_link: "{{ lookup('env','RUN_DISPLAY_URL') }}"
+        title: "A Job failed to cleanup, please check that there is no resources left over"
+        collapsed: False
+  ignore_errors: True


### PR DESCRIPTION
As we still have some issues when cleaning up (openstack failures,
resources blocked, disconnecting CI agents, etc...) sometimes
the cleanup will fail and there will be resources left over.

This introduces a very small role that will notify our channel on
failures to clean up so we can go and fix them manually until we
have a more stable CI/environment/tasks