### PR TITLE
Allow setting pod resource limits for osh

### DIFF
--- a/site/soc/software/charts/osh/openstack-ceph-config/ceph-config.yaml
+++ b/site/soc/software/charts/osh/openstack-ceph-config/ceph-config.yaml
@@ -53,4 +53,7 @@ data:
       job_namespace_client_key: false
       storageclass_cephfs: false
       storageclass_rbd: false
+    pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['ceph'] }}
 ...

--- a/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
@@ -50,6 +50,8 @@ data:
     timeout: {{ test_timeout }}
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['cinder'] }}
       replicas:
         api: 1
         volume: 1

--- a/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/rabbitmq.yaml
@@ -23,6 +23,8 @@ data:
     timeout: {{ test_timeout }}
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['cinder_rabbitmq'] }}
       replicas:
         server: 1
     monitoring:

--- a/site/soc/software/charts/osh/openstack-compute-kit/libvirt.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/libvirt.yaml
@@ -17,6 +17,9 @@ data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   values:
+    pod:
+      resources:
+        eanbled: {{ openstack_helm_pod_resources_enabled['libvirt'] }}
     labels:
       agent:
         libvirt:

--- a/site/soc/software/charts/osh/openstack-compute-kit/neutron-rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/neutron-rabbitmq.yaml
@@ -30,6 +30,8 @@ data:
     timeout: {{ test_timeout }}
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['neutron_rabbitmq'] }}
       replicas:
         server: 1
     monitoring:

--- a/site/soc/software/charts/osh/openstack-compute-kit/neutron.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/neutron.yaml
@@ -32,6 +32,8 @@ data:
     timeout: {{ test_timeout }}
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['neutron'] }}
       replicas:
         server: 1
     network:

--- a/site/soc/software/charts/osh/openstack-compute-kit/nova-rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova-rabbitmq.yaml
@@ -30,6 +30,8 @@ data:
     timeout: {{ test_timeout }}
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['nova_rabbitmq'] }}
       replicas:
         server: 1
     monitoring:

--- a/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
+++ b/site/soc/software/charts/osh/openstack-compute-kit/nova.yaml
@@ -113,6 +113,8 @@ data:
         DEFAULT:
           mkisofs_cmd: mkisofs
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['nova'] }}
       replicas:
         api_metadata: 1 
         placement: 1

--- a/site/soc/software/charts/osh/openstack-glance/glance.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/glance.yaml
@@ -46,6 +46,8 @@ data:
             image_file: "cirros-0.4.0-x86_64-disk.img"
             private: false
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['glance'] }}
       replicas:
         api: 1
         registry: 1

--- a/site/soc/software/charts/osh/openstack-glance/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-glance/rabbitmq.yaml
@@ -30,6 +30,8 @@ data:
     timeout: {{ test_timeout }}
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['glance_rabbitmq'] }}
       replicas:
         server: 1
     monitoring:

--- a/site/soc/software/charts/osh/openstack-heat/heat.yaml
+++ b/site/soc/software/charts/osh/openstack-heat/heat.yaml
@@ -48,6 +48,8 @@ data:
     timeout: {{ test_timeout }}
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['heat'] }}
       replicas:
         api: 1
         cfn: 1

--- a/site/soc/software/charts/osh/openstack-heat/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-heat/rabbitmq.yaml
@@ -28,6 +28,8 @@ data:
     timeout: {{ test_timeout }}
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['heat_rabbitmq'] }}
       replicas:
         server: 1
     monitoring:

--- a/site/soc/software/charts/osh/openstack-horizon/horizon.yaml
+++ b/site/soc/software/charts/osh/openstack-horizon/horizon.yaml
@@ -27,6 +27,8 @@ data:
     timeout: {{ openstack_helm_deploy_timeout }}
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['horizon'] }}
       replicas:
         server: 1
     conf:

--- a/site/soc/software/charts/osh/openstack-ingress-controller/ingress.yaml
+++ b/site/soc/software/charts/osh/openstack-ingress-controller/ingress.yaml
@@ -29,6 +29,8 @@ metadata:
 data:
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['ingress'] }}
       replicas:
         ingress: 1
         error_page: 1

--- a/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
@@ -28,6 +28,8 @@ data:
     timeout: {{ test_timeout }}
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['keystone'] }}
       replicas:
         api: 1
       security_context:

--- a/site/soc/software/charts/osh/openstack-keystone/rabbitmq.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/rabbitmq.yaml
@@ -30,6 +30,8 @@ data:
     timeout: {{ test_timeout }}
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['keystone_rabbitmq'] }}
       replicas:
         server: 1
     monitoring:

--- a/site/soc/software/charts/osh/openstack-mariadb/mariadb.yaml
+++ b/site/soc/software/charts/osh/openstack-mariadb/mariadb.yaml
@@ -30,6 +30,8 @@ data:
     timeout: {{ test_timeout }}
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['mariadb'] }}
       replicas:
         server: 1
     volume:

--- a/site/soc/software/charts/osh/openstack-memcached/memcached.yaml
+++ b/site/soc/software/charts/osh/openstack-memcached/memcached.yaml
@@ -29,6 +29,8 @@ metadata:
 data:
   values:
     pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['memcached'] }}
       replicas:
         server: 1
         prometheus_memcached_exporter: 1

--- a/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
+++ b/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
@@ -18,6 +18,9 @@ data:
     timeout: 12000
 {% if deploy_tempest is defined and deploy_tempest is sameas true %}
   values:
+    pod:
+      resources:
+        enabled: {{ openstack_helm_pod_resources_enabled['tempest'] }}
     jobs:
       run_tests:
         backoffLimit: 0

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -143,3 +143,25 @@ airship_ucp_control_workers: 2
 
 # Location of the kubeconfig file, fetched from velum UI (CaaSP3) or copied from cluster setup dir (CaaSP4)
 kubeconfig_file_path: "{{ socok8s_deploy_config_location }}/kubeconfig"
+
+# enable resource limiting for openstack pods
+openstack_helm_pod_resources_enabled:
+  ceph: true
+  libvirt: true
+  ingress: true
+  cinder: true
+  cinder_rabbitmq: false
+  neutron: true
+  neutron_rabbitmq: false
+  nova: true
+  nova_rabbitmq: false
+  glance: true
+  glance_rabbitmq: false
+  heat: true
+  heat_rabbitmq: false
+  horizon: true
+  keystone: true
+  keystone_rabbitmq: false
+  mariadb: true
+  memcached: true
+  tempest: true


### PR DESCRIPTION
All osh charts have some limits in place for all its pods but currently
we cannot enable those

This patch adds a way of setting the resource limits enabled or disabled
for all the pods in each osh chart via the common vars

COMPONENT_rabbitmq values are disabled for now as the current limits seem
too low and containers are killed due to OOMKilled