### PR TITLE
Correctly add missing labels to first worker node

### DIFF
--- a/playbooks/roles/deploy-osh/tasks/enroll-caasp-nodes-for-osh.yml
+++ b/playbooks/roles/deploy-osh/tasks/enroll-caasp-nodes-for-osh.yml
@@ -4,14 +4,14 @@
     set -o pipefail
     kubectl get nodes -o json | jq -M -r '.items[].metadata.name'
   changed_when: false
-  register: _all_casp_nodenames
+  register: _all_caasp_nodenames
 
 - name: Ensure enough nodes are running for HA
   fail:
     msg: "You do not have enough nodes to run OSH in HA"
   when:
     - suse_osh_deploy_require_ha | bool
-    - _all_casp_nodenames.stdout_lines | length < 3
+    - _all_caasp_nodenames.stdout_lines | length < 3
 
 # TODO(evrardjp): Make this conditional if a previous enrollment was already done
 - name: Enroll node for OSH control plane
@@ -23,7 +23,7 @@
     - _enrollforopenstack.rc != 0
     - _enrollforopenstack.stderr.find("already has a value (enabled)") == -1
   with_items:
-    - "{{ _all_casp_nodenames.stdout_lines }}"
+    - "{{ _all_caasp_nodenames.stdout_lines }}"
 
 - name: Enroll node for OSH compute node
   command: "kubectl label nodes {{ item }} openstack-compute-node=enabled"
@@ -34,7 +34,7 @@
     - _enrollforopenstack.rc != 0
     - _enrollforopenstack.stderr.find("already has a value (enabled)") == -1
   with_items:
-    - "{{ _all_casp_nodenames.stdout_lines }}"
+    - "{{ _all_caasp_nodenames.stdout_lines }}"
 
 - name: Enroll node for OSH as ovs node
   command: "kubectl label nodes {{ item }} openvswitch=enabled"
@@ -45,7 +45,7 @@
     - _enrollforopenstack.rc != 0
     - _enrollforopenstack.stderr.find("already has a value (enabled)") == -1
   with_items:
-    - "{{ _all_casp_nodenames.stdout_lines }}"
+    - "{{ _all_caasp_nodenames.stdout_lines }}"
 
 - name: Store all nodes details
   command: kubectl get nodes -o json
@@ -53,16 +53,21 @@
   register: _nodes
 
 - name: Find master node
-  set_fact:
-    master_node: "{{ _nodes.stdout_lines | join('') | from_json | json_query(query) }}"
-  vars:
-    query: 'items[].spec.{node: externalID, taints: taints} | [?taints].node'
+  shell: |
+    set -o pipefail
+    kubectl get node --selector='node-role.kubernetes.io/master' -o name
+  changed_when: false
+  register: _master_node
 
-# Select the first non-master node for single-node labels
+- name: Find first non-master node
+  shell: |
+    set -o pipefail
+    kubectl get node --selector='!node-role.kubernetes.io/master' -o name | head -n 1
+  changed_when: false
+  register: _primary_node
+
 - name: Apply labels to a single non-master node
-  vars:
-    primary_node: "{{ _all_casp_nodenames.stdout_lines | difference(master_node) | first }}"
-  command: "kubectl label nodes {{ primary_node }} {{ item }} --overwrite=true"
+  command: "kubectl label nodes {{ _primary_node.stdout }} {{ item }} --overwrite=true"
   register: _enrollforopenstack
   changed_when:
     - _enrollforopenstack.rc == 0
@@ -71,14 +76,10 @@
   with_items:
     - 'openstack-helm-node-class=primary'
     - 'ceph-mon=enabled'
-  when:
-    - "(master_node | default('')) | length > 0"
 
 # TODO(evrardjp): Move this to check the return code and task content
 - name: Remove taints when only 3 nodes and ha is required
-  command: "kubectl taint nodes {{ item }} node-role.kubernetes.io/master:NoSchedule-"
-  with_items: "{{ master_node }}"
+  command: "kubectl taint nodes {{ _master_node.stdout }} node-role.kubernetes.io/master:NoSchedule-"
   when:
-    - "(master_node | default('')) | length > 0"
     - suse_osh_deploy_require_ha | bool
-    - (_all_casp_nodenames.stdout_lines | length) == 3
+    - (_all_caasp_nodenames.stdout_lines | length) == 3


### PR DESCRIPTION
Previous check was not able to find a master node, probably because
of the switch to CaaSP4.
This led to the situation where no worker node got
'openstack-helm-node-class=primary' label which is required as a node
selector for (at least) nova-api-metadata pod.