### PR TITLE
Add missing ingress chart

### DIFF
--- a/site/soc/software/charts/ucp/core/ingress.yaml
+++ b/site/soc/software/charts/ucp/core/ingress.yaml
@@ -35,8 +35,4 @@ data:
       replicas:
         ingress: 1
         error_page: 1
-  source:
-    type: local
-    location: /armada/airship-components/openstack-helm-infra
-    subpath: ingress
 ...

--- a/site/soc/software/config/versions.yaml
+++ b/site/soc/software/config/versions.yaml
@@ -48,9 +48,14 @@ data:
         reference: 494ce39624f66d715f383f2647b90f2d27f776ba
         subpath: helm-toolkit
         type: git
+      ingress:
+        location: https://opendev.org/openstack/openstack-helm-infra
+        reference: 494ce39624f66d715f383f2647b90f2d27f776ba
+        subpath: ingress
+        type: git
       ingress-htk:
         location: https://opendev.org/openstack/openstack-helm-infra
-        reference: 5e1ecd9840397bf9e8829ce0d98fcb721db1b74e
+        reference: 494ce39624f66d715f383f2647b90f2d27f776ba
         subpath: helm-toolkit
         type: git
       neutron:


### PR DESCRIPTION
We were missing the ingress chart version. This meant that we were
picking the ingress images from ... somewhere which gave us really
really old images (0.20.0)

Bumping this to a commmit from 5 months ago like the companion
ingress-htk has, which should give us a 0.23.0 image
