### PR TITLE
Create CI scale profile

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -49,6 +49,7 @@ pipeline {
         SOCOK8S_DEPLOY_DSTAT = "YES"
         SOCOK8S_TEMPEST_SUBUNIT_OUTPUT = "True"
         SOCOK8S_RUN_CONTAINER_TESTS= "False"
+        SOCOK8S_SCALE_PROFILE = "ci"
     }
 
     stages {

--- a/playbooks/roles/airship-deploy-ucp/files/profiles/pod-scale-ci.yaml
+++ b/playbooks/roles/airship-deploy-ucp/files/profiles/pod-scale-ci.yaml
@@ -1,0 +1,200 @@
+---
+schema: pegleg/PodScaleProfile/v1
+metadata:
+  schema: metadata/Document/v1
+  name: pod-scale-profile
+  storagePolicy: cleartext
+  layeringDefinition:
+    abstract: false
+    layer: site
+data:
+  pods:
+    ucp:
+      armada:
+        api:
+          min: 1
+          max: 1
+      shipyard:
+        api:
+          min: 1
+          max: 1
+        airflow:
+          web:
+            min: 1
+            max: 1
+          worker:
+            min: 1
+            max: 1
+          flower:
+            min: 1
+            max: 1
+          scheduler:
+            min: 1
+            max: 1
+      deckhand:
+        deckhand:
+          min: 1
+          max: 1
+      postgresql:
+        server:
+           min: 1
+           max: 1
+           quorum: true
+        prometheus_postgresql_exporter:
+           min: 1
+           max: 1
+      barbican:
+        api:
+          min: 1
+          max: 1
+      ingress:
+        ingress:
+          min: 1
+          max: 1
+        error_page:
+          min: 1
+          max: 1
+      keystone:
+        api:
+          min: 1
+          max: 1
+      mariadb:
+        server:
+           min: 1
+           max: 1
+           quorum: true
+        ingress:
+           min: 1
+           max: 1
+        error_page:
+           min: 1
+           max: 1
+        prometheus_mysql_exporter:
+           min: 1
+           max: 1
+      memcached:
+        server:
+          min: 1
+          max: 1
+        prometheus_memcached_exporter:
+          min: 1
+          max: 1
+      rabbitmq:
+        server:
+          min: 1
+          max: 1
+        prometheus_rabbitmq_exporter:
+          min: 1
+          max: 1
+    osh:
+      barbican:
+        api:
+          min: 1
+          max: 1
+      cinder:
+        api:
+          min: 1
+          max: 1
+        volume:
+          min: 1
+          max: 1
+        scheduler:
+          min: 1
+          max: 1
+        backup:
+          min: 1
+          max: 1
+      glance:
+        api:
+          min: 1
+          max: 1
+        registry:
+          min: 1
+          max: 1
+      heat:
+        api:
+          min: 1
+          max: 1
+        cfn:
+          min: 1
+          max: 1
+        cloudwatch:
+          min: 1
+          max: 1
+        engine:
+          min: 1
+          max: 1
+      horizon:
+        server:
+          min: 1
+          max: 1
+      ingress:
+        ingress:
+          min: 1
+          max: 1
+        error_page:
+          min: 1
+          max: 1
+      keystone:
+        api:
+          min: 2
+          max: 2
+      mariadb:
+        server:
+           min: 1
+           max: 1
+        ingress:
+           min: 1
+           max: 1
+        error_page:
+           min: 1
+           max: 1
+        prometheus_mysql_exporter:
+           min: 1
+           max: 1
+      memcached:
+        server:
+          min: 1
+          max: 1
+        prometheus_memcached_exporter:
+          min: 1
+          max: 1
+      neutron:
+        server:
+          min: 1
+          max: 1
+      nova:
+        api_metadata:
+          min: 1
+          max: 1
+        compute_ironic:
+          min: 1
+          max: 1
+        placement:
+          min: 1
+          max: 1
+        osapi:
+          min: 1
+          max: 1
+        conductor:
+          min: 1
+          max: 1
+        consoleauth:
+          min: 1
+          max: 1
+        scheduler:
+          min: 1
+          max: 1
+        novncproxy:
+          min: 1
+          max: 1
+        spiceproxy:
+          min: 1
+          max: 1
+      rabbitmq:
+        server:
+          min: 1
+          max: 1
+      prometheus_rabbitmq_exporter:
+          min: 1
+          max: 1

--- a/site/soc/software/charts/osh/openstack-ingress-controller/ingress.yaml
+++ b/site/soc/software/charts/osh/openstack-ingress-controller/ingress.yaml
@@ -12,6 +12,8 @@ metadata:
     actions:
       - method: replace
         path: .values.pod
+      - method: merge
+        path: .values.conf
   storagePolicy: cleartext
   substitutions:
     - src:
@@ -28,6 +30,17 @@ metadata:
         path: .values.pod.replicas.error_page
 data:
   values:
+    conf:
+      ingress:
+        # pass to the next upstream the request if we have a 503
+        # error and timeout are the default values for this option
+        proxy_next_upstream : "error timeout http_503"
+        # but timeout after 10s in case there is a real issue
+        # default timeout is 0 which means unlimited
+        proxy_next_upstream_timeout: "10"
+        # this sets the number of times it will try to pass the request to
+        # the next upstream. Its 0 by default which means unlimited
+        proxy_next_upstream_tries: "5"
     pod:
       resources:
         enabled: {{ openstack_helm_pod_resources_enabled['ingress'] }}

--- a/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
@@ -30,8 +30,6 @@ data:
     pod:
       resources:
         enabled: {{ openstack_helm_pod_resources_enabled['keystone'] }}
-      replicas:
-        api: 1
       security_context:
         keystone:
           pod:

--- a/vars/common-vars.yml
+++ b/vars/common-vars.yml
@@ -130,7 +130,7 @@ rabbitmq_volume_size: 1Gi
 db_volume_size: 5Gi
 
 #Set scale profile; options: "minimal" or "ha"
-scale_profile: "{{ lookup('env','scale_profile') | default('minimal', true) }}"
+scale_profile: "{{ lookup('env','SOCOK8S_SCALE_PROFILE') | default('minimal', true) }}"
 
 #Set timeout for helm cleanup.
 helm_delete_timeout: 900


### PR DESCRIPTION
Add a scale pod profile for ci which has 2 pods for keystone api
to be more resilient to pod failure or timeout. Also adds new
options to the ingress controller for openstack, namely:
 - proxy_next_upstream: Now also catch 503 and pass to next upstream
 - proxy_next_upstream_timeout: timeout after 10s
 - proxy_next_upstream_tries: number of tries to pass to next upstream

All this options are explained in the nginx docs[0]

Also changes the scale profile env var to something more exclusive
of our socok8s repo so its clear where its coming from, changed
from scale_profile to SOCOK8S_SCALE_PROFILE

[0] http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream

