### PR TITLE
Skip error conditions for Airship wait action (SOC-10375)

### DIFF
--- a/playbooks/roles/airship-deploy-osh/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-osh/tasks/main.yml
@@ -184,7 +184,10 @@
         OS_PASSWORD: "{{ lookup('password', secrets_location + '/ucp_shipyard_keystone_password ' + password_opts) }}"
       register: shipyard_desc_action
       failed_when: "'failed' in shipyard_desc_action.stdout"
-      until: shipyard_desc_action.stdout.find('Processing') < 0 and shipyard_desc_action.stdout.find('running') < 0
+      until:
+        - shipyard_desc_action.stdout.find('Processing') == -1
+        - shipyard_desc_action.stdout.find('running') == -1
+        - shipyard_desc_action.stdout.find('Error') == -1
       retries: "{{ airship_deploy_openstack_timeout | int * 2 }}"
       delay: 30
       tags:


### PR DESCRIPTION
When checking the status of 'airship describe' in the 'Wait for update software' action sometimes we receive temporary errors (503,504) that make the task to stop. Since we consider these to be spurious errors we are going to skip those.

Reference: SOC-10375