### PR TITLE
Add missing ingress chart

### DIFF
--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -47,6 +47,11 @@ data:
         reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
         subpath: helm-toolkit
         type: git
+      ingress:
+        location: https://opendev.org/openstack/openstack-helm-infra
+        reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
+        subpath: ingress
+        type: git
       ingress-htk:
         location: https://opendev.org/openstack/openstack-helm-infra
         reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e


### PR DESCRIPTION
We were missing the ingress chart version. This meant that we were
picking the ingress images from ... somewhere which gave us really
really old images (0.20.0)

Bumping this to a commmit from 5 months ago like the companion
ingress-htk has, which should give us a 0.23.0 image