### PR TITLE
Delete ara dir on job start

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -127,6 +127,13 @@ pipeline {
                 sh "rm -Rf .tox"
             }
         }
+        stage('Clean up ara dir') {
+            steps {
+                dir("${env.WORKSPACE}/.ara/") {
+                    deleteDir()
+                }
+            }
+        }
         stage('Create network') {
             when { expression { return  TestFunctional } }
             options {


### PR DESCRIPTION
We want to have a clean slate when we trigger ara. As we are
storing everything in the WORKSPACE, we are safe to delete the dir

This fixes having a really big ara db on long running branches