### PR TITLE
retry terraform destroy

### DIFF
--- a/playbooks/roles/caasp4/tasks/cleanup_nodes.yml
+++ b/playbooks/roles/caasp4/tasks/cleanup_nodes.yml
@@ -40,6 +40,8 @@
   args:
     chdir: "{{ skuba_ci_terraform_workspace }}"
   when: _terraform_state_file.stat.exists
+  retries: 30
+  delay: 10
 
 - name: Destroy terraform plan
   terraform:


### PR DESCRIPTION
Sometimes in CI the terraform apply command can be killed if other
parallel task has failed. CI has a grace period of 20 seconds for
other parallel steps to exit gracefully. Unfortunately terraform
apply takes more time thatn that and in those cases, jenkins will
just kill it. This leaves the process running and creating resources
so when the teardown tries to destroy it cant due to the lock file

This patch introduces a retry for the destroy so we allow the
apply to finish and the lock file to be removed sow e can
proceed to clean up those resources automatically