### PR TITLE
Disable helm test containers on CI

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -48,6 +48,7 @@ pipeline {
         ARA_DIR = "$WORKSPACE"
         SOCOK8S_DEPLOY_DSTAT = "YES"
         SOCOK8S_TEMPEST_SUBUNIT_OUTPUT = "True"
+        SOCOK8S_RUN_CONTAINER_TESTS= "False"
     }
 
     stages {

--- a/playbooks/roles/airship-deploy-ucp/defaults/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 airship_pegleg_image: "{{ suse_airship_registry_location }}/airshipit/pegleg:{{ suse_airship_components_image_tag['pegleg'] }}"
-run_tests: true
+run_tests: "{{ lookup('env', 'SOCOK8S_RUN_CONTAINER_TESTS') | default('True',  True) | bool }}"
 test_timeout: 2700
 neutron_external_interface: ""
 neutron_tunnel_device: null


### PR DESCRIPTION
We are interested in the tempest tests to check for issues.
Running the container tests as part of the CI is useless as we
cannot extract any data from those and thye make the deployment
slower.

Not only that, but those tests are run as part of upstream so they
have already been confirmed to work. Running them again makes no
sense from a CI point of view.