### PR TITLE
Adapt the kubectl get command to get just name of the nodes

### DIFF
--- a/playbooks/roles/deploy-osh/tasks/enroll-caasp-nodes-for-osh.yml
+++ b/playbooks/roles/deploy-osh/tasks/enroll-caasp-nodes-for-osh.yml
@@ -53,16 +53,12 @@
   register: _nodes
 
 - name: Find master node
-  shell: |
-    set -o pipefail
-    kubectl get node --selector='node-role.kubernetes.io/master' -o name
+  command: kubectl get node --selector='node-role.kubernetes.io/master' -o jsonpath='{.items[].metadata.name}'
   changed_when: false
   register: _master_node
 
 - name: Find first non-master node
-  shell: |
-    set -o pipefail
-    kubectl get node --selector='!node-role.kubernetes.io/master' -o name | head -n 1
+  command: kubectl get node --selector='!node-role.kubernetes.io/master' -o jsonpath="{.items[0].metadata.name}"
   changed_when: false
   register: _primary_node
 


### PR DESCRIPTION
This way the return value is like 'worker-0' instead of 'node/worker0'.
The latter case would require change of subsequent kubectl set command.

Also: no need for pipes any more