### PR TITLE
Move from ibs in provo to download.suse.de

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -36,6 +36,7 @@ pipeline {
            the CaaSP Velum automation has issues with mixed case hostnames. */
         SOCOK8S_ENVNAME = "cloud-socok8s-${BRANCH_NAME_ONLY.replaceAll("[^a-zA-Z0-9-]+", "-").toLowerCase()}-${env.BUILD_NUMBER}"
         SOCOK8S_OPENSUSE_MIRROR="https://provo-mirror.opensuse.org"
+        SOCOK8S_IBS_MIRROR="http://download.suse.de/ibs"
         OS_CLOUD = "engcloud-socok8s-ci"
         SOCOK8S_TEST_CEPH_ROOK="true"
         KEYNAME = "engcloud-cloud-ci"

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -20,7 +20,7 @@ suse_infra_image_version: "latest-opensuse_15"
 suse_osh_openstack_release: "rocky"
 
 obs_mirror: "{{ lookup('env','SOCOK8S_OPENSUSE_MIRROR') | default('https://download.opensuse.org', true) }}"
-ibs_mirror: http://ibs-mirror.prv.suse.net/ibs
+ibs_mirror: "{{ lookup('env','SOCOK8S_IBS_MIRROR') | default('http://ibs-mirror.prv.suse.net/ibs', true) }}"
 dist_mirror: http://ibs-mirror.prv.suse.net/dist
 
 socok8s_repos_to_configure:


### PR DESCRIPTION
There is an ongoing issue with the provo mirror that blocks CI.
Lets move to download.suse.de for now to unblock CI