### PR TITLE
Skip the tempest step for OSH (SOC-10225)

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -219,7 +219,12 @@ pipeline {
             options {
                 timeout(time: 240, unit: 'MINUTES', activity: true)
             }
-            when { expression { return  TestFunctional } }
+            when {
+                allOf {
+                    expression { params.deployment == "airship" }
+                    expression { return  TestFunctional }
+                }
+            }
 
             steps {
                 sh """


### PR DESCRIPTION
That might be useful for scenarios that include their own set of tests
(like deploy_osh deployment path).