### PR TITLE
Ignore failures detected by junit

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -233,7 +233,7 @@ pipeline {
                     script {
                         try {
                             sh "./run.sh parse_tempest_ci"
-                            junit testResults: 'tempest.xml', allowEmptyResults: true, keepLongStdio: true
+                            junit testResults: 'tempest.xml', allowEmptyResults: true, keepLongStdio: true, healthScaleFactor: 0
                         } catch(e) {
                             echo "Could not parse tempest results"
                         }


### PR DESCRIPTION
The junit step is detecting known failures and marking the jobs as
unstable, which github interprets as a failure. By setting the
health-scale factor to zero, we disable the test result contribution
to the build score, and the jobs should no longer be marked as unstable.

This should be reverted once the tempest tests are passing reliably.