### PR TITLE
Fix hang in cleanup script

### DIFF
--- a/script_library/cleanup-k8s.sh
+++ b/script_library/cleanup-k8s.sh
@@ -41,8 +41,9 @@ for NS in openstack ceph docker-registry; do
     done
 done
 
+# ignore pv's for ucp if they still exist (kubectl get pv -n does not filter for namespace unfortunatelly)
 for NS in openstack ceph docker-registry; do
-    for pv in $(kubectl get pv -n $NS | awk ' NR > 1 { print $1 ; }'); do
+    for pv in $(kubectl get pv -o jsonpath="{.items[?(@.spec.claimRef.namespace!=\"ucp\")].metadata.name}"); do
         kubectl delete pv $pv -n $NS || true;
     done
 done


### PR DESCRIPTION
Unfortunatelly 'kubectl get pv -n $NS' does not filter by namespace. And if you try to delete pv that belongs to ucp namespace which pvc was not deleted yet (it's done by other script), it hangs.