### PR TITLE
Use default number of nodes (3) to deploy MariaDB galera cluster

### DIFF
--- a/site/soc/software/charts/osh/openstack-mariadb/mariadb.yaml
+++ b/site/soc/software/charts/osh/openstack-mariadb/mariadb.yaml
@@ -15,13 +15,6 @@ metadata:
       - method: delete
         path: .values.labels.prometheus_mysql_exporter
   storagePolicy: cleartext
-  substitutions:
-    - src:
-        schema: pegleg/PodScaleProfile/v1
-        name: pod-scale-profile
-        path: .pods.osh.mariadb.server.min
-      dest:
-        path: .values.pod.replicas.server
 data:
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
@@ -32,8 +25,6 @@ data:
     pod:
       resources:
         enabled: {{ openstack_helm_pod_resources_enabled['mariadb'] }}
-      replicas:
-        server: 1
     volume:
       size: {{ db_volume_size }}
       backup:


### PR DESCRIPTION
See SOC-10344

This is mostly a test PR to see how the CI will react. It's possible more is needed than just this simple change...