### PR TITLE
Manually mount BPFFS on caasp workers

### DIFF
--- a/playbooks/kvm-deploy_caasp.yml
+++ b/playbooks/kvm-deploy_caasp.yml
@@ -51,6 +51,16 @@
 - hosts: caasp-workers
   vars_files:
     - "{{ playbook_dir }}/../vars/common-vars.yml"
+  pre_tasks:
+    # fix for cilium losing connectivity on restart
+    # TODO: Remove when https://github.com/SUSE/skuba/pull/598 is merged
+    - name: Ensure bpf is mounted
+      become: true
+      mount:
+        path: /sys/fs/bpf
+        src: bpffs
+        fstype: bpf
+        state: mounted
   roles:
     - role: dstat
       when: lookup('env', 'SOCOK8S_DEPLOY_DSTAT') | default(False, True)

--- a/playbooks/openstack-deploy_caasp.yml
+++ b/playbooks/openstack-deploy_caasp.yml
@@ -51,6 +51,16 @@
 - hosts: caasp-workers
   vars_files:
     - "{{ playbook_dir }}/../vars/common-vars.yml"
+  pre_tasks:
+    # fix for cilium losing connectivity on restart
+    # TODO: Remove when https://github.com/SUSE/skuba/pull/598 is merged
+    - name: Ensure bpf is mounted
+      become: true
+      mount:
+        path: /sys/fs/bpf
+        src: bpffs
+        fstype: bpf
+        state: mounted
   roles:
     - role: dstat
       when: lookup('env', 'SOCOK8S_DEPLOY_DSTAT') | default(False, True)


### PR DESCRIPTION
When cilium pods are restarted, there is network disruption.
Enabling the BPF fs in the workers should avoid any network
disruption when pods are restarted.

There is a PR upstream to fix this, but for the moment lets apply it
ourselves