### PR TITLE
Remove bridge-utils package installation from OSH

### DIFF
--- a/playbooks/roles/deploy-osh/defaults/main.yml
+++ b/playbooks/roles/deploy-osh/defaults/main.yml
@@ -18,7 +18,6 @@ suse_osh_deploy_packages:
   - python-selinux
   - ceph-common
   - nfs-utils
-  - bridge-utils
 
 suse_osh_openstackclient_packages:
   - python3-openstackclient


### PR DESCRIPTION
The repository that contains bridge-utils was removed in #750
so the installation of OSH cannot continue.

Because this package is not going to be used any more, is removed
from the installation