### PR TITLE
Run LVM2 on the caasp nodes

### DIFF
--- a/playbooks/roles/caasp4/templates/skuba-terraform-libvirt.tfvars.j2
+++ b/playbooks/roles/caasp4/templates/skuba-terraform-libvirt.tfvars.j2
@@ -39,6 +39,7 @@ packages = [
   "-kernel-default-base",
   "ca-certificates-suse",
   "ceph-common",
+  "lvm2"
 ]
 
 authorized_keys = [

--- a/playbooks/roles/caasp4/templates/skuba-terraform-openstack.tfvars.j2
+++ b/playbooks/roles/caasp4/templates/skuba-terraform-openstack.tfvars.j2
@@ -31,7 +31,8 @@ packages = [
   "kernel-default",
   "-kernel-default-base",
   "ca-certificates-suse",
-  "ceph-common"
+  "ceph-common",
+  "lvm2"
 ]
 
 authorized_keys = [


### PR DESCRIPTION
So that rook-ceph can correctly activate the volumes.
See also bsc#1148954