### PR TITLE
Enable delaying of teardown for jobs that are already running

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -273,7 +273,8 @@ pipeline {
                 }
             }
             script {
-                if (params.hold_instance_for_debug == true) {
+                // For delaying the teardown of running job, create /tmp/${env.SOCOK8S_ENVNAME}.hold_instance file manually on the jenkins worker
+                if (fileExists("/tmp/${env.SOCOK8S_ENVNAME}.hold_instance") || params.hold_instance_for_debug == true) {
                      try {
                         echo "You can reach this node by connecting to its floating IP as root user, with the default password of your image."
                         timeout(time: 3, unit: 'HOURS') {


### PR DESCRIPTION
For delaying the teardown of running job (which is handy for debugging
purposes), create /tmp/${env.SOCOK8S_ENVNAME}.hold_instance (like /tmp/cloud-socok8s-pr-782-1.hold_instance)
file manually on the jenkins worker.