### PR TITLE
Installing skuba, terraform for non-CI workflow.

### DIFF
--- a/doc/source/suse-ecp/ose-localhost.rst
+++ b/doc/source/suse-ecp/ose-localhost.rst
@@ -85,6 +85,18 @@ venv in |socok8s_workspace_default|\ `/.ansiblevenv`.
       :code:
 
 
+For CaaSP 4.x deployment, skuba (https://github.com/SUSE/skuba) and terraform
+packages are required. Currently deployment steps automatically configure
+related package repositories and installs the appropriate packages if ansible
+runner (the host where ansible is running) is SLES-15.0 or SLES-15-SP1 host.
+
+.. note ::
+
+   If your ansible runner OS is not SLES-15 or SLES-15-SP1, then you will
+   need to find above packages for your OS distribution and version. Please
+   make sure that terrform version is v0.11.x as that's the only working
+   version for now.
+
 
 Cloning this repository
 -----------------------

--- a/playbooks/kvm-deploy_caasp.yml
+++ b/playbooks/kvm-deploy_caasp.yml
@@ -23,6 +23,10 @@
     - "{{ playbook_dir }}/../vars/deploy-on-kvm.yml"
   tasks:
     - import_role:
+        name: runner-setup
+        tasks_from: assert_packages.yml
+
+    - import_role:
         name: caasp4
         tasks_from: setup_terraform_workspace_libvirt
       vars:

--- a/playbooks/openstack-deploy_caasp.yml
+++ b/playbooks/openstack-deploy_caasp.yml
@@ -23,6 +23,10 @@
     - "{{ playbook_dir }}/../vars/deploy-on-openstack.yml"
   tasks:
     - import_role:
+        name: runner-setup
+        tasks_from: assert_packages.yml
+
+    - import_role:
         name: caasp4
         tasks_from: setup_terraform_workspace_openstack
       vars:

--- a/playbooks/roles/runner-setup/defaults/main.yml
+++ b/playbooks/roles/runner-setup/defaults/main.yml
@@ -1,0 +1,2 @@
+# variable to identify caasp specific package repositories
+caasp_pkgs_repo_version: "CAASP40-{{ ansible_distribution }}-{{ ansible_distribution_version | replace('.', '') }}"

--- a/playbooks/roles/runner-setup/tasks/assert_packages.yml
+++ b/playbooks/roles/runner-setup/tasks/assert_packages.yml
@@ -1,0 +1,67 @@
+---
+#
+# (c) Copyright 2019 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+- name: Configure repositories for skuba and terraforms
+  become: yes
+  zypper_repository:
+    name: "{{ caasp_pkgs_repo_version }}"
+    repo: "{{ socok8s_repos_to_configure[caasp_pkgs_repo_version] }}"
+    autorefresh: True
+    auto_import_keys: yes
+    state: present
+  when:
+    - caasp_pkgs_repo_version in socok8s_repos_to_configure
+
+- name: Install required skuba, terraform packages for OS versions
+  become: yes
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - skuba
+    - terraform
+  when:
+    - caasp_pkgs_repo_version in socok8s_repos_to_configure
+
+- name: Check skuba binary is available
+  command: "skuba version"
+  ignore_errors: yes
+  register: _skuba_present
+  changed_when: False
+
+- name: Assert required skuba is present
+  assert:
+    that:
+      - _skuba_present.rc == 0
+    fail_msg:
+      - "Skuba binary/package is not installed"
+      - "Identify package repository for your OS version and install skuba package manually"
+
+- name: Check terraform binary is available
+  shell: "{{ terraform_binary_path }} version | egrep -q \"^Terraform\\sv0\\.11\\.[0-9]{2}$\""
+  ignore_errors: yes
+  register: _terraform_present
+  changed_when: False
+
+- name: Assert required terraform version is present
+  assert:
+    that:
+      - _terraform_present.rc == 0
+    fail_msg:
+      - "Terraform package is not installed or incorrect version is installed"
+      - "Currently only supported terraform version is v0.11.x"
+      - "Identify package repository for your OS version and install matching version of terraform package manually"

--- a/script_library/deployment-actions-kvm.sh
+++ b/script_library/deployment-actions-kvm.sh
@@ -19,8 +19,6 @@ function deploy_ses(){
     echo "ses-ansible deploy is successful"
 }
 function deploy_caasp(){
-    source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp_skuba_dir_available
-    source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp_terraform_available
     source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp_ssh_agent_running
     echo "Starting CaaSP 4 deploy on libvirt"
     run_ansible ${socok8s_absolute_dir}/playbooks/kvm-deploy_caasp.yml
@@ -43,8 +41,6 @@ function remove_compute(){
 }
 function clean_caasp(){
     if command -v ${TERRAFORM_BINARY_PATH} && [ -d submodules/skuba ]; then
-        source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp_skuba_dir_available
-        source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp_terraform_available
         echo "Delete CaaSP 4"
         run_ansible ${socok8s_absolute_dir}/playbooks/kvm-delete_caasp.yml
     fi

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -24,9 +24,6 @@ function deploy_ses(){
 }
 function deploy_caasp(){
     source ${scripts_absolute_dir}/pre-flight-checks.sh check_openstack_environment_is_ready_for_deploy
-    source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp_skuba_available
-    source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp_terraform_available
-    source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp_terraform_version
     source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp_ssh_agent_running
     echo "Starting CaaSP 4 deploy"
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-deploy_caasp.yml
@@ -44,7 +41,6 @@ function configure_ccp_deployer() {
 }
 function clean_caasp(){
     if command -v ${TERRAFORM_BINARY_PATH} ; then
-        source ${scripts_absolute_dir}/pre-flight-checks.sh check_caasp_terraform_available
         echo "Delete CaaSP 4"
         run_ansible ${socok8s_absolute_dir}/playbooks/openstack-delete_caasp.yml
     fi

--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -39,38 +39,6 @@ check_openstack_env_vars_set (){
         export EXTERNAL_NETWORK="floating"
     fi
 }
-
-check_caasp_skuba_dir_available(){
-    echo "Checking for CaaSP 4 that SUSE/skuba is available"
-    if ! [ -d submodules/skuba ]; then
-        echo "submodules/skuba directory not available. Can not deploy CaaSP 4"
-        exit 1
-    fi
-}
-check_caasp_skuba_available(){
-    echo "Checking for CaaSP 4 that skuba is available"
-    if ! rpm -q --quiet skuba; then
-        echo "skuba package is not installed. Can not deploy CaaSP 4"
-        exit 1
-    fi
-}
-check_caasp_terraform_available(){
-    echo "Checking for CaaSP 4 that terraform is available"
-    command -v ${TERRAFORM_BINARY_PATH} 1> /dev/null
-    if [ $? -ne 0 ]; then
-        echo "${TERRAFORM_BINARY_PATH} executable not in \$PATH. Can not deploy CaaSP 4"
-        exit 1
-    fi
-}
-
-check_caasp_terraform_version(){
-  echo "Checking for terraform version (should be version 0.11)"
-  ${TERRAFORM_BINARY_PATH} version|egrep -q "^Terraform\sv0\.11\.[0-9]{2}$"
-  if [ $? -ne 0 ]; then
-    echo "Only version 0.11.x is supported for ${TERRAFORM_BINARY_PATH}"
-    exit 1
-  fi
-}
 check_caasp_ssh_agent_running(){
     echo "Checking if ssh-agent is running"
     if ! ssh-add -L >/dev/null ; then

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -46,6 +46,10 @@ socok8s_repos_to_configure:
   socok8s_SLE15SP1: "https://download.opensuse.org/repositories/Cloud:/socok8s:/master/SLE_15_SP1/"
   CAASP30-update: "{{ dist_mirror }}/ibs/SUSE/Updates/SUSE-CAASP/3.0/x86_64/update/"
   CAASP30-pool: "{{ dist_mirror }}/ibs/SUSE/Products/SUSE-CAASP/3.0/x86_64/product/"
+  # needed for skuba and terraform
+  CAASP40-SLES-151: "{{ ibs_mirror }}/Devel:/CaaSP:/4.0/SLE_15_SP1/"
+  CAASP40-SLES-150: "{{ ibs_mirror }}/Devel:/CaaSP:/4.0/SLE_15/"
+
 
 ######################################################
 # Following variables are used by airship logic only


### PR DESCRIPTION
In CI, skuba and terraform repos are directly added on CI ansible runner
node. For non-CI deployments, adding skuba and terraform packages
install when ansible runner is SLES-15.0 or SLES-15-SP1 . For other
versions, still manual step is needed.

For now, I did not find skuba and terraform packages for opensuse Leap
or any other SLES version. So may be we will need to limit ansible
runner to be either SLES-15.0 or SLES-15-SP1

Binary and version checks are now moved to ansible logic from shell
script.

Added ssh-agent setup to specific steps based on what's there in CI
jenkinsfile.