### PR TITLE
Update the cinder configuration to match changes in upstream charts

### DIFF
--- a/playbooks/roles/deploy-osh/templates/cinder.yaml.j2
+++ b/playbooks/roles/deploy-osh/templates/cinder.yaml.j2
@@ -2,6 +2,12 @@ conf:
   ceph:
     enabled: true
     admin_keyring: {{ ceph_admin_keyring_key }}
+    pools:
+      {{ ses_cluster_configuration['cinder']['rbd_store_pool'] }}:
+        replication: 3
+        crush_rule: replicated_rule
+        chunk_size: 8
+        app_name: cinder-volume
   cinder:
     DEFAULT:
       debug: true

--- a/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
+++ b/site/soc/software/charts/osh/openstack-cinder/cinder.yaml
@@ -67,6 +67,12 @@ data:
         enabled: true
         monitors: {{ ','.join(suse_airship_deploy_ceph_mons) }}
         admin_keyring: {{ ceph_admin_keyring_b64key | b64decode }}
+        pools:
+          {{ ses_cluster_configuration['cinder']['rbd_store_pool'] }}:
+            replication: 3
+            crush_rule: replicated_rule
+            chunk_size: 8
+            app_name: cinder-volume
       cinder:
         DEFAULT:
           debug: true


### PR DESCRIPTION
This is because https://review.opendev.org/#/c/666599/. Specific pool
values now have to be provided for each cinder pool we are using.

Specifically, look at the change in job-storage-init for the changed locations of the values:

https://review.opendev.org/#/c/666599/6/cinder/templates/job-storage-init.yaml