### PR TITLE
Reduce volume size for rabbit

### DIFF
--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -128,7 +128,7 @@ ucp_deploy_timeout: 1800
 openstack_helm_deploy_timeout: 3000
 
 #Set volume size for all rabbitmq in openstack deployment and postgresql in ucp deployment.
-rabbitmq_volume_size: 5Gi
+rabbitmq_volume_size: 1Gi
 db_volume_size: 5Gi
 
 #Set scale profile; options: "minimal" or "ha"


### PR DESCRIPTION
While 5Gb migth be a good size for the default db volumes, for
rabbitmq is way too much.

It doesnt help that airship creates a rabbitmq container per component
so we end up with several 5Gb volumes around for a lot of containers.

Instead set it to a more reasonable size (1Gb) which should allow for
rabbitmq to store to persist to disk with no issues