### PR TITLE
Retry teardown on CI

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -272,9 +272,11 @@ pipeline {
                 sh "pkill -f 'ssh-agent -a /tmp/${env.SOCOK8S_ENVNAME}'"
                 if (fileExists("/tmp/${env.SOCOK8S_ENVNAME}.needcleanup")) {
                     try {
-                        sh './run.sh teardown'
-                        sh 'rm /tmp/${SOCOK8S_ENVNAME}.needcleanup'
-                    } catch (e) {
+                        retry(3) {
+                            sh './run.sh teardown'
+                            sh 'rm /tmp/${SOCOK8S_ENVNAME}.needcleanup'
+                        }
+                    } catch (error) {
                         sh 'ansible-playbook playbooks/generic-notify_failure_rocket.yml -v'
                         // manually set the build to failure if we could not cleanup resources
                         currentBuild.result = 'FAILURE'


### PR DESCRIPTION
Currently if one of the steps inside the teardown script fails,
the whole thing will stop. Be it a temporal problem or a real
issue.

This patch wraps the teardown into a retry statement so we try to
cleanup a max of 3 times and then resort to notifying via RocketChat