### PR TITLE
Fix gather logs on CI failing job

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -247,10 +247,14 @@ pipeline {
                         reportName: 'ARA Report'
             ]
             script {
-                sh "source ${WORKSPACE}/sock_${env.SOCOK8S_ENVNAME} && ./run.sh gather_logs"
+                try {
+                    sh "source ${WORKSPACE}/sock_${env.SOCOK8S_ENVNAME} && ./run.sh gather_logs"
+                    zip archive: true, dir: 'logs/', zipFile: 'logs.zip'
+                    archiveArtifacts artifacts: 'logs.zip'
+                } catch(e) {
+                    echo "Could not gather logs"
+                }
             }
-            zip archive: true, dir: 'logs/', zipFile: 'logs.zip'
-            archiveArtifacts artifacts: 'logs.zip'
         }
         failure {
             script {


### PR DESCRIPTION
Now that we run gather logs always, we need to protect against
failures as to not fail on jobs that are paasing due to failed
log gathering, for example on docs only jobs