### PR TITLE
Drop ingress override for k8s

### DIFF
--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -1,12 +1,6 @@
 ---
 data:
   charts:
-    kubernetes:
-      # contains dev patcher to enable multiple vips
-      ingress:
-        type: local
-        location: /armada/airship-components/openstack-helm-infra
-        subpath: ingress
     osh:
       cinder:
         location: https://opendev.org/openstack/openstack-helm


### PR DESCRIPTION
We are no longer using the dev-patcher VIPs patch so we should use
the ingress used by default upstream

This may or may not help with the 503?