### PR TITLE
Try to always gather logs

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -246,6 +246,11 @@ pipeline {
                         reportFiles: 'index.html',
                         reportName: 'ARA Report'
             ]
+            script {
+                sh "source ${WORKSPACE}/sock_${env.SOCOK8S_ENVNAME} && ./run.sh gather_logs"
+            }
+            zip archive: true, dir: 'logs/', zipFile: 'logs.zip'
+            archiveArtifacts artifacts: 'logs.zip'
         }
         failure {
             script {
@@ -256,11 +261,6 @@ pipeline {
                     }
                 }
             }
-            script {
-                sh "source ${WORKSPACE}/sock_${env.SOCOK8S_ENVNAME} && ./run.sh gather_logs"
-            }
-            zip archive: true, dir: 'logs/', zipFile: 'logs.zip'
-            archiveArtifacts artifacts: 'logs.zip'
         }
         cleanup {
             script {


### PR DESCRIPTION
As currently our CI passes even with error or timeouts, try to
always gather logs so its easier to go back and check what really
happened in the k8s environment