### PR TITLE
Wait up to 120s for connections to finish before reloading

### DIFF
--- a/site/soc/software/charts/kubernetes/ingress/ingress.yaml
+++ b/site/soc/software/charts/kubernetes/ingress/ingress.yaml
@@ -16,5 +16,9 @@ metadata:
       - method: merge
         path: .
   storagePolicy: cleartext
-data: {}
+data:
+  values:
+    conf:
+      ingress:
+        worker-shutdown-timeout: "120s"
 ...

--- a/site/soc/software/charts/osh/openstack-ingress-controller/ingress.yaml
+++ b/site/soc/software/charts/osh/openstack-ingress-controller/ingress.yaml
@@ -12,6 +12,8 @@ metadata:
     actions:
       - method: replace
         path: .values.pod
+      - method: merge
+        path: .values.conf
   storagePolicy: cleartext
   substitutions:
     - src:
@@ -28,6 +30,9 @@ metadata:
         path: .values.pod.replicas.error_page
 data:
   values:
+    conf:
+      ingress:
+        worker-shutdown-timeout: "120s"
     pod:
       resources:
         enabled: {{ openstack_helm_pod_resources_enabled['ingress'] }}

--- a/site/soc/software/charts/ucp/core/ingress.yaml
+++ b/site/soc/software/charts/ucp/core/ingress.yaml
@@ -31,6 +31,9 @@ data:
   wait:
     timeout: {{ ucp_deploy_timeout }}
   values:
+    conf:
+      ingress:
+        worker-shutdown-timeout: "120s"
     pod:
       replicas:
         ingress: 1

--- a/site/soc/software/charts/ucp/kube-system-ingress/ingress.yaml
+++ b/site/soc/software/charts/ucp/kube-system-ingress/ingress.yaml
@@ -19,6 +19,9 @@ metadata:
   storagePolicy: cleartext
 data:
   values:
+    conf:
+      ingress:
+        worker-shutdown-timeout: "120s"
     network:
       host_namespace: True
       vip:


### PR DESCRIPTION
Looks like there is a limit of 10 seconds for a connection to
finish when a reload is done on ingress before it gets killed.

This means that long requests like those of openstack can get killed
if ther is a backend reload in the start of middle of them.

This bumps it to 120s so we can let those requests finish. This should
not affect anything else as this is only applied to ongoing requests,
so any new requests will get a reloaded backend as this will only
affect the worker dealing with that request