### PR TITLE
Use all workers for openstack-control-plane

### DIFF
--- a/playbooks/roles/airship-configure-worker/tasks/enroll-nodes.yml
+++ b/playbooks/roles/airship-configure-worker/tasks/enroll-nodes.yml
@@ -47,14 +47,27 @@
   tags:
     - skip_ansible_lint
 
-- name: Enroll node for Airship Openstack compute plane
-  command: "kubectl label nodes {{ item }} openstack-compute-node=enabled openvswitch=enabled"
+- name: Enroll node for Airship Openstack compute plane (compute label)
+  command: "kubectl label nodes {{ item }} openstack-compute-node=enabled"
   register: _enrollforopenstackcomp
   changed_when:
     - _enrollforopenstackcomp.rc == 0
   failed_when:
     - _enrollforopenstackcomp.rc != 0
     - _enrollforopenstackcomp.stderr.find("already has a value (enabled)") == -1
+  loop: "{{ groups['airship-openstack-compute-workers'] | default([]) }}"
+  tags:
+    - skip_ansible_lint
+    - add_compute_node
+
+- name: Enroll node for Airship Openstack compute plane (openvswitch label)
+  command: "kubectl label nodes {{ item }} openvswitch=enabled"
+  register: _enrollforopenstackcompopenvswitch
+  changed_when:
+    - _enrollforopenstackcompopenvswitch.rc == 0
+  failed_when:
+    - _enrollforopenstackcompopenvswitch.rc != 0
+    - _enrollforopenstackcompopenvswitch.stderr.find("already has a value (enabled)") == -1
   loop: "{{ groups['airship-openstack-compute-workers'] | default([]) }}"
   tags:
     - skip_ansible_lint

--- a/playbooks/roles/caasp4/templates/inventory-caasp4.yml.j2
+++ b/playbooks/roles/caasp4/templates/inventory-caasp4.yml.j2
@@ -22,10 +22,8 @@ caasp-workers:
 airship-openstack-control-workers:
   hosts: &first_workers
 {% for worker_ip in _terraform_json_output.ip_workers.value %}
-{% if loop.index0 < airship_ucp_control_workers %}
     worker-{{ loop.index0 }}:
       ansible_host: {{ worker_ip }}
-{% endif %}
 {% endfor %}
   vars:
     ansible_user: sles


### PR DESCRIPTION
Currently we are using only 2 out of 3 workers (default deployment)
for the control plane deployment of controller pods. This makes the
2 first nodes resource exhausted while the third node does nothing.

Instead, as this is used only for development/CI currently, use
all of the workers for a smooth, no-pod-restart, development/CI
workflow.

This has the side effect of having to separate the labeling of the
compute nodes as the openvswitch label already exists in the
worker-2 so it wont be labeled properly. Its still a good thing
to have as we should label things separatedly in case of errors
and/or retries