### PR TITLE
Bump ingress to 0.23.0

### DIFF
--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -156,6 +156,7 @@ data:
         db_drop: "{{ suse_osh_registry_location }}/openstackhelm/heat:{{ suse_openstack_image_version }}"
         horizon: "{{ suse_osh_registry_location }}/openstackhelm/horizon:{{ suse_openstack_image_version }}"
       ingress:
+        ingress: "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.23.0"
         ingress_module_init: "{{ suse_osh_registry_location }}/openstackhelm/neutron:{{ suse_openstack_image_version }}"
         ingress_routed_vip: "{{ suse_osh_registry_location }}/openstackhelm/neutron:{{ suse_openstack_image_version }}"
       keystone:
@@ -270,6 +271,7 @@ data:
       divingbell: {}
       drydock: {}
       ingress:
+        ingress: "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.23.0"
         ingress_module_init: "{{ suse_osh_registry_location }}/openstackhelm/neutron:{{ suse_openstack_image_version }}"
         ingress_routed_vip: "{{ suse_osh_registry_location }}/openstackhelm/neutron:{{ suse_openstack_image_version }}"
       keystone:


### PR DESCRIPTION
According to versions we should have a newer ingress version as
we are using commit 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e for
ingress-htk which includes this bump but somehow airship is ignoring
this and using an older version (0.20.0)

It just happens that this version has a know problem of returning
a 503 on backend reload.

In other words, this may fix the dreaded 503 once and for all.

This approach forces the image to be the 0.23.0 as a test, not final