### PR TITLE
Fix tempest_test_type value

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -225,7 +225,7 @@ pipeline {
             }
             steps {
                 sh """
-                  export TEMPEST_TEST_TYPE=${env.tempest_test_type}
+                  export TEMPEST_TEST_TYPE=${params.tempest_test_type}
                   export AIRSHIP_TEMPEST_LOG_STDOUT=True
                   ./run.sh test
                 """


### PR DESCRIPTION
It was using env instead of params to capture the test type so
the tempest template was failing to be rendered properly