### PR TITLE
Parse subunit output from tempest into junit

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -47,6 +47,7 @@ pipeline {
         USE_ARA = "True"
         ARA_DIR = "$WORKSPACE"
         SOCOK8S_DEPLOY_DSTAT = "YES"
+        SOCOK8S_TEMPEST_SUBUNIT_OUTPUT = "True"
     }
 
     stages {
@@ -226,6 +227,18 @@ pipeline {
                   export AIRSHIP_TEMPEST_LOG_STDOUT=True
                   ./run.sh test
                 """
+            }
+            post {
+                success {
+                    script {
+                        try {
+                            sh "./run.sh parse_tempest_ci"
+                            junit testResults: 'tempest.xml', allowEmptyResults: true, keepLongStdio: true
+                        } catch(e) {
+                            echo "Could not parse tempest results"
+                        }
+                    }
+                }
             }
         }
     }

--- a/playbooks/generic-tempest-output-to-junit.yml
+++ b/playbooks/generic-tempest-output-to-junit.yml
@@ -1,0 +1,83 @@
+---
+- hosts: soc-deployer
+  gather_facts: yes
+  tasks:
+    - name: Run container to attach tempest pvc
+      shell: |
+        set pipefail -o
+        cat <<EOF | kubectl -n openstack apply -f -
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: tempest-data
+        spec:
+          containers:
+          - name: tempest-data
+            image: opensuse/leap
+            command: ["/bin/bash", "-ec", "while :; do echo '.'; sleep 5 ; done"]
+            volumeMounts:
+            - name: mypvc
+              mountPath: /data
+          volumes:
+          - name: mypvc
+            persistentVolumeClaim:
+              claimName: pvc-tempest
+        EOF
+      register: tempest_data_pod_create
+      ignore_errors: true
+      tags:
+        - skip_ansible_lint
+    - name: Wait until data pod api pod is deployed
+      command: "kubectl get pod -n openstack tempest-data -o jsonpath='{.status.containerStatuses[].ready}'"
+      register: tempest_data_pod_status
+      until: tempest_data_pod_status.stdout == "true"
+      retries: 60
+      delay: 2
+      changed_when: False
+      when: tempest_data_pod_create.rc == 0
+    - name: Cat the tempest output into a local file
+      shell: "kubectl -n openstack exec -i tempest-data -- cat /data/.stestr/0 > {{ ansible_env.HOME }}/tempest.subunit"
+      register: _tempest_output
+      when: tempest_data_pod_status.rc == 0
+    - name: Fetch the tempest output
+      fetch:
+        dest: "{{ playbook_dir }}/../tempest.subunit"
+        src: "{{ ansible_env.HOME }}/tempest.subunit"
+        flat: yes
+      when:
+        - _tempest_output.rc == 0
+    - name: Delete the data pod
+      command: kubectl -n openstack delete pod tempest-data --grace-period=5
+      when: tempest_data_pod_create.rc == 0
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Check that previous task were successfull
+      stat:
+        path: "{{ playbook_dir }}/../tempest.subunit"
+      register: _tempest_file
+    - name: Install required packages in a virtualenv
+      pip:
+        name:
+          - junitxml
+          - python-subunit
+        virtualenv: "{{ playbook_dir }}/../junitvirtualenv"
+        virtualenv_python: python2  # junit stuff does not work under py3 for some reason, needs more investigation
+      when: _tempest_file.stat.exists
+    # This task can output rc 1 even if it succeeds!
+    # subunit2junitxml will forward the stream results to the exit code, so if tests fail, exit code will be 1
+    - name: Transform subunit into junit
+      shell: |
+        source {{ playbook_dir }}/../junitvirtualenv/bin/activate
+        cat {{ playbook_dir }}/../tempest.subunit | subunit-1to2 | subunit2junitxml > {{ playbook_dir }}/../tempest.xml
+      args:
+        executable: /bin/bash
+      failed_when: False
+      tags:
+        - skip_ansible_lint
+      when: _tempest_file.stat.exists
+    - name: Remove virtualenv
+      file:
+        path: "{{ playbook_dir }}/../junitvirtualenv"
+        state: absent

--- a/playbooks/roles/airship-deploy-tempest/defaults/main.yml
+++ b/playbooks/roles/airship-deploy-tempest/defaults/main.yml
@@ -22,3 +22,5 @@ cirros_test_image_url: "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_
 use_blacklist: true
 # Flag to hide tempest pod logs during ansible tempest run. Default is True (show tempest logs)
 print_tempest_log: "{{ lookup('env','AIRSHIP_TEMPEST_LOG_STDOUT') | default('True', true) | bool }}"
+# wheter to output tempest in subunit format
+tempest_subunit: "{{ lookup('env', 'SOCOK8S_TEMPEST_SUBUNIT_OUTPUT') | default(False, True) | bool }}"

--- a/playbooks/roles/airship-deploy-tempest/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-tempest/tasks/main.yml
@@ -137,6 +137,7 @@
       when:
         - _tempest_run_pod_name.rc == 0
         - print_tempest_log
+        - not tempest_subunit
 
     - name: Show command for gathering tempest logs
       debug:
@@ -155,3 +156,4 @@
       when:
         - _tempest_run_pod_name.rc == 0
         - print_tempest_log
+        - not tempest_subunit

--- a/run.sh
+++ b/run.sh
@@ -172,6 +172,9 @@ case "$deployment_action" in
     "delete_ses_rook")
         delete_ses_rook
         ;;
+    "parse_tempest_ci")
+        parse_tempest_output
+        ;;
     *)
         echo "Invalid option, Check --help for valid options"
         ;;

--- a/script_library/deployment-actions-common.sh
+++ b/script_library/deployment-actions-common.sh
@@ -83,3 +83,8 @@ function gather_dstat_output(){
     echo "Gathering dstat output"
     run_ansible ${socok8s_absolute_dir}/playbooks/generic-gather_dstat_output.yml
 }
+
+function parse_tempest_output(){
+    echo "Parsing tempest output for CI"
+    run_ansible ${socok8s_absolute_dir}/playbooks/generic-tempest-output-to-junit.yml
+}

--- a/script_library/deployment-actions-kvm.sh
+++ b/script_library/deployment-actions-kvm.sh
@@ -53,6 +53,10 @@ function clean_kvm(){
     echo "Not implemented"
 }
 function teardown(){
+    if [[ ${SOCOK8S_TEMPEST_PARSE_RESULTS} == "True" ]]
+    then
+      parse_tempest_ci
+    fi
     if [[ ${SOCOK8S_GATHER_LOGS:-"NO"} == "YES" ]]
     then
         gather_logs

--- a/script_library/deployment-actions-openstack.sh
+++ b/script_library/deployment-actions-openstack.sh
@@ -61,6 +61,10 @@ function clean_openstack(){
     run_ansible ${socok8s_absolute_dir}/playbooks/openstack-delete_network.yml
 }
 
+function parse_tempest_ci() {
+    parse_tempest_ci
+}
+
 function teardown(){
     if [[ ${SOCOK8S_DEPLOY_DSTAT:-"NO"} == "YES" ]]
     then

--- a/script_library/pre-flight-checks.sh
+++ b/script_library/pre-flight-checks.sh
@@ -141,7 +141,7 @@ validate_cli_options (){
        exit 1
    fi
 
-   OPTIONS=(deploy test update_openstack add_openstack_compute remove_openstack_compute remove_deployment deploy_network deploy_ses deploy_caasp deploy_caasp4 deploy_caasp4 configure_ccp_deployer deploy_ccp_deployer enroll_caasp_workers patch_upstream build_images deploy_osh setup_caasp_workers_for_openstack setup_hosts setup_openstack setup_airship setup_everything teardown clean_caasp clean_k8s clean_airship_not_images gather_logs deploy_ses_rook delete_ses_rook)
+   OPTIONS=(deploy test update_openstack add_openstack_compute remove_openstack_compute remove_deployment deploy_network deploy_ses deploy_caasp deploy_caasp4 deploy_caasp4 configure_ccp_deployer deploy_ccp_deployer enroll_caasp_workers patch_upstream build_images deploy_osh setup_caasp_workers_for_openstack setup_hosts setup_openstack setup_airship setup_everything teardown clean_caasp clean_k8s clean_airship_not_images gather_logs deploy_ses_rook delete_ses_rook parse_tempest_ci)
 
    action=$1
    isvalid=false

--- a/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
+++ b/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
@@ -27,12 +27,17 @@ data:
         restartPolicy: Never
     conf:
       script: |
+        tempest workspace register --path /var/lib/tempest/data --name default
         tempest run \
+        --workspace default \
         --config-file /etc/tempest/tempest.conf \
         -w {{ tempest_workers }} \
         {{ tempest_test_args[tempest_test_type] }} \
 {% if use_blacklist %}
         --blacklist-file /etc/tempest/test-blacklist \
+{% endif %}
+{% if tempest_subunit is defined and tempest_subunit is sameas true %}
+        --subunit \
 {% endif %}
         || true
 {% if use_blacklist %}


### PR DESCRIPTION
Currently we have no way of tracking the output of tempest in
the CI.

This patch adds a new playbook to extract the logs from the tempest
container, transform them into junit files and parse them on CI
for easy tracking of the tempest tests.

Just setting SOCOK8S_TEMPEST_PARSE_RESULTS=True should be enough to get
the output file with the tempest results

What it does its that it creates a temporal container with the tempest
pvc attached in order to extract the data from the tempest run, then
brings it to ansible_host, creates a temporal virtualenv to install
the tools needed for transofrming the data, and then transforms it
into a junit file so the CI can understand the output.

This requires a small change in our tempest deployment, which creates
a workspace at /var/lib/tempest/data, which is where the pvc is mounted,
in order to save the results. This also means that you can run tempest
several times and all the results will be in the same place, accesible
by creating a container and mounting the pvc.