### PR TITLE
Clean up the namespace variables

### DIFF
--- a/playbooks/generic-clean_airship.yml
+++ b/playbooks/generic-clean_airship.yml
@@ -17,6 +17,8 @@
 - hosts: soc-deployer
   gather_facts: no
   any_errors_fatal: true
+  vars_files:
+    - "{{ playbook_dir }}/../vars/common-vars.yml"
   tasks:
     - name: Remove compute nodes.
       include_role:
@@ -27,9 +29,8 @@
 
 - hosts: soc-deployer
   gather_facts: no
-  pre_tasks:
-    - name: Load generic vars
-      include_vars: "{{ playbook_dir }}/../vars/common-vars.yml"
+  vars_files:
+    - "{{ playbook_dir }}/../vars/common-vars.yml"
   tasks:
     - name: Running cleanup script
       script: "{{ playbook_dir }}/../script_library/clean-airship.sh '{{ clean_action | default('') }}' '{{ helm_delete_timeout }}'"

--- a/playbooks/remove_compute.yml
+++ b/playbooks/remove_compute.yml
@@ -2,5 +2,7 @@
 - hosts: soc-deployer
   gather_facts: yes
   any_errors_fatal: true
+  vars_files:
+    - "{{ playbook_dir }}/../vars/common-vars.yml"
   roles:
     - role: openstack-remove-compute

--- a/playbooks/roles/airship-configure-caasp/defaults/main.yml
+++ b/playbooks/roles/airship-configure-caasp/defaults/main.yml
@@ -1,7 +1,3 @@
 ---
-ucp_namespace_name: "{{ ucp_namespace | default('ucp') }}"
-ceph_namespace_name: "{{ ceph_namespace | default('ceph') }}"
-openstack_namespace_name: "{{ openstack_namespace | default('openstack') }}"
-
 # ClusterRole to allow privileged containers
 suse_airship_deploy_privileged_cluster_role: suse:caasp:psp:privileged

--- a/playbooks/roles/airship-configure-ceph/defaults/main.yml
+++ b/playbooks/roles/airship-configure-ceph/defaults/main.yml
@@ -1,8 +1,4 @@
 ---
-ucp_namespace_name: "{{ ucp_namespace | default('ucp') }}"
-ceph_namespace_name: "{{ ceph_namespace | default('ceph') }}"
-openstack_namespace_name: "{{ openstack_namespace | default('openstack') }}"
-
 suse_airship_deploy_storage:
   adminId: admin
   adminSecretName: pvc-ceph-conf-combined-storageclass

--- a/playbooks/roles/airship-configure-worker/defaults/main.yml
+++ b/playbooks/roles/airship-configure-worker/defaults/main.yml
@@ -1,8 +1,4 @@
 ---
-ucp_namespace_name: "{{ ucp_namespace | default('ucp') }}"
-ceph_namespace_name: "{{ ceph_namespace | default('ceph') }}"
-openstack_namespace_name: "{{ openstack_namespace | default('openstack') }}"
-
 suse_cp_node_create_subvolume: false
 apparmor_profiles:
   - usr.sbin.dnsmasq

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -54,7 +54,10 @@ socok8s_repos_to_configure:
 suse_ovs_image_version: "v2.8.1"
 
 socok8s_deploy_config_location: "{{ socok8s_workspace }}"
+
 ucp_namespace_name: "{{ ucp_namespace | default('ucp') }}"
+ceph_namespace_name: "{{ ceph_namespace | default('ceph') }}"
+openstack_namespace_name: "{{ openstack_namespace | default('openstack') }}"
 
 # Variables used for building airship images locally
 suse_distro_identifier: opensuse_15


### PR DESCRIPTION
Only have one set of namespace variables in the common-vars file, and make
sure we load those vars before any tasks that need them.

This fixes the `remove_deployment` action which previously failed to define
the 'openstack_namespace_name' variable.