### PR TITLE
Use password for ssh auth in tempest

### DIFF
--- a/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
+++ b/site/soc/software/charts/osh/openstack-tempest/tempest.yaml
@@ -63,6 +63,7 @@ data:
           public_network_id: "{{ tempest_public_network_details.stdout_lines[0] }}"
           shared_physical_network: "{{ tempest_public_network_details.stdout_lines[1] }}"
         validation:
+          auth_method: "password"
           image_ssh_user: "cirros"
           image_ssh_password: "gocubsgo"
           network_for_ssh: "{{ openstack_external_network_name }}"


### PR DESCRIPTION
Set tempest to use auth authentication on the ssh tests