### PR TITLE
Enable apparmor profile for dnsmasq

### DIFF
--- a/playbooks/generic-deploy_airship.yml
+++ b/playbooks/generic-deploy_airship.yml
@@ -41,16 +41,15 @@
       tags:
         - upstream_patching
 
-# Apparmor does not seem to be present on current CaaSP4 nodes
-#- hosts: caasp-workers
-#  tasks:
-#    - import_role:
-#      name: airship-configure-worker
-#      tasks_from: apparmor
-#    when: redeploy_osh_only is not defined or not redeploy_osh_only
-#    tags:
-#      - preinstall
-#      - add_compute_node
+- hosts: caasp-workers
+  tasks:
+    - import_role:
+        name: airship-configure-worker
+        tasks_from: apparmor
+      when: redeploy_osh_only is not defined or not redeploy_osh_only
+      tags:
+        - preinstall
+        - add_compute_node
 
 - hosts: soc-deployer
   gather_facts: no

--- a/playbooks/roles/airship-configure-worker/handlers/main.yml
+++ b/playbooks/roles/airship-configure-worker/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Reload apparmor profile
   command: "apparmor_parser -r /etc/apparmor.d/{{ item.item }}"
+  become: yes
   when: item.changed
   loop: "{{ apparmor_copy.results | flatten(levels=1) }}"
   loop_control:

--- a/playbooks/roles/airship-configure-worker/tasks/apparmor.yml
+++ b/playbooks/roles/airship-configure-worker/tasks/apparmor.yml
@@ -1,5 +1,6 @@
 ---
 - name: Copy openstack apparmor profile into the workers
+  become: yes
   copy:
     src: "{{ item }}"
     dest: "/etc/apparmor.d/local/{{ item }}"


### PR DESCRIPTION
Looks like apparmor is now enabled by default again so we need
to run the profile task to make sure neutron dhcp containers
have access to the host routes to read and write dhcp releases

This enables back the dnsmasq profile which was temporarily disabled
due to apparmor being off is previous caasp4 versions