### PR TITLE
Use dev patcher to patch keystone chart, fixes 503  (SOC-10514)

### DIFF
--- a/playbooks/roles/airship-deploy-ucp/tasks/main.yml
+++ b/playbooks/roles/airship-deploy-ucp/tasks/main.yml
@@ -330,6 +330,18 @@
     - name: Wait until all pods to be ready
       command: "{{ upstream_repos_clone_folder }}/openstack/openstack-helm/tools/deployment/common/wait-for-pods.sh {{ ucp_namespace_name }} 3600"
 
+    # TODO(aagate): Add a changed_when: to help idempotency
+    # local changes need to go into the armada-api pod as thats the one executing the code
+    - name: Copy patched repos into Armada-api pod
+      command: "{{ item }}"
+      loop:
+        - kubectl exec {{ armada_pod_name }} -n ucp -- mkdir -p /armada/airship-components
+        - kubectl cp {{ upstream_repos_clone_folder }}/openstack/openstack-helm-infra {{ ucp_namespace_name }}/{{ armada_api_pod_name }}:/armada/airship-components/
+        - kubectl cp {{ upstream_repos_clone_folder }}/openstack/openstack-helm {{ ucp_namespace_name }}/{{ armada_api_pod_name }}:/armada/airship-components/
+      tags:
+        - install
+        - skip_ansible_lint
+
   rescue:
     - name: List all ucp pods
       command: "kubectl get pods -n {{ ucp_namespace_name }}"

--- a/playbooks/roles/dev-patcher/defaults/main.yml
+++ b/playbooks/roles/dev-patcher/defaults/main.yml
@@ -7,4 +7,7 @@ dev_patcher_packages:
 #merged patches will be skipped
 #unrelated patches will fail (because not cloned)
 #conflicting patches will fail (because need resolving)
-dev_patcher_patches: []
+dev_patcher_patches:
+  # https://review.opendev.org/#/c/683220/ -> Keystone: allow probes configuration
+  - - 683220
+    - current

--- a/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
@@ -27,6 +27,14 @@ data:
     enabled: {{ run_tests }}
     timeout: {{ test_timeout }}
   values:
+    probes:
+      keystone_api:
+        # bump probe timeout to 30s to avoid ingress removing the pods from the pool when they take long to respond
+        # default upstream is 5s
+        readinessProbe:
+          timeoutSeconds: 30
+        livenessProbe:
+          timeoutSeconds: 30
     pod:
       resources:
         enabled: {{ openstack_helm_pod_resources_enabled['keystone'] }}

--- a/site/soc/software/config/endpoints.yaml
+++ b/site/soc/software/config/endpoints.yaml
@@ -562,6 +562,10 @@ data:
           default: 9104
     keystone_oslo_messaging:
       namespace: openstack
+      # this is set to null so on the conf the rabbitmq dns looks like: keystone-rabbitmq.openstack.svc.cluster.local
+      # otherwise it would end up with rabbitmq-rabbitmq-0.keystone-rabbitmq.openstack.svc.cluster.local
+      # this is due to a change upstream: https://github.com/openstack/openstack-helm/commit/9bcf0df94c1a8455e17aa79f20efaf2736eed0f4
+      statefulset: null
       hosts:
         default: keystone-rabbitmq
       host_fqdn_override:

--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -38,13 +38,14 @@ data:
         subpath: helm-toolkit
         type: git
       keystone:
-        location: https://opendev.org/openstack/openstack-helm
-        reference: f22f53030335121a6019a603910deef0a759b1de
+        # use local patched keystone chart until https://review.opendev.org/#/c/683220/ is merged upstream
+        # and we can bump this to use the latest keystone with the included patch
+        type: local
+        location: /armada/airship-components/openstack-helm
         subpath: keystone
-        type: git
       keystone-htk:
         location: https://opendev.org/openstack/openstack-helm-infra
-        reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
+        reference: 494ce39624f66d715f383f2647b90f2d27f776ba
         subpath: helm-toolkit
         type: git
       ingress-htk:


### PR DESCRIPTION
In order to use a non-merged patch[0] to keystone to fix the probe
timeouts we need to move to local patching and passing the local
patched repo to ariship

This also bumps the keystone-api pod timeout for the probes to 30s
as by default this is 5s and it causes the ingress pod to remove
keystone-api from the pool as soon as it receives a timeout, which
happens when there is load in the servers (i.e. tempest tests)

As a side effect this also includes a minor change to our site/soc
config to keep using the same name as we used before for keystone
rabbit as the way of generating the name was changed here[1]

[0] https://review.opendev.org/#/c/683220/
[1] https://github.com/openstack/openstack-helm/commit/9bcf0df94c1a8455e17aa79f20efaf2736eed0f4