### PR TITLE
Restore missing l3 label

### DIFF
--- a/playbooks/roles/caasp4/templates/inventory-caasp4.yml.j2
+++ b/playbooks/roles/caasp4/templates/inventory-caasp4.yml.j2
@@ -47,6 +47,18 @@ airship-openstack-compute-workers:
     ansible_user: sles
     ansible_python_interpreter: /usr/bin/python3
 
+airship-openstack-l3-agent-workers:
+  hosts:
+{% for worker_ip in _terraform_json_output.ip_workers.value %}
+{% if loop.index0 >= airship_ucp_control_workers %}
+    worker-{{ loop.index0}}:
+      ansible_host: {{ worker_ip }}
+{% endif %}
+{% endfor %}
+  vars:
+    ansible_user: sles
+    ansible_python_interpreter: /usr/bin/python3
+
 airship-kube-system-workers:
   hosts: *first_workers
   vars:


### PR DESCRIPTION
Somehow this label was lost inthe transition from caasp3 to caasp4
inventory management

Restore it to have the last node be the l3 labeled node