### PR TITLE
Do not add volumes to our OpenStack servers for now

### DIFF
--- a/playbooks/roles/caasp4/templates/skuba-terraform-openstack.tfvars.j2
+++ b/playbooks/roles/caasp4/templates/skuba-terraform-openstack.tfvars.j2
@@ -10,8 +10,6 @@ masters = {{ master_count }}
 workers = {{ worker_count }}
 master_size = "{{ master_flavor }}"
 worker_size = "{{ worker_flavor }}"
-workers_vol_enabled = 1
-workers_vol_size = 10
 
 username = "{{ image_username }}"
 password = "{{ image_password }}"


### PR DESCRIPTION
There is some issue with ECP setup that makes connection to
storage cluster very flaky. Let's remove this part of the setup
until the problem is solved.

Mounting volumes to worker nodes is needed only for rook setup