### PR TITLE
Move probe config to scale profile

### DIFF
--- a/playbooks/roles/airship-deploy-ucp/files/profiles/pod-scale-ha.yaml
+++ b/playbooks/roles/airship-deploy-ucp/files/profiles/pod-scale-ha.yaml
@@ -10,6 +10,21 @@ metadata:
     abstract: false
     layer: site
 data:
+  probes:
+    osh:
+      keystone_api:
+        readinessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
+        livenessProbe:
+          initialDelaySeconds: 50
+          periodSeconds: 20
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
   pods:
     ucp:
       armada:

--- a/playbooks/roles/airship-deploy-ucp/files/profiles/pod-scale-minimal.yaml
+++ b/playbooks/roles/airship-deploy-ucp/files/profiles/pod-scale-minimal.yaml
@@ -13,6 +13,21 @@ metadata:
   #      - method: merge
   #        path: .
 data:
+  probes:
+    osh:
+      keystone_api:
+        readinessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 30
+          successThreshold: 1
+          failureThreshold: 3
+        livenessProbe:
+          initialDelaySeconds: 50
+          periodSeconds: 20
+          timeoutSeconds: 30
+          successThreshold: 1
+          failureThreshold: 3
   pods:
     ucp:
       armada:

--- a/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
+++ b/site/soc/software/charts/osh/openstack-keystone/keystone.yaml
@@ -20,21 +20,21 @@ metadata:
         path: .pods.osh.keystone.api.min
       dest:
         path: .values.pod.replicas.api
+    - src:
+        schema: pegleg/PodScaleProfile/v1
+        name: pod-scale-profile
+        path: .probes.osh.keystone_api
+      dest:
+        path: .values.probes.keystone_api
 data:
+  values:
+    proves:
+      keystone_api: null
   wait:
     timeout: {{ openstack_helm_deploy_timeout }}
   test:
     enabled: {{ run_tests }}
     timeout: {{ test_timeout }}
-  values:
-    probes:
-      keystone_api:
-        # bump probe timeout to 30s to avoid ingress removing the pods from the pool when they take long to respond
-        # default upstream is 5s
-        readinessProbe:
-          timeoutSeconds: 30
-        livenessProbe:
-          timeoutSeconds: 30
     pod:
       resources:
         enabled: {{ openstack_helm_pod_resources_enabled['keystone'] }}


### PR DESCRIPTION
Move the config for the probes into the scale profile so its
configurable instead of hardcoded and its present in a single
place